### PR TITLE
Don't add unit drops to core if the core is full

### DIFF
--- a/core/src/io/anuke/mindustry/entities/units/UnitDrops.java
+++ b/core/src/io/anuke/mindustry/entities/units/UnitDrops.java
@@ -35,7 +35,8 @@ public class UnitDrops{
 
                 if(Mathf.chance(0.03)){
                     int amount = Mathf.random(20, 40);
-                    Call.transferItemTo(item, amount, unit.x + Mathf.range(2f), unit.y + Mathf.range(2f), core.tile);
+                    amount = core.tile.block().acceptStack(item, amount, core.tile, null);
+                    if (amount > 0) Call.transferItemTo(item, amount, unit.x + Mathf.range(2f), unit.y + Mathf.range(2f), core.tile);
                 }
             }
         }


### PR DESCRIPTION
Enemy unit drops would previously be added to the core even if the core was at max capacity for the item