### PR TITLE
Implement queues for inbound resources

### DIFF
--- a/core/src/io/anuke/mindustry/world/blocks/types/production/Crafter.java
+++ b/core/src/io/anuke/mindustry/world/blocks/types/production/Crafter.java
@@ -37,7 +37,7 @@ public class Crafter extends Block{
 	@Override
 	public void update(Tile tile){
 		
-		if(tile.entity.timer.get(timerDump, 20) && tile.entity.hasItem(result)){
+		if(tile.entity.timer.get(timerDump, 15) && tile.entity.hasItem(result)){
 			tryDump(tile, -1, result);
 		}
 		

--- a/core/src/io/anuke/mindustry/world/blocks/types/production/Crafter.java
+++ b/core/src/io/anuke/mindustry/world/blocks/types/production/Crafter.java
@@ -1,19 +1,24 @@
 package io.anuke.mindustry.world.blocks.types.production;
 
+import java.util.Arrays;
+
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.utils.Array;
+
+import io.anuke.mindustry.Vars;
 import io.anuke.mindustry.graphics.Fx;
 import io.anuke.mindustry.resource.Item;
 import io.anuke.mindustry.world.Block;
 import io.anuke.mindustry.world.Tile;
 import io.anuke.ucore.core.Effects;
 
-import java.util.Arrays;
-
 public class Crafter extends Block{
 	protected final int timerDump = timers++;
 	
 	protected Item[] requirements;
 	protected Item result;
+
+        int capacity = 20;
 
 	public Crafter(String name) {
 		super(name);
@@ -26,12 +31,13 @@ public class Crafter extends Block{
 		super.getStats(list);
 		list.add("[craftinfo]Input: " + Arrays.toString(requirements));
 		list.add("[craftinfo]Output: " + result);
+		list.add("[craftinfo]Capacity per input type: " + capacity);
 	}
 	
 	@Override
 	public void update(Tile tile){
 		
-		if(tile.entity.timer.get(timerDump, 15) && tile.entity.hasItem(result)){
+		if(tile.entity.timer.get(timerDump, 20) && tile.entity.hasItem(result)){
 			tryDump(tile, -1, result);
 		}
 		
@@ -51,11 +57,19 @@ public class Crafter extends Block{
 
 	@Override
 	public boolean acceptItem(Item item, Tile dest, Tile source){
+		boolean craft = false;
 		for(Item req : requirements){
 			if(item == req){
-				return true;
+                            return dest.entity.getItem(item) < capacity;
 			}
 		}
 		return false;
+	}
+
+	@Override
+	public void drawSelect(Tile tile){
+                float fract = (float)tile.entity.totalItems()/((requirements.length-1) *capacity);
+		
+		Vars.renderer.drawBar(Color.GREEN, tile.worldx(), tile.worldy() + 6, fract);
 	}
 }

--- a/core/src/io/anuke/mindustry/world/blocks/types/production/Crafter.java
+++ b/core/src/io/anuke/mindustry/world/blocks/types/production/Crafter.java
@@ -57,7 +57,6 @@ public class Crafter extends Block{
 
 	@Override
 	public boolean acceptItem(Item item, Tile dest, Tile source){
-		boolean craft = false;
 		for(Item req : requirements){
 			if(item == req){
                             return dest.entity.getItem(item) < capacity;


### PR DESCRIPTION
There are now input queues per resource (currently flat 20 per resource type) along with indicator of how full the queue is.