### PR TITLE
Command Centre mode labels.

### DIFF
--- a/core/src/io/anuke/mindustry/world/blocks/units/CommandCenter.java
+++ b/core/src/io/anuke/mindustry/world/blocks/units/CommandCenter.java
@@ -81,11 +81,18 @@ public class CommandCenter extends Block{
     public void buildTable(Tile tile, Table table){
         CommandCenterEntity entity = tile.entity();
         ButtonGroup<ImageButton> group = new ButtonGroup<>();
+        Table buttons = new Table();
 
         for(UnitCommand cmd : UnitCommand.values()){
-            table.addImageButton("command-" + cmd.name(), "toggle", 8*3, () -> threads.run(() -> Call.onCommandCenterSet(players[0], tile, cmd))).size(40f, 44f)
+            buttons.addImageButton("command-" + cmd.name(), "toggle", 8*3, () -> threads.run(() -> Call.onCommandCenterSet(players[0], tile, cmd))).size(40f, 44f)
                 .checked(entity.command == cmd).group(group);
         }
+        table.add(buttons);
+        table.row();
+        Table lab = new Table("pane");
+        lab.label(() -> entity.command.localized()).center().width(group.getButtons().size * 40 - 20);
+        table.add(lab);
+
     }
 
     @Remote(called = Loc.server, forward = true, targets = Loc.both)


### PR DESCRIPTION
It wasn't always clear to new players what each of the buttons in the Command Center did. The Command Center will now display a label with the name of it's current setting to clear up any confusion.