### PR TITLE
Workaround which fixes negative power values when loading the map

### DIFF
--- a/core/src/io/anuke/mindustry/world/modules/PowerModule.java
+++ b/core/src/io/anuke/mindustry/world/modules/PowerModule.java
@@ -28,6 +28,10 @@ public class PowerModule extends BlockModule{
         if(Float.isNaN(amount)){
             amount = 0f;
         }
+        // Workaround: If power went negative for some reason, at least fix it when reloading the map
+        if(amount < 0f){
+            amount = 0f;
+        }
 
         short amount = stream.readShort();
         for(int i = 0; i < amount; i++){


### PR DESCRIPTION
This does not fix any actual power issue but allows resetting power to normal levels when loading a map at least.