### PR TITLE
Adjustable core position

### DIFF
--- a/core/src/io/anuke/mindustry/maps/TutorialSector.java
+++ b/core/src/io/anuke/mindustry/maps/TutorialSector.java
@@ -30,7 +30,8 @@ public class TutorialSector{
             //TODO fill turret with items mission
             //new BlockMission(ProductionBlocks.mechanicalDrill).setMessage("$tutorial.drillturret"),
 
-            new WaveMission(2).setMessage("$tutorial.waves"),
+            // Create a wave mission which spawns the core at 60, 60 rather than in the center of the map
+            new WaveMission(2, (gen, team) -> gen.tiles[60][60]).setMessage("$tutorial.waves"),
 
             new ItemMission(Items.lead, 150).setMessage("$tutorial.lead"),
             new ItemMission(Items.copper, 250).setMessage("$tutorial.morecopper"),

--- a/core/src/io/anuke/mindustry/maps/TutorialSector.java
+++ b/core/src/io/anuke/mindustry/maps/TutorialSector.java
@@ -31,7 +31,7 @@ public class TutorialSector{
             //new BlockMission(ProductionBlocks.mechanicalDrill).setMessage("$tutorial.drillturret"),
 
             // Create a wave mission which spawns the core at 60, 60 rather than in the center of the map
-            new WaveMission(2, (gen, team) -> gen.tiles[60][60]).setMessage("$tutorial.waves"),
+            new WaveMission(2, 60, 60).setMessage("$tutorial.waves"),
 
             new ItemMission(Items.lead, 150).setMessage("$tutorial.lead"),
             new ItemMission(Items.copper, 250).setMessage("$tutorial.morecopper"),

--- a/core/src/io/anuke/mindustry/maps/missions/BattleMission.java
+++ b/core/src/io/anuke/mindustry/maps/missions/BattleMission.java
@@ -13,8 +13,20 @@ import static io.anuke.mindustry.Vars.*;
 public class BattleMission extends MissionWithStartingCore{
     final int spacing = 30;
 
+    /**
+     * Creates a battle mission with the player core being in the center of the map.
+     */
     public BattleMission(){
-        super((gen, team) -> gen.tiles[50][50]);
+        super();
+    }
+
+    /**
+     * Creates a wave survival with the player core being at a custom location.
+     * @param xCorePos The X coordinate of the custom core position.
+     * @param yCorePos The Y coordinate of the custom core position.
+     */
+    public BattleMission(int xCorePos, int yCorePos){
+        super(xCorePos, yCorePos);
     }
 
     @Override

--- a/core/src/io/anuke/mindustry/maps/missions/BattleMission.java
+++ b/core/src/io/anuke/mindustry/maps/missions/BattleMission.java
@@ -10,8 +10,12 @@ import io.anuke.ucore.util.Bundles;
 
 import static io.anuke.mindustry.Vars.*;
 
-public class BattleMission extends Mission{
+public class BattleMission extends MissionWithStartingCore{
     final int spacing = 30;
+
+    public BattleMission(){
+        super((gen, team) -> gen.tiles[50][50]);
+    }
 
     @Override
     public String getIcon(){
@@ -30,7 +34,7 @@ public class BattleMission extends Mission{
 
     @Override
     public void generate(Generation gen){
-        generateCoreAt(gen, 50, 50, defaultTeam);
+        generateCore(gen, defaultTeam);
 
         if(state.teams.get(defaultTeam).cores.size == 0){
             return;

--- a/core/src/io/anuke/mindustry/maps/missions/BattleMission.java
+++ b/core/src/io/anuke/mindustry/maps/missions/BattleMission.java
@@ -15,9 +15,7 @@ public class BattleMission extends MissionWithStartingCore{
     public static final int defaultXCorePos = 50;
     public static final int defaultYCorePos = 50;
 
-    /**
-     * Creates a battle mission with the player core being at (@defaultXCorePos, @defaultYCorePos)
-     */
+    /** Creates a battle mission with the player core being at (@defaultXCorePos, @defaultYCorePos) */
     public BattleMission(){
         this(defaultXCorePos, defaultYCorePos);
     }
@@ -48,7 +46,7 @@ public class BattleMission extends MissionWithStartingCore{
 
     @Override
     public void generate(Generation gen){
-        generateCore(gen, defaultTeam);
+        generateCoreAtFirstSpawnPoint(gen, defaultTeam);
 
         if(state.teams.get(defaultTeam).cores.size == 0){
             return;

--- a/core/src/io/anuke/mindustry/maps/missions/BattleMission.java
+++ b/core/src/io/anuke/mindustry/maps/missions/BattleMission.java
@@ -12,12 +12,14 @@ import static io.anuke.mindustry.Vars.*;
 
 public class BattleMission extends MissionWithStartingCore{
     final int spacing = 30;
+    public static final int defaultXCorePos = 50;
+    public static final int defaultYCorePos = 50;
 
     /**
-     * Creates a battle mission with the player core being in the center of the map.
+     * Creates a battle mission with the player core being at (@defaultXCorePos, @defaultYCorePos)
      */
     public BattleMission(){
-        super();
+        this(defaultXCorePos, defaultYCorePos);
     }
 
     /**

--- a/core/src/io/anuke/mindustry/maps/missions/Mission.java
+++ b/core/src/io/anuke/mindustry/maps/missions/Mission.java
@@ -100,10 +100,4 @@ public abstract class Mission{
     }
 
     public void generate(Generation gen){}
-
-    public void generateCoreAt(Generation gen, int coreX, int coreY, Team team){
-        gen.tiles[coreX][coreY].setBlock(StorageBlocks.core);
-        gen.tiles[coreX][coreY].setTeam(team);
-        state.teams.get(team).cores.add(gen.tiles[coreX][coreY]);
-    }
 }

--- a/core/src/io/anuke/mindustry/maps/missions/MissionWithStartingCore.java
+++ b/core/src/io/anuke/mindustry/maps/missions/MissionWithStartingCore.java
@@ -12,14 +12,10 @@ import static io.anuke.mindustry.Vars.state;
 public abstract class MissionWithStartingCore extends Mission{
 
 
-    /**
-     * Stores a custom starting location for the core, or null if the default calculation (map center) shall be used
-     */
+    /** Stores a custom starting location for the core, or null if the default calculation (map center) shall be used. */
     private final GridPoint2 customStartingPoint;
 
-    /**
-     * Default constructor. Missions created this way will have a player starting core in the center of the map.
-     */
+    /** Default constructor. Missions created this way will have a player starting core in the center of the map. */
     MissionWithStartingCore(){
         this.customStartingPoint = null;
     }
@@ -52,9 +48,9 @@ public abstract class MissionWithStartingCore extends Mission{
 
     /**
      * Retrieves the spawn point in the center of the map or at a custom location which was provided through the constructor.
-     * @implNote Must return an array with at least one entry.
      * @param gen The generation parameters which provide the map size.
      * @return The center of the map or a custom location.
+     * @implNote Must return an array with at least one entry.
      */
     @Override
     public Array<GridPoint2> getSpawnPoints(Generation gen){

--- a/core/src/io/anuke/mindustry/maps/missions/MissionWithStartingCore.java
+++ b/core/src/io/anuke/mindustry/maps/missions/MissionWithStartingCore.java
@@ -1,6 +1,7 @@
 package io.anuke.mindustry.maps.missions;
 
 import com.badlogic.gdx.math.GridPoint2;
+import com.badlogic.gdx.utils.Array;
 import io.anuke.mindustry.content.blocks.StorageBlocks;
 import io.anuke.mindustry.game.Team;
 import io.anuke.mindustry.maps.generation.Generation;
@@ -34,23 +35,33 @@ public abstract class MissionWithStartingCore extends Mission{
 
     /**
      * Generates a player core based on generation parameters.
-     * @param gen The map generation parameters.
+     * @param gen  The generation parameters which provide the map size.
      * @param team The team to generate the core for.
      */
-    public void generateCore(Generation gen, Team team){
-        int xPos, yPos;
-
-        if(this.customStartingPoint == null){
-            xPos = gen.width/2;
-            yPos = gen.height/2;
-        }else{
-            xPos = this.customStartingPoint.x;
-            yPos = this.customStartingPoint.y;
+    public void generateCoreAtFirstSpawnPoint(Generation gen, Team team){
+        Array<GridPoint2> spawnPoints = getSpawnPoints(gen);
+        if(spawnPoints == null || spawnPoints.size == 0){
+            throw new IllegalArgumentException("A MissionWithStartingCore subclass did not provide a spawn point in getSpawnPoints(). However, at least one point must always be provided.");
         }
 
-        Tile startingCoreTile = gen.tiles[xPos][yPos];
+        Tile startingCoreTile = gen.tiles[spawnPoints.first().x][spawnPoints.first().y];
         startingCoreTile.setBlock(StorageBlocks.core);
         startingCoreTile.setTeam(team);
         state.teams.get(team).cores.add(startingCoreTile);
+    }
+
+    /**
+     * Retrieves the spawn point in the center of the map or at a custom location which was provided through the constructor.
+     * @implNote Must return an array with at least one entry.
+     * @param gen The generation parameters which provide the map size.
+     * @return The center of the map or a custom location.
+     */
+    @Override
+    public Array<GridPoint2> getSpawnPoints(Generation gen){
+        if(this.customStartingPoint == null){
+            return Array.with(new GridPoint2(gen.width / 2, gen.height / 2));
+        }else{
+            return Array.with(this.customStartingPoint);
+        }
     }
 }

--- a/core/src/io/anuke/mindustry/maps/missions/MissionWithStartingCore.java
+++ b/core/src/io/anuke/mindustry/maps/missions/MissionWithStartingCore.java
@@ -1,0 +1,51 @@
+package io.anuke.mindustry.maps.missions;
+
+import io.anuke.mindustry.content.blocks.StorageBlocks;
+import io.anuke.mindustry.game.Team;
+import io.anuke.mindustry.maps.generation.Generation;
+import io.anuke.mindustry.world.Tile;
+
+import static io.anuke.mindustry.Vars.state;
+
+public abstract class MissionWithStartingCore extends Mission{
+
+    /**
+     * Retrieves a tile for the starting core based on the generation parameters.
+     */
+    @FunctionalInterface
+    public interface StartingCorePositionRetriever{
+        Tile getCoreTile(Generation gen, Team team);
+    }
+
+    /**
+     * Stores a function which calculates the position of the starting core.
+     */
+    private final StartingCorePositionRetriever startingCorePositionRetriever;
+
+    /**
+     * Default constructor. Missions created this way will have a player starting core in the center of the map.
+     */
+    MissionWithStartingCore(){
+        this((gen, team) -> gen.tiles[gen.width/2][gen.height/2]);
+    }
+
+    /**
+     * Creates a mission with a core on a non-default location.
+     * @param startingCorePositionRetriever
+     */
+    MissionWithStartingCore(StartingCorePositionRetriever startingCorePositionRetriever){
+        this.startingCorePositionRetriever = startingCorePositionRetriever;
+    }
+
+    /**
+     * Generates a player core based on generation parameters.
+     * @param gen The map generation parameters.
+     * @param team The team to generate the core for.
+     */
+    public void generateCore(Generation gen, Team team){
+        Tile startingCoreTile = startingCorePositionRetriever.getCoreTile(gen, team);
+        startingCoreTile.setBlock(StorageBlocks.core);
+        startingCoreTile.setTeam(team);
+        state.teams.get(team).cores.add(startingCoreTile);
+    }
+}

--- a/core/src/io/anuke/mindustry/maps/missions/MissionWithStartingCore.java
+++ b/core/src/io/anuke/mindustry/maps/missions/MissionWithStartingCore.java
@@ -1,5 +1,6 @@
 package io.anuke.mindustry.maps.missions;
 
+import com.badlogic.gdx.math.GridPoint2;
 import io.anuke.mindustry.content.blocks.StorageBlocks;
 import io.anuke.mindustry.game.Team;
 import io.anuke.mindustry.maps.generation.Generation;
@@ -9,32 +10,26 @@ import static io.anuke.mindustry.Vars.state;
 
 public abstract class MissionWithStartingCore extends Mission{
 
-    /**
-     * Retrieves a tile for the starting core based on the generation parameters.
-     */
-    @FunctionalInterface
-    public interface StartingCorePositionRetriever{
-        Tile getCoreTile(Generation gen, Team team);
-    }
 
     /**
-     * Stores a function which calculates the position of the starting core.
+     * Stores a custom starting location for the core, or null if the default calculation (map center) shall be used
      */
-    private final StartingCorePositionRetriever startingCorePositionRetriever;
+    private final GridPoint2 customStartingPoint;
 
     /**
      * Default constructor. Missions created this way will have a player starting core in the center of the map.
      */
     MissionWithStartingCore(){
-        this((gen, team) -> gen.tiles[gen.width/2][gen.height/2]);
+        this.customStartingPoint = null;
     }
 
     /**
      * Creates a mission with a core on a non-default location.
-     * @param startingCorePositionRetriever
+     * @param xCorePos The x coordinate of the custom core position.
+     * @param yCorePos The y coordinate of the custom core position.
      */
-    MissionWithStartingCore(StartingCorePositionRetriever startingCorePositionRetriever){
-        this.startingCorePositionRetriever = startingCorePositionRetriever;
+    MissionWithStartingCore(int xCorePos, int yCorePos){
+        this.customStartingPoint = new GridPoint2(xCorePos, yCorePos);
     }
 
     /**
@@ -43,7 +38,17 @@ public abstract class MissionWithStartingCore extends Mission{
      * @param team The team to generate the core for.
      */
     public void generateCore(Generation gen, Team team){
-        Tile startingCoreTile = startingCorePositionRetriever.getCoreTile(gen, team);
+        int xPos, yPos;
+
+        if(this.customStartingPoint == null){
+            xPos = gen.width/2;
+            yPos = gen.height/2;
+        }else{
+            xPos = this.customStartingPoint.x;
+            yPos = this.customStartingPoint.y;
+        }
+
+        Tile startingCoreTile = gen.tiles[xPos][yPos];
         startingCoreTile.setBlock(StorageBlocks.core);
         startingCoreTile.setTeam(team);
         state.teams.get(team).cores.add(startingCoreTile);

--- a/core/src/io/anuke/mindustry/maps/missions/WaveMission.java
+++ b/core/src/io/anuke/mindustry/maps/missions/WaveMission.java
@@ -46,7 +46,7 @@ public class WaveMission extends MissionWithStartingCore{
 
     @Override
     public void generate(Generation gen){
-        generateCore(gen, Team.blue);
+        generateCoreAtFirstSpawnPoint(gen, Team.blue);
     }
 
     @Override
@@ -86,10 +86,5 @@ public class WaveMission extends MissionWithStartingCore{
     @Override
     public boolean isComplete(){
         return state.wave > target && Vars.unitGroups[Vars.waveTeam.ordinal()].size() == 0;
-    }
-
-    @Override
-    public Array<GridPoint2> getSpawnPoints(Generation gen){
-        return Array.with(new GridPoint2(gen.width/2, gen.height/2));
     }
 }

--- a/core/src/io/anuke/mindustry/maps/missions/WaveMission.java
+++ b/core/src/io/anuke/mindustry/maps/missions/WaveMission.java
@@ -18,13 +18,23 @@ import static io.anuke.mindustry.Vars.world;
 public class WaveMission extends MissionWithStartingCore{
     private final int target;
 
+    /**
+     * Creates a wave survival mission with the player core being in the center of the map.
+     * @param target The number of waves to be survived.
+     */
     public WaveMission(int target){
         super();
         this.target = target;
     }
 
-    public WaveMission(int target, StartingCorePositionRetriever startingCorePositionRetriever){
-        super(startingCorePositionRetriever);
+    /**
+     * Creates a wave survival with the player core being at a custom location.
+     * @param target The number of waves to be survived.
+     * @param xCorePos The X coordinate of the custom core position.
+     * @param yCorePos The Y coordinate of the custom core position.
+     */
+    public WaveMission(int target, int xCorePos, int yCorePos){
+        super(xCorePos, yCorePos);
         this.target = target;
     }
 

--- a/core/src/io/anuke/mindustry/maps/missions/WaveMission.java
+++ b/core/src/io/anuke/mindustry/maps/missions/WaveMission.java
@@ -15,12 +15,19 @@ import static io.anuke.mindustry.Vars.state;
 import static io.anuke.mindustry.Vars.waveTeam;
 import static io.anuke.mindustry.Vars.world;
 
-public class WaveMission extends Mission{
+public class WaveMission extends MissionWithStartingCore{
     private final int target;
 
     public WaveMission(int target){
+        super();
         this.target = target;
     }
+
+    public WaveMission(int target, StartingCorePositionRetriever startingCorePositionRetriever){
+        super(startingCorePositionRetriever);
+        this.target = target;
+    }
+
 
     @Override
     public Array<SpawnGroup> getWaves(Sector sector){
@@ -29,8 +36,7 @@ public class WaveMission extends Mission{
 
     @Override
     public void generate(Generation gen){
-        int coreX = gen.width/2, coreY = gen.height/2;
-        generateCoreAt(gen, coreX, coreY, Team.blue);
+        generateCore(gen, Team.blue);
     }
 
     @Override


### PR DESCRIPTION
Refactored the previous pull request so it uses `int`s in the public interface. I opened a new pull request since I messed up the old branch. To sum it up again:
- Wave missions spawn the core in the center of the map by default
- Battle missions spawn the core at (50|50) by default
- Both mentioned mission types allow configuring a custom location.
- The tutorial sector spawns the core at (60|60) again like in previous versions (but is still disabled)