### PR TITLE
Grammatical correction for remaining enemies label

### DIFF
--- a/core/src/io/anuke/mindustry/ui/fragments/HudFragment.java
+++ b/core/src/io/anuke/mindustry/ui/fragments/HudFragment.java
@@ -159,6 +159,12 @@ public class HudFragment implements Fragment{
 			}
 		}
 	}
+
+	private String printEnemiesRemaining() {
+		if(control.getEnemiesRemaining() == 1) {
+			return " enemy left";
+		} else return " enemies left";
+	}
 	
 	private void addWaveTable(){
 		float uheight = 66f;
@@ -173,7 +179,7 @@ public class HudFragment implements Fragment{
 				row();
 			
 				new label(()-> control.getEnemiesRemaining() > 0 ?
-					control.getEnemiesRemaining() + " enemies" : 
+					control.getEnemiesRemaining() + printEnemiesRemaining() : 
 						(control.getTutorial().active() || Vars.control.getMode() == GameMode.sandbox) ? "waiting..." : "Wave in " + (int) (control.getWaveCountdown() / 60f))
 				.minWidth(140).units(Unit.dp).left();
 


### PR DESCRIPTION
Noticed that when the remaining enemy count comes down to 1, the word 'enemies' persists on the label, so i corrected that to show 'enemy' or 'enemies' instead, depending on the remaining enemy count. I also put 'left' after it to sort of bring back the more proper-sounding 'remaning' from back then, but it's shorter now to save space.
 
 Used to be: 
'3 ENEMIES'
'2 ENEMIES'
'1 ENEMIES' <doesn't sound right doesn't it?

Now:
'3 ENEMIES LEFT'
'2 ENEMIES LEFT'
'1 ENEMY LEFT' <sounds quite about right, and I even brought back the 'remaining' but shorter.

That's about it, and for a fact I'm really new to Java and am actively practicing it, using examples from yours' and other's code. It gets less complicated the more i look into it. :)

~~also first two dialogue/localization JSON coming soon~~