### PR TITLE
Introduce workaround for libgdx issue by @codegist

### DIFF
--- a/android/src/io/anuke/mindustry/AndroidLauncher.java
+++ b/android/src/io/anuke/mindustry/AndroidLauncher.java
@@ -12,7 +12,6 @@ import android.provider.Settings.Secure;
 import android.telephony.TelephonyManager;
 import android.util.Log;
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.backends.android.AndroidApplication;
 import com.badlogic.gdx.backends.android.AndroidApplicationConfiguration;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.Base64Coder;
@@ -48,7 +47,7 @@ import java.util.Locale;
 
 import static io.anuke.mindustry.Vars.*;
 
-public class AndroidLauncher extends AndroidApplication{
+public class AndroidLauncher extends PatchedAndroidApplication{
     public static final int PERMISSION_REQUEST_CODE = 1;
 
     boolean doubleScaleTablets = true;

--- a/android/src/io/anuke/mindustry/PatchedAndroidApplication.java
+++ b/android/src/io/anuke/mindustry/PatchedAndroidApplication.java
@@ -1,0 +1,25 @@
+package io.anuke.mindustry;
+
+import com.badlogic.gdx.backends.android.AndroidApplication;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class PatchedAndroidApplication extends AndroidApplication {
+
+    private final ExecutorService exec = Executors.newSingleThreadExecutor();
+    private final Runnable forcePause = new Runnable() {
+        @Override
+        public void run() {
+            try {Thread.sleep(100);} catch (InterruptedException e) {}
+            graphics.onDrawFrame(null);
+        }
+    };
+
+    @Override
+    protected void onPause () {
+        if(useImmersiveMode) {
+            exec.submit(forcePause);
+        }
+        super.onPause();
+    }
+}


### PR DESCRIPTION
libgdx has a [buggy piece of code](https://github.com/libgdx/libgdx/blob/9e46b2768e06292f4c9c859ad95ae37bf52bd0ac/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java#L392) which introduces crashes into some devices. This happens in some devices as commented in libgdx/libgdx#4626.

Basically if the game is in foreground and you lock the screen the application gets killed by libgdx `AndroidGraphics` when resuming.
```
AndroidGraphics: waiting for pause synchronization took too long; assuming deadlock and killing
```
Luckily @codegist discussed a workaround in libgdx/libgdx#3861. This pull request adds the workaround to Mindustry.

