### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,22 +16,24 @@ Bleeding-edge live builds are generated automatically for every commit. You can 
 If you'd rather compile on your own, follow these instructions.
 First, make sure you have Java 8 and JDK 8 installed. Open a terminal in the root directory, and run the following commands:
 
+#### Windows
 
-**_Windows_**
+_Running:_ `gradlew desktop:run`  
+_Building:_ `gradlew desktop:dist`
 
-_Running:_ `gradlew.bat desktop:run`  
-_Building:_ `gradlew.bat desktop:dist`
-
-
-**_Linux_**
+#### Linux
 
 _Running:_ `./gradlew desktop:run`  
 _Building:_ `./gradlew desktop:dist`
 
+#### For Server Builds...
+
+Server builds are bundled with each released build (in Releases). If you'd rather compile on your own, replace 'desktop' with 'server' i.e. `gradlew server:dist`.
+
 ---
 
 Gradle may take up to several minutes to download files. Be patient. <br>
-After building, the output .JAR file should be in `/desktop/build/libs/desktop-release.jar.`
+After building, the output .JAR file should be in `/desktop/build/libs/desktop-release.jar` for desktop builds, and in `/server/build/libs/server-release.jar` for server builds.
 
 ### Downloads
 


### PR DESCRIPTION
Proper formatting (md:h4)
Syntactic update, '.bat' no longer needs to come after 'gradlew' for Windows building
Server build instructions