### PR TITLE
Refactors to Liquids and Items

### DIFF
--- a/core/src/io/anuke/mindustry/core/Control.java
+++ b/core/src/io/anuke/mindustry/core/Control.java
@@ -45,7 +45,7 @@ public class Control extends Module{
 	boolean hiscore = false;
 	
 	final Array<Weapon> weapons = new Array<>();
-	final int[] items = new int[Item.values().length];
+	final int[] items = new int[Item.getAllItems().size];
 	
 	public final EntityGroup<Enemy> enemyGroup = Entities.addGroup(Enemy.class);
 	public final EntityGroup<TileEntity> tileGroup = Entities.addGroup(TileEntity.class, false);
@@ -434,11 +434,11 @@ public class Control extends Module{
 	}
 	
 	public  int getAmount(Item item){
-		return items[item.ordinal()];
+		return items[item.id];
 	}
 	
 	public void addItem(Item item, int amount){
-		items[item.ordinal()] += amount;
+		items[item.id] += amount;
 		shouldUpdateItems = true;
 	}
 	
@@ -457,15 +457,15 @@ public class Control extends Module{
 	}
 	
 	public boolean hasItem(ItemStack req){
-		return items[req.item.ordinal()] >= req.amount; 
+		return items[req.item.id] >= req.amount;
 	}
 	
 	public boolean hasItem(Item item, int amount){
-		return items[item.ordinal()] >= amount; 
+		return items[item.id] >= amount;
 	}
 	
 	public void removeItem(ItemStack req){
-		items[req.item.ordinal()] -= req.amount;
+		items[req.item.id] -= req.amount;
 		shouldUpdateItems = true;
 	}
 	

--- a/core/src/io/anuke/mindustry/entities/TileEntity.java
+++ b/core/src/io/anuke/mindustry/entities/TileEntity.java
@@ -20,7 +20,7 @@ import io.anuke.ucore.util.Timer;
 
 public class TileEntity extends Entity{
 	public Tile tile;
-	public int[] items = new int[Item.values().length];
+	public int[] items = new int[Item.getAllItems().size];
 	public Timer timer;
 	public int maxhealth, health;
 	public boolean dead = false;
@@ -110,7 +110,7 @@ public class TileEntity extends Entity{
 	}
 	
 	public int getItem(Item item){
-		return items[item.ordinal()];
+		return items[item.id];
 	}
 	
 	public boolean hasItem(Item item){
@@ -122,11 +122,11 @@ public class TileEntity extends Entity{
 	}
 	
 	public void addItem(Item item, int amount){
-		items[item.ordinal()] += amount;
+		items[item.id] += amount;
 	}
 	
 	public void removeItem(Item item, int amount){
-		items[item.ordinal()] -= amount;;
+		items[item.id] -= amount;
 	}
 	
 	@Override

--- a/core/src/io/anuke/mindustry/io/BundleGen.java
+++ b/core/src/io/anuke/mindustry/io/BundleGen.java
@@ -53,8 +53,8 @@ public class BundleGen {
         for(Item item : Item.values()){
             write("item." + item.name() + ".name=" + item.name());
         }
-        for(Liquid liquid : Liquid.values()){
-            write("liquid." + liquid.name() + ".name=" + liquid.name());
+        for(Liquid liquid : Liquid.getAllLiquids()){
+            write("liquid." + liquid.name + ".name=" + liquid.name);
         }
         for(Block block : Block.getAllBlocks()){
             write("block." + block.name + ".name=" + block.formalName);

--- a/core/src/io/anuke/mindustry/io/BundleGen.java
+++ b/core/src/io/anuke/mindustry/io/BundleGen.java
@@ -50,8 +50,8 @@ public class BundleGen {
             write("weapon." + weapon.name() + ".name=" + weapon.name());
             write("weapon." + weapon.name() + ".description=" + weapon.description);
         }
-        for(Item item : Item.values()){
-            write("item." + item.name() + ".name=" + item.name());
+        for(Item item : Item.getAllItems()){
+            write("item." + item.name + ".name=" + item.name);
         }
         for(Liquid liquid : Liquid.getAllLiquids()){
             write("liquid." + liquid.name + ".name=" + liquid.name);

--- a/core/src/io/anuke/mindustry/io/SaveIO.java
+++ b/core/src/io/anuke/mindustry/io/SaveIO.java
@@ -309,7 +309,6 @@ public class SaveIO{
 	public static void load(FileHandle file){
 		
 		try(DataInputStream stream = new DataInputStream(file.read())){
-			Item[] itemEnums = Item.values();
 			
 			int version = stream.readInt();
 			/*long loadTime = */stream.readLong();
@@ -356,9 +355,9 @@ public class SaveIO{
 			Arrays.fill(Vars.control.getItems(), 0);
 			
 			for(int i = 0; i < totalItems; i ++){
-				Item item = itemEnums[stream.readByte()];
+				Item item = Item.items.get(stream.readByte());
 				int amount = stream.readInt();
-				Vars.control.getItems()[item.ordinal()] = amount;
+				Vars.control.getItems()[item.id] = amount;
 			}
 			
 			Vars.ui.updateItems();

--- a/core/src/io/anuke/mindustry/resource/Item.java
+++ b/core/src/io/anuke/mindustry/resource/Item.java
@@ -1,16 +1,40 @@
 package io.anuke.mindustry.resource;
 
+import com.badlogic.gdx.utils.Array;
 import io.anuke.ucore.util.Bundles;
 
-public enum Item{
-	stone, iron, coal, steel, titanium, dirium, uranium;
+public class Item{
 
-	public String localized(){
-		return Bundles.get("item."+name() + ".name");
+	public static final Array<Item> items = new Array<>();
+
+	public static final Item stone = new Item("stone");
+	public static final Item iron = new Item("iron");
+	public static final Item coal = new Item("coal");
+	public static final Item steel = new Item("steel");
+	public static final Item titanium = new Item("titanium");
+	public static final Item dirium = new Item("dirium");
+	public static final Item uranium = new Item("uranium");
+
+	public final int id;
+	public final String name;
+
+	public Item(String name) {
+		this.id = items.size;
+		this.name = name;
+
+		Item.items.add(this);
+	}
+
+	public String localizedName(){
+		return Bundles.get("item." + this.name + ".name");
 	}
 
 	@Override
 	public String toString() {
-		return localized();
+		return localizedName();
+	}
+
+	public static Array<Item> getAllItems() {
+		return Item.items;
 	}
 }

--- a/core/src/io/anuke/mindustry/resource/Liquid.java
+++ b/core/src/io/anuke/mindustry/resource/Liquid.java
@@ -1,26 +1,41 @@
 package io.anuke.mindustry.resource;
 
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.utils.Array;
 import io.anuke.ucore.util.Bundles;
 
-public enum Liquid{
-	water(Color.ROYAL),
-	plasma(Color.CORAL),
-	lava(Color.valueOf("ed5334")),
-	oil(Color.valueOf("292929"));
+public class Liquid {
+
+	public static final Array<Liquid> liquids = new Array<>();
+
+	public static final Liquid water = new Liquid("water", Color.ROYAL);
+	public static final Liquid plasma = new Liquid("plasma", Color.CORAL);
+	public static final Liquid lava = new Liquid("lava", Color.valueOf("ed5334"));
+	public static final Liquid oil = new Liquid("oil", Color.valueOf("292929"));
 	
 	public final Color color;
+	public final String name;
+	public final int id;
 	
-	private Liquid(Color color){
+	public Liquid(String name, Color color) {
+		this.name = name;
 		this.color = new Color(color);
+
+		this.id = liquids.size;
+
+		Liquid.liquids.add(this);
 	}
 
-	public String localized(){
-		return Bundles.get("liquid."+name() + ".name");
+	public String localizedName(){
+		return Bundles.get("liquid."+ this.name + ".name");
 	}
 
 	@Override
 	public String toString(){
-		return localized();
+		return localizedName();
+	}
+
+	public static Array<Liquid> getAllLiquids() {
+		return Liquid.liquids;
 	}
 }

--- a/core/src/io/anuke/mindustry/ui/UpgradeDialog.java
+++ b/core/src/io/anuke/mindustry/ui/UpgradeDialog.java
@@ -93,7 +93,7 @@ public class UpgradeDialog extends FloatingDialog{
 					for(ItemStack s : req){
 						
 						int amount = Math.min(Vars.control.getAmount(s.item), s.amount);
-						reqtable.addImage(Draw.region("icon-" + s.item.name())).padRight(3).size(8*2);
+						reqtable.addImage(Draw.region("icon-" + s.item.name)).padRight(3).size(8*2);
 						reqtable.add(
 								(amount >= s.amount ? "" : "[RED]")
 						+ amount + " / " +s.amount, 0.5f).left();

--- a/core/src/io/anuke/mindustry/ui/fragments/BlocksFragment.java
+++ b/core/src/io/anuke/mindustry/ui/fragments/BlocksFragment.java
@@ -261,7 +261,7 @@ public class BlocksFragment implements Fragment{
 		
 		for(ItemStack stack : recipe.requirements){
 			ItemStack fs = stack;
-			requirements.addImage(Draw.region("icon-"+stack.item.name())).size(8*3);
+			requirements.addImage(Draw.region("icon-"+stack.item.name)).size(8*3);
 			Label reqlabel = new Label("");
 			
 			reqlabel.update(()->{
@@ -295,13 +295,11 @@ public class BlocksFragment implements Fragment{
 			return;
 		}
 
-		Item[] items = Item.values();
-
 		for(int i = 0; i < control.getItems().length; i ++){
 			int amount = control.getItems()[i];
 			if(amount == 0) continue;
 			String formatted = amount > 99999999 ? "inf" : format(amount);
-			Image image = new Image(Draw.region("icon-" + items[i].name()));
+			Image image = new Image(Draw.region("icon-" + Item.items.get(i).name));
 			Label label = new Label(formatted);
 			label.setFontScale(fontscale*1.5f);
 			itemtable.add(image).size(8*3);

--- a/core/src/io/anuke/mindustry/world/Block.java
+++ b/core/src/io/anuke/mindustry/world/Block.java
@@ -189,7 +189,7 @@ public class Block{
 			Tile other = tiles[i];
 			
 			if(i == direction || direction == -1){
-				for(Item item : Item.values()){
+				for(Item item : Item.getAllItems()){
 					
 					if(todump != null && item != todump) continue;
 					

--- a/core/src/io/anuke/mindustry/world/blocks/types/LiquidBlock.java
+++ b/core/src/io/anuke/mindustry/world/blocks/types/LiquidBlock.java
@@ -123,14 +123,14 @@ public class LiquidBlock extends Block implements LiquidAcceptor{
 		
 		@Override
 		public void write(DataOutputStream stream) throws IOException{
-			stream.writeByte(liquid == null ? -1 : liquid.ordinal());
+			stream.writeByte(liquid == null ? -1 : liquid.id);
 			stream.writeByte((byte)(liquidAmount));
 		}
 		
 		@Override
 		public void read(DataInputStream stream) throws IOException{
-			byte ordinal = stream.readByte();
-			liquid = ordinal == -1 ? null : Liquid.values()[ordinal];
+			byte id = stream.readByte();
+			liquid = id == -1 ? null : Liquid.liquids.get(id);
 			liquidAmount = stream.readByte();
 		}
 	}

--- a/core/src/io/anuke/mindustry/world/blocks/types/distribution/Conveyor.java
+++ b/core/src/io/anuke/mindustry/world/blocks/types/distribution/Conveyor.java
@@ -20,7 +20,6 @@ import io.anuke.ucore.core.Timers;
 import io.anuke.ucore.util.*;
 
 public class Conveyor extends Block{
-	private static Item[] items = Item.values();
 	private static ItemPos pos1 = new ItemPos();
 	private static ItemPos pos2 = new ItemPos();
 	private static IntArray removals = new IntArray();
@@ -74,7 +73,7 @@ public class Conveyor extends Block{
 			Tmp.v1.set(tilesize, 0).rotate(rotation * 90);
 			Tmp.v2.set(-tilesize / 2, pos.x*tilesize/2).rotate(rotation * 90);
 			
-			Draw.rect("icon-" + pos.item.name(), 
+			Draw.rect("icon-" + pos.item.name,
 					tile.x * tilesize + Tmp.v1.x * pos.y + Tmp.v2.x, 
 					tile.y * tilesize + Tmp.v1.y * pos.y + Tmp.v2.y, itemSize, itemSize);
 		}
@@ -234,7 +233,7 @@ public class Conveyor extends Block{
 		
 		ItemPos set(int value){
 			byte[] values = Bits.getBytes(value);
-			item = items[values[0]];
+			item = Item.getAllItems().get(values[0]);
 			x = values[1] / 127f;
 			y = ((int)values[2] + 128) / 255f;
 			seed = values[3];
@@ -247,7 +246,7 @@ public class Conveyor extends Block{
 		
 		static int packItem(Item item, float x, float y, byte seed){
 			byte[] bytes = Bits.getBytes(0);
-			bytes[0] = (byte)item.ordinal();
+			bytes[0] = (byte)item.id;
 			bytes[1] = (byte)(x*127);
 			bytes[2] = (byte)(y*255-128);
 			bytes[3] = seed;

--- a/core/src/io/anuke/mindustry/world/blocks/types/distribution/Sorter.java
+++ b/core/src/io/anuke/mindustry/world/blocks/types/distribution/Sorter.java
@@ -28,7 +28,7 @@ public class Sorter extends Junction implements Configurable{
 		
 		SorterEntity entity = tile.entity();
 		
-		TextureRegion region = Draw.region("icon-" + entity.sortItem.name());
+		TextureRegion region = Draw.region("icon-" + entity.sortItem.name);
 		Tmp.tr1.setRegion(region, 4, 4, 1, 1);
 		
 		Draw.rect(Tmp.tr1, tile.worldx(), tile.worldy(), 4f, 4f);
@@ -93,24 +93,24 @@ public class Sorter extends Junction implements Configurable{
 		SorterEntity entity = tile.entity();
 		
 		table.addIButton("icon-arrow-left", 10*3, ()->{
-			int color = entity.sortItem.ordinal();
+			int color = entity.sortItem.id;
 			
 			color --;
 			if(color < 0)
-				color += Item.values().length;
+				color += Item.getAllItems().size;
 			
-			entity.sortItem = Item.values()[color];
+			entity.sortItem = Item.getAllItems().get(color);
 		});
 		
 		table.add().size(40f);
 		
 		table.addIButton("icon-arrow-right", 10*3, ()->{
-			int color = entity.sortItem.ordinal();
+			int color = entity.sortItem.id;
 			
 			color ++;
-			color %= Item.values().length;
+			color %= Item.getAllItems().size;
 			
-			entity.sortItem = Item.values()[color];
+			entity.sortItem = Item.getAllItems().get(color);
 		});
 	}
 	
@@ -124,12 +124,12 @@ public class Sorter extends Junction implements Configurable{
 		
 		@Override
 		public void write(DataOutputStream stream) throws IOException{
-			stream.writeByte(sortItem.ordinal());
+			stream.writeByte(sortItem.id);
 		}
 		
 		@Override
 		public void read(DataInputStream stream) throws IOException{
-			sortItem = Item.values()[stream.readByte()];
+			sortItem = Item.getAllItems().get(stream.readByte());
 		}
 	}
 }

--- a/core/src/io/anuke/mindustry/world/blocks/types/production/LiquidPowerGenerator.java
+++ b/core/src/io/anuke/mindustry/world/blocks/types/production/LiquidPowerGenerator.java
@@ -119,15 +119,15 @@ public class LiquidPowerGenerator extends Generator implements LiquidAcceptor{
 		@Override
 		public void write(DataOutputStream stream) throws IOException{
 			super.write(stream);
-			stream.writeByte(liquid == null ? -1 : liquid.ordinal());
+			stream.writeByte(liquid == null ? -1 : liquid.id);
 			stream.writeByte((byte)(liquidAmount));
 		}
 		
 		@Override
 		public void read(DataInputStream stream) throws IOException{
 			super.read(stream);
-			byte ordinal = stream.readByte();
-			liquid = ordinal == -1 ? null : Liquid.values()[ordinal];
+			byte id = stream.readByte();
+			liquid = id == -1 ? null : Liquid.liquids.get(id);
 			liquidAmount = stream.readByte();
 		}
 	}


### PR DESCRIPTION
Changed both `Liquid` and `Item` enums to classes.

These classes contain the old enum members as static instances to minimize the impact of this change.

Possible future TODO:
- Remove the static item/liquid instances and move to completely dynamic setup.
- Make liquid tiles the color of their fluid.