### PR TITLE
Sector  -2 0 fix

### DIFF
--- a/core/src/io/anuke/mindustry/ai/BlockIndexer.java
+++ b/core/src/io/anuke/mindustry/ai/BlockIndexer.java
@@ -247,7 +247,7 @@ public class BlockIndexer{
         for(int x = quadrantX * structQuadrantSize; x < world.width() && x < (quadrantX + 1) * structQuadrantSize; x++){
             for(int y = quadrantY * structQuadrantSize; y < world.height() && y < (quadrantY + 1) * structQuadrantSize; y++){
                 Tile result = world.tile(x, y);
-                if(result.block().drops == null || !scanOres.contains(result.block().drops.item)) continue;
+                if( result == null || result.block().drops == null || !scanOres.contains(result.block().drops.item)) continue;
 
                 itemSet.add(result.block().drops.item);
             }

--- a/core/src/io/anuke/mindustry/maps/SectorPresets.java
+++ b/core/src/io/anuke/mindustry/maps/SectorPresets.java
@@ -56,7 +56,8 @@ public class SectorPresets{
                 Missions.blockRecipe(ProductionBlocks.waterExtractor),
                 new ContentMission(Items.biomatter),
                 Missions.blockRecipe(CraftingBlocks.biomatterCompressor),
-                new ContentMission(Liquids.oil)
+                new ContentMission(Liquids.oil),
+                new BattleMission()
             ),
             Array.with(Items.copper, Items.lead, Items.coal, Items.titanium)));
     }

--- a/core/src/io/anuke/mindustry/maps/SectorPresets.java
+++ b/core/src/io/anuke/mindustry/maps/SectorPresets.java
@@ -56,8 +56,8 @@ public class SectorPresets{
                 Missions.blockRecipe(ProductionBlocks.waterExtractor),
                 new ContentMission(Items.biomatter),
                 Missions.blockRecipe(CraftingBlocks.biomatterCompressor),
-                new ContentMission(Liquids.oil)//,
-                //new BattleMission()
+                new ContentMission(Liquids.oil),
+                new BattleMission()
             ),
             Array.with(Items.copper, Items.lead, Items.coal, Items.titanium)));
     }

--- a/core/src/io/anuke/mindustry/maps/SectorPresets.java
+++ b/core/src/io/anuke/mindustry/maps/SectorPresets.java
@@ -56,8 +56,8 @@ public class SectorPresets{
                 Missions.blockRecipe(ProductionBlocks.waterExtractor),
                 new ContentMission(Items.biomatter),
                 Missions.blockRecipe(CraftingBlocks.biomatterCompressor),
-                new ContentMission(Liquids.oil),
-                new BattleMission()
+                new ContentMission(Liquids.oil)//,
+                //new BattleMission()
             ),
             Array.with(Items.copper, Items.lead, Items.coal, Items.titanium)));
     }
@@ -69,6 +69,8 @@ public class SectorPresets{
     public SectorPreset get(int x, int y){
         return presets.get(x, y);
     }
+
+    public GridMap<SectorPreset> getPresets() { return presets; }
 
     private void add(SectorPreset preset){
         presets.put(preset.x, preset.y, preset);

--- a/tests/src/test/java/SectorTests.java
+++ b/tests/src/test/java/SectorTests.java
@@ -1,0 +1,54 @@
+import com.badlogic.gdx.utils.Array;
+import io.anuke.mindustry.Vars;
+import io.anuke.mindustry.core.ContentLoader;
+import io.anuke.mindustry.maps.SectorPresets;
+import io.anuke.mindustry.maps.generation.Generation;
+import io.anuke.mindustry.maps.missions.Mission;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** This class is responsible for testing predefined sectors. */
+public class SectorTests{
+
+    private SectorPresets presets;
+    private Generation fakeGen;
+
+    @BeforeAll
+    static void initializeDependencies(){
+        Vars.content = new ContentLoader();
+        Vars.content.load();
+    }
+
+    @BeforeEach
+    void initTest(){
+        this.presets = new SectorPresets();
+
+        // Fake away the Generation dependency
+        this.fakeGen = new Generation(null, null, 250, 250, null);
+    }
+
+    /** Returns true if at least one mission provides a spawn point. */
+    private boolean spawnPointIsDefined(Array<Mission> missions){
+        for(Mission mission : missions){
+            if(mission.getSpawnPoints(this.fakeGen).size > 0){
+                return true;
+            }
+        }
+        // No spawn point provided
+        return false;
+    }
+
+    /**
+     * Makes sure that every predefined sector has a position for the player core defined.
+     * This is achieved by adding at least one mission which defines a spawn point.
+     */
+    @Test
+    void test_sectorHasACore(){
+        for(SectorPresets.SectorPreset preset : this.presets.getPresets().values()){
+            assertTrue(spawnPointIsDefined(preset.missions), "Sector at (" + preset.x + "|" + preset.y + ") contains no missions which define a spawn point. Add a battle or wave mission.");
+        }
+    }
+}


### PR DESCRIPTION
Fixed sector -2,0 by adding a mission which provides a spawn point.
Additionally, a unit test class was added which validates all predefined sectors. However, it was necessary to add a getPresets() method to the SectorPresets class. If this is undesired, I could change the test to directly access the field using reflections maybe.