### PR TITLE
Omnidrill will report unproductive base surface

### DIFF
--- a/core/src/io/anuke/mindustry/world/blocks/ProductionBlocks.java
+++ b/core/src/io/anuke/mindustry/world/blocks/ProductionBlocks.java
@@ -164,6 +164,11 @@ public class ProductionBlocks{
 				tryDump(tile);
 			}
 		}
+		
+                @Override
+                public boolean isLayer(Tile tile){
+                    return tile.floor().drops == null;
+                }
 	},
 	coalgenerator = new ItemPowerGenerator("coalgenerator"){
 		{


### PR DESCRIPTION
In contrast with one-resource drill, the omnidrill is not reporting it has been placed on unproductive base surface (i.e. water, grass, sand, lava etc.). This change fixes this issue.