### PR TITLE
File choosing assistance

### DIFF
--- a/core/src/io/anuke/mindustry/ui/dialogs/FileChooser.java
+++ b/core/src/io/anuke/mindustry/ui/dialogs/FileChooser.java
@@ -201,13 +201,39 @@ public class FileChooser extends FloatingDialog {
 		
 		ButtonGroup<TextButton> group = new ButtonGroup<TextButton>();
 		group.setMinCheckCount(0);
-
-		for(FileHandle file : names){
+		
+		////////////////////////////////////////////////////////////////
+		// Contributer's name (On discord)://///////////////////////////
+		// we need moar missiles#6435 //////////////////////////////////
+		/*Sorting time!*/
+		String[] sortedNames = new String[names.length];
+		FileHandle[] sortedFiles = new FileHandle[names.length];
+		for (int i = 0; i < names.length; i++) {
+			sortedNames[i] = names[i].name().toLowerCase();
+			sortedFiles[i] = null;
+		}
+		Arrays.sort(sortedNames);
+		for (int i = 0; i < names.length; i++) {
+			for (int j = 0; j < sortedNames.length; j++) {
+				if(sortedNames[j].equals(names[i].name().toLowerCase())){
+					sortedFiles[j] = names[i];
+					break;
+				}
+			}
+		}
+		names = sortedFiles;
+		/*Sorting over.*/
+		// Contributer's name (On discord)://///////////////////////////
+		// we need moar missiles#6435 //////////////////////////////////
+		////////////////////////////////////////////////////////////////
+		
+		for(int i = 0; i < names.length; i++){
+			FileHandle file = names[i];
 			if( !file.isDirectory() && !filter.test(file)) continue; //skip non-filtered files
 
 			String filename = file.name();
 
-			TextButton button = new TextButton(shorten(filename), "toggle");
+			TextButton button = new TextButton(shorten(sortedFiles[i].name()), "toggle");
 			group.add(button);
 			
 			button.clicked(()->{


### PR DESCRIPTION
When choosing files, what used to happen is if I, say, had a file named "A" and file named "a" they would not appear together because that is *technically* what alphabetical order says. Other than that, it would work just fine in "alphabetical" order, ABCDEFabcdef.  
However, in Mindustry font, caps and lower looks the same. So it looks really weird: ABCDEFABCDEF.  
  
This change makes it so it doesn't matter the caps/un-caps, it will sort the above files as AABBCCDDEEFF.  
(The slight problem comes when someone has two files with the same name but different caps at the start, but that seems like a less common problem, I feel.)  
  
That's the change that has been made here.  
I feel like it's fairly inefficient, so I hope you find a better source in the future.  
It also replaces a foreach loop with a fori loop, but there (might) be a better way to do it in the future.