### PR TITLE
Cultivator placement fix

### DIFF
--- a/core/src/io/anuke/mindustry/world/Build.java
+++ b/core/src/io/anuke/mindustry/world/Build.java
@@ -132,7 +132,7 @@ public class Build{
         if(tile == null) return false;
 
         if(type.isMultiblock()){
-            // If a block shall replace another block we need to make sure the drills have the same size and the
+            // If a block shall replace another block we need to make sure the blocks have the same size and the
             // resources on the given tiles allow for the new type.
             if(type.canReplace(tile.block()) && tile.block().size == type.size && type.canPlaceOn(tile)){
                 return true;

--- a/core/src/io/anuke/mindustry/world/Build.java
+++ b/core/src/io/anuke/mindustry/world/Build.java
@@ -132,7 +132,9 @@ public class Build{
         if(tile == null) return false;
 
         if(type.isMultiblock()){
-            if(type.canReplace(tile.block()) && tile.block().size == type.size){
+            // If a block shall replace another block we need to make sure the drills have the same size and the
+            // resources on the given tiles allow for the new type.
+            if(type.canReplace(tile.block()) && tile.block().size == type.size && type.canPlaceOn(tile)){
                 return true;
             }
 

--- a/core/src/io/anuke/mindustry/world/Build.java
+++ b/core/src/io/anuke/mindustry/world/Build.java
@@ -133,7 +133,7 @@ public class Build{
 
         if(type.isMultiblock()){
             // If a block shall replace another block we need to make sure the blocks have the same size and the
-            // resources on the given tiles allow for the new type.
+            // requirements for building the new block are fulfilled by the given tiles.
             if(type.canReplace(tile.block()) && tile.block().size == type.size && type.canPlaceOn(tile)){
                 return true;
             }


### PR DESCRIPTION
This change makes sure that when trying to replace a block by another block of the same type (e.g. replacing any drill by a Cultivator), the replacement is not possible if the new block may not be built in this spot.
Otherwise, it would be possible to e.g. place a Cultivator on a non-grass resource field. That cultivator would then not produce anything since it is not actually placed on a grass tile.