### PR TITLE
Fix UUID generation on desktop

### DIFF
--- a/desktop/src/io/anuke/mindustry/desktop/DesktopPlatform.java
+++ b/desktop/src/io/anuke/mindustry/desktop/DesktopPlatform.java
@@ -135,7 +135,7 @@ public class DesktopPlatform extends Platform{
         try{
             Enumeration<NetworkInterface> e = NetworkInterface.getNetworkInterfaces();
             NetworkInterface out;
-            for(out = e.nextElement(); out.getHardwareAddress() == null && e.hasMoreElements() && validAddress(out.getHardwareAddress()); out = e.nextElement()) ;
+            for(out = e.nextElement(); (out.getHardwareAddress() == null || !validAddress(out.getHardwareAddress())) && e.hasMoreElements(); out = e.nextElement()) ;
 
             byte[] bytes = out.getHardwareAddress();
             byte[] result = new byte[8];


### PR DESCRIPTION
Fix NullPointerException when the hardware address for the first interface is `null`