### PR TITLE
Check client version type against server version type

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
     ext {
         versionNumber = '4'
         versionModifier = 'alpha'
-        versionType = 'official'
+        if (!project.hasProperty("versionType")) versionType = 'official'
         appName = 'Mindustry'
         gdxVersion = '1.9.9'
         roboVMVersion = '2.3.0'

--- a/core/src/io/anuke/mindustry/core/NetServer.java
+++ b/core/src/io/anuke/mindustry/core/NetServer.java
@@ -127,7 +127,7 @@ public class NetServer extends Module{
                 return;
             }
 
-            if(packet.versionType == null || ((packet.version == -1 || !packet.versionType.equals("official")) && Version.build != -1 && !admins.allowsCustomClients())){
+            if(packet.versionType == null || ((packet.version == -1 || !packet.versionType.equals(Version.type)) && Version.build != -1 && !admins.allowsCustomClients())){
                 kick(id, KickReason.customClient);
                 return;
             }


### PR DESCRIPTION
Previously, the server would reject all clients with a Version.type that is not "official". This allows for clients compiled with the same Version.type as the server to connect.