### PR TITLE
Remove duplicate roundrobin properties in weapons

### DIFF
--- a/core/src/io/anuke/mindustry/content/Weapons.java
+++ b/core/src/io/anuke/mindustry/content/Weapons.java
@@ -60,7 +60,6 @@ public class Weapons implements ContentList{
             reload = 60f;
             shots = 4;
             inaccuracy = 2f;
-            roundrobin = false;
             roundrobin = true;
             ejectEffect = Fx.none;
             velocityRnd = 0.2f;
@@ -75,7 +74,6 @@ public class Weapons implements ContentList{
             shots = 4;
             spacing = 8f;
             inaccuracy = 8f;
-            roundrobin = false;
             roundrobin = true;
             ejectEffect = Fx.none;
             shake = 3f;


### PR DESCRIPTION
missiles and swarmer have the roundrobin property set twice to different values