### PR TITLE
Info Pages will now display tool tips for any item icons

### DIFF
--- a/core/src/io/anuke/mindustry/ui/ItemImage.java
+++ b/core/src/io/anuke/mindustry/ui/ItemImage.java
@@ -3,7 +3,6 @@ package io.anuke.mindustry.ui;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import io.anuke.mindustry.type.ItemStack;
-import io.anuke.mindustry.world.meta.StatValue;
 import io.anuke.ucore.core.Core;
 import io.anuke.ucore.function.Supplier;
 import io.anuke.ucore.scene.ui.Image;

--- a/core/src/io/anuke/mindustry/ui/ItemImage.java
+++ b/core/src/io/anuke/mindustry/ui/ItemImage.java
@@ -3,6 +3,7 @@ package io.anuke.mindustry.ui;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import io.anuke.mindustry.type.ItemStack;
+import io.anuke.mindustry.world.meta.StatValue;
 import io.anuke.ucore.core.Core;
 import io.anuke.ucore.function.Supplier;
 import io.anuke.ucore.scene.ui.Image;

--- a/core/src/io/anuke/mindustry/ui/dialogs/UnlocksDialog.java
+++ b/core/src/io/anuke/mindustry/ui/dialogs/UnlocksDialog.java
@@ -6,10 +6,10 @@ import io.anuke.mindustry.game.Content;
 import io.anuke.mindustry.game.UnlockableContent;
 import io.anuke.mindustry.graphics.Palette;
 import io.anuke.mindustry.type.ContentType;
+import io.anuke.mindustry.world.meta.StatValue;
 import io.anuke.ucore.scene.event.HandCursorListener;
 import io.anuke.ucore.scene.ui.Image;
 import io.anuke.ucore.scene.ui.ScrollPane;
-import io.anuke.ucore.scene.ui.Tooltip;
 import io.anuke.ucore.scene.ui.layout.Table;
 import io.anuke.ucore.scene.utils.UIUtils;
 
@@ -65,10 +65,7 @@ public class UnlocksDialog extends FloatingDialog{
 
                     if(control.unlocks.isUnlocked(unlock)){
                         image.clicked(() -> Vars.ui.content.show(unlock));
-                        image.addListener(new Tooltip<>(new Table("clear"){{
-                            add(unlock.localizedName());
-                            margin(4);
-                        }}));
+                        StatValue.addToolTip(image, unlock);
                     }
 
                     if((++count) % maxWidth == 0){

--- a/core/src/io/anuke/mindustry/world/blocks/production/Cultivator.java
+++ b/core/src/io/anuke/mindustry/world/blocks/production/Cultivator.java
@@ -42,6 +42,7 @@ public class Cultivator extends Drill{
         stats.remove(BlockStat.drillTier);
         stats.add(BlockStat.drillTier, table -> {
             table.addImage("grass1").size(8 * 3).padBottom(3).padTop(3);
+            // TODO: find out localized name and add tool tip
         });
     }
 

--- a/core/src/io/anuke/mindustry/world/blocks/production/Drill.java
+++ b/core/src/io/anuke/mindustry/world/blocks/production/Drill.java
@@ -16,11 +16,14 @@ import io.anuke.mindustry.world.consumers.ConsumeLiquid;
 import io.anuke.mindustry.world.meta.BlockGroup;
 import io.anuke.mindustry.world.meta.BlockStat;
 import io.anuke.mindustry.world.meta.StatUnit;
+import io.anuke.mindustry.world.meta.StatValue;
 import io.anuke.ucore.core.Effects;
 import io.anuke.ucore.core.Effects.Effect;
 import io.anuke.ucore.core.Graphics;
 import io.anuke.ucore.core.Timers;
 import io.anuke.ucore.graphics.Draw;
+import io.anuke.ucore.scene.ui.Image;
+import io.anuke.ucore.scene.ui.layout.Cell;
 import io.anuke.ucore.util.Mathf;
 import io.anuke.ucore.util.Threads;
 
@@ -133,7 +136,8 @@ public class Drill extends Block{
 
             for(int i = 0; i < list.size; i++){
                 Item item = list.get(i);
-                table.addImage(item.name + "1").size(8 * 3).padRight(2).padLeft(2).padTop(3).padBottom(3);
+                Cell<Image> imageCell = table.addImage(item.name + "1").size(8 * 3).padRight(2).padLeft(2).padTop(3).padBottom(3);
+                StatValue.addToolTip(imageCell.getElement(), item);
                 if(i != list.size - 1){
                     table.add("/");
                 }

--- a/core/src/io/anuke/mindustry/world/meta/StatValue.java
+++ b/core/src/io/anuke/mindustry/world/meta/StatValue.java
@@ -1,5 +1,10 @@
 package io.anuke.mindustry.world.meta;
 
+import io.anuke.mindustry.game.UnlockableContent;
+import io.anuke.ucore.scene.Element;
+import io.anuke.ucore.scene.ui.Image;
+import io.anuke.ucore.scene.ui.Tooltip;
+import io.anuke.ucore.scene.ui.layout.Cell;
 import io.anuke.ucore.scene.ui.layout.Table;
 
 /**
@@ -7,8 +12,38 @@ import io.anuke.ucore.scene.ui.layout.Table;
  */
 public interface StatValue{
     /**
-     * This method should all elements necessary to display this stat to the specified table.
+     * This method should provide all elements necessary to display this stat to the specified table.
      * For example, a stat that is just text would add label to the table.
      */
     void display(Table table);
+
+    /**
+     * This method adds an icon image together with a tool tip which contains the name of the item.
+     * @param table the table to add the image cell to.
+     * @param item The item which provides the tool tip content.
+     * @return the image cell which was created. The cell is not yet sized or padded.
+     */
+    static Cell<Image> addImageWithToolTip(Table table, UnlockableContent item){
+
+        // Create a table cell with a new image as provided by the item
+        Cell<Image> imageCell = table.addImage(item.getContentIcon());
+
+        // Retrieve the image and add a tool tip with the item's name
+        addToolTip(imageCell.getElement(), item);
+
+        // Return the table cell for further processing (sizing, padding, ...)
+        return imageCell;
+    }
+
+    /**
+     * Adds a tool tip containing the item's localized name to the given element.
+     * @param element The element to assign the tool tip to.
+     * @param item The item which provides the tool tip content.
+     */
+    static void addToolTip(Element element, UnlockableContent item){
+        element.addListener(new Tooltip<>(new Table("clear"){{
+            add(item.localizedName());
+            margin(4);
+        }}));
+    }
 }

--- a/core/src/io/anuke/mindustry/world/meta/values/ItemFilterValue.java
+++ b/core/src/io/anuke/mindustry/world/meta/values/ItemFilterValue.java
@@ -4,6 +4,8 @@ import com.badlogic.gdx.utils.Array;
 import io.anuke.mindustry.type.Item;
 import io.anuke.mindustry.world.meta.StatValue;
 import io.anuke.ucore.function.Predicate;
+import io.anuke.ucore.scene.ui.Image;
+import io.anuke.ucore.scene.ui.layout.Cell;
 import io.anuke.ucore.scene.ui.layout.Table;
 import static io.anuke.mindustry.Vars.*;
 
@@ -24,7 +26,12 @@ public class ItemFilterValue implements StatValue{
 
         for(int i = 0; i < list.size; i++){
             Item item = list.get(i);
-            table.addImage(item.region).size(8 * 3).padRight(2).padLeft(2);
+
+            Cell<Image> imageCell = table.addImage(item.region);
+            imageCell.size(8 * 3).padRight(2).padLeft(2);
+
+            StatValue.addToolTip(imageCell.getElement(), item);
+
             if(i != list.size - 1){
                 table.add("/");
             }

--- a/core/src/io/anuke/mindustry/world/meta/values/ItemListValue.java
+++ b/core/src/io/anuke/mindustry/world/meta/values/ItemListValue.java
@@ -5,6 +5,9 @@ import io.anuke.mindustry.type.Item;
 import io.anuke.mindustry.type.ItemStack;
 import io.anuke.mindustry.ui.ItemImage;
 import io.anuke.mindustry.world.meta.ContentStatValue;
+import io.anuke.mindustry.world.meta.StatValue;
+import io.anuke.ucore.scene.ui.Image;
+import io.anuke.ucore.scene.ui.layout.Cell;
 import io.anuke.ucore.scene.ui.layout.Table;
 
 public class ItemListValue implements ContentStatValue{
@@ -38,11 +41,17 @@ public class ItemListValue implements ContentStatValue{
     public void display(Table table){
         if(items != null){
             for(Item item : items){
-                table.addImage(item.region).size(8 * 3).padRight(5);
+                Cell<Image> imageCell = table.addImage(item.region);
+                imageCell.size(8 * 3).padRight(5);
+
+                StatValue.addToolTip(imageCell.getElement(), item);
             }
         }else{
             for(ItemStack stack : stacks){
-                table.add(new ItemImage(stack)).size(8 * 3).padRight(5);
+                ItemImage image = new ItemImage(stack);
+                table.add(image).size(8 * 3).padRight(5);
+
+                StatValue.addToolTip(image, stack.item);
             }
         }
     }

--- a/core/src/io/anuke/mindustry/world/meta/values/ItemValue.java
+++ b/core/src/io/anuke/mindustry/world/meta/values/ItemValue.java
@@ -5,6 +5,7 @@ import io.anuke.mindustry.type.Item;
 import io.anuke.mindustry.type.ItemStack;
 import io.anuke.mindustry.ui.ItemImage;
 import io.anuke.mindustry.world.meta.ContentStatValue;
+import io.anuke.mindustry.world.meta.StatValue;
 import io.anuke.ucore.scene.ui.layout.Table;
 
 public class ItemValue implements ContentStatValue{
@@ -22,6 +23,8 @@ public class ItemValue implements ContentStatValue{
     @Override
     public void display(Table table){
         //TODO better implementation, quantity support
-        table.add(new ItemImage(item)).size(8 * 3);
+        ItemImage image = new ItemImage(item);
+        table.add(image).size(8 * 3);
+        StatValue.addToolTip(image, item.item);
     }
 }

--- a/core/src/io/anuke/mindustry/world/meta/values/LiquidFilterValue.java
+++ b/core/src/io/anuke/mindustry/world/meta/values/LiquidFilterValue.java
@@ -4,6 +4,9 @@ import com.badlogic.gdx.utils.Array;
 import io.anuke.mindustry.type.Liquid;
 import io.anuke.mindustry.world.meta.StatValue;
 import io.anuke.ucore.function.Predicate;
+import io.anuke.ucore.scene.ui.Image;
+import io.anuke.ucore.scene.ui.Tooltip;
+import io.anuke.ucore.scene.ui.layout.Cell;
 import io.anuke.ucore.scene.ui.layout.Table;
 import static io.anuke.mindustry.Vars.*;
 
@@ -24,7 +27,10 @@ public class LiquidFilterValue implements StatValue{
 
         for(int i = 0; i < list.size; i++){
             Liquid item = list.get(i);
-            table.addImage(item.getContentIcon()).size(8 * 3).padRight(2).padLeft(2).padTop(2).padBottom(2);
+
+            Cell<Image> imageCell = StatValue.addImageWithToolTip(table, item);
+            imageCell.size(8 * 3).padRight(2).padLeft(2).padTop(2).padBottom(2);
+
             if(i != list.size - 1){
                 table.add("/");
             }

--- a/core/src/io/anuke/mindustry/world/meta/values/LiquidValue.java
+++ b/core/src/io/anuke/mindustry/world/meta/values/LiquidValue.java
@@ -3,6 +3,9 @@ package io.anuke.mindustry.world.meta.values;
 import io.anuke.mindustry.game.UnlockableContent;
 import io.anuke.mindustry.type.Liquid;
 import io.anuke.mindustry.world.meta.ContentStatValue;
+import io.anuke.mindustry.world.meta.StatValue;
+import io.anuke.ucore.scene.ui.Image;
+import io.anuke.ucore.scene.ui.layout.Cell;
 import io.anuke.ucore.scene.ui.layout.Table;
 
 public class LiquidValue implements ContentStatValue{
@@ -19,6 +22,7 @@ public class LiquidValue implements ContentStatValue{
 
     @Override
     public void display(Table table){
-        table.addImage(liquid.getContentIcon()).size(8 * 3);
+        Cell<Image> imageCell = StatValue.addImageWithToolTip(table, liquid);
+        imageCell.size(8 * 3);
     }
 }


### PR DESCRIPTION
This is especially useful for beginners who are unable to distinguish all the item icons from one another.
Note that I added several dependencies which might include undesired ones. Feel free to point out better locations for the static functions, for example.