### PR TITLE
Made Unloader have the same "memory" as the sorter

### DIFF
--- a/core/src/io/anuke/mindustry/world/blocks/storage/SortedUnloader.java
+++ b/core/src/io/anuke/mindustry/world/blocks/storage/SortedUnloader.java
@@ -17,13 +17,20 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 import static io.anuke.mindustry.Vars.content;
+import static io.anuke.mindustry.Vars.threads;
 
 public class SortedUnloader extends Unloader implements SelectionTrait{
     protected float speed = 1f;
+    private static Item lastItem;
 
     public SortedUnloader(String name){
         super(name);
         configurable = true;
+    }
+
+    @Override
+    public void playerPlaced(Tile tile){
+        threads.runDelay(() -> Call.setSortedUnloaderItem(null, tile, lastItem));
     }
 
     @Remote(targets = Loc.both, called = Loc.both, forward = true)
@@ -65,7 +72,10 @@ public class SortedUnloader extends Unloader implements SelectionTrait{
     @Override
     public void buildTable(Tile tile, Table table){
         SortedUnloaderEntity entity = tile.entity();
-        buildItemTable(table, () -> entity.sortItem, item -> Call.setSortedUnloaderItem(null, tile, item));
+        buildItemTable(table, () -> entity.sortItem, item -> {
+            lastItem = item;
+            Call.setSortedUnloaderItem(null, tile, item);
+        });
     }
 
     @Override


### PR DESCRIPTION
I implemented the same 'memory' feature as the sorter's, introduced in b62. It's sort of under the 'sorter' category in terms of features, so I thought it would be logical to do so.