### PR TITLE
Remove code duplication and rename set/get method on editor/DrawOperation.java #494

### DIFF
--- a/core/src/io/anuke/mindustry/editor/DrawOperation.java
+++ b/core/src/io/anuke/mindustry/editor/DrawOperation.java
@@ -24,21 +24,23 @@ public class DrawOperation{
 
     public void undo(MapEditor editor){
         for(int i = array.size - 1; i >= 0; i--){
-            long l = array.get(i);
-            array.set(i, TileOp.get(TileOp.x(l), TileOp.y(l), TileOp.type(l), get(editor.tile(TileOp.x(l), TileOp.y(l)), TileOp.type(l))));
-            set(editor, editor.tile(TileOp.x(l), TileOp.y(l)), TileOp.type(l), TileOp.value(l));
+            updateTile(editor, i);
         }
     }
 
     public void redo(MapEditor editor){
         for(int i = 0; i < array.size; i++){
-            long l = array.get(i);
-            array.set(i, TileOp.get(TileOp.x(l), TileOp.y(l), TileOp.type(l), get(editor.tile(TileOp.x(l), TileOp.y(l)), TileOp.type(l))));
-            set(editor, editor.tile(TileOp.x(l), TileOp.y(l)), TileOp.type(l), TileOp.value(l));
+            updateTile(editor, i);
         }
     }
 
-    short get(Tile tile, byte type){
+    private void updateTile(MapEditor editor, int i) {
+        long l = array.get(i);
+        array.set(i, TileOp.get(TileOp.x(l), TileOp.y(l), TileOp.type(l), getTile(editor.tile(TileOp.x(l), TileOp.y(l)), TileOp.type(l))));
+        setTile(editor, editor.tile(TileOp.x(l), TileOp.y(l)), TileOp.type(l), TileOp.value(l));
+    }
+
+    short getTile(Tile tile, byte type){
         if(type == OpType.floor.ordinal()){
             return tile.floorID();
         }else if(type == OpType.block.ordinal()){
@@ -53,7 +55,7 @@ public class DrawOperation{
         throw new IllegalArgumentException("Invalid type.");
     }
 
-    void set(MapEditor editor, Tile tile, byte type, short to){
+    void setTile(MapEditor editor, Tile tile, byte type, short to){
         editor.load(() -> {
             if(type == OpType.floor.ordinal()){
                 tile.setFloor((Floor)content.block(to));


### PR DESCRIPTION
## Abstract 
Refactoring for maintainability and readability of `editor/DrawOperation.java`. 

## Refactoring 
- Extract a method `updateTile` to remove code duplication in `undo` and `redo` methods.
- Rename `set/get` methods to `setTile/getTile` for readability.

## Related Issue
#494 