### PR TITLE
Added Unlocks menu button to Escape menu on desktop

### DIFF
--- a/core/src/io/anuke/mindustry/core/UI.java
+++ b/core/src/io/anuke/mindustry/core/UI.java
@@ -155,6 +155,7 @@ public class UI extends SceneModule{
         load = new LoadDialog();
         levels = new CustomGameDialog();
         language = new LanguageDialog();
+        unlocks = new UnlocksDialog();
         settings = new SettingsMenuDialog();
         host = new HostDialog();
         paused = new PausedDialog();
@@ -165,7 +166,6 @@ public class UI extends SceneModule{
         traces = new TraceDialog();
         maps = new MapsDialog();
         localplayers = new LocalPlayerDialog();
-        unlocks = new UnlocksDialog();
         content = new ContentInfoDialog();
         sectors = new SectorsDialog();
         missions = new MissionDialog();

--- a/core/src/io/anuke/mindustry/ui/dialogs/PausedDialog.java
+++ b/core/src/io/anuke/mindustry/ui/dialogs/PausedDialog.java
@@ -58,6 +58,9 @@ public class PausedDialog extends FloatingDialog{
             });
 
             content().row();
+            content().addButton("$text.unlocks", ui.unlocks::show);
+
+            content().row();
             content().addButton("$text.settings", ui.settings::show);
 
             content().row();


### PR DESCRIPTION
Since the ingame menu was removed on desktop, there was no possibility to display the unlocked blocks in an active game (only from the main menu). 
This change would produce button order like this:
![grafik](https://user-images.githubusercontent.com/10223149/48315638-02a79080-e5d9-11e8-9eba-242fe26c602f.png)
