### PR TITLE
Reduce the cyclomatic complexity of render method in MapRenderer.java 

### DIFF
--- a/core/src/io/anuke/mindustry/editor/MapRenderer.java
+++ b/core/src/io/anuke/mindustry/editor/MapRenderer.java
@@ -6,6 +6,7 @@ import io.anuke.arc.collection.IntSet.IntSetIterator;
 import io.anuke.arc.graphics.Color;
 import io.anuke.arc.graphics.Texture;
 import io.anuke.arc.graphics.g2d.Draw;
+import io.anuke.arc.graphics.g2d.TextureAtlas.AtlasRegion;
 import io.anuke.arc.graphics.g2d.TextureRegion;
 import io.anuke.arc.math.Mathf;
 import io.anuke.arc.util.Disposable;
@@ -15,6 +16,9 @@ import io.anuke.mindustry.graphics.IndexedRenderer;
 import io.anuke.mindustry.world.Block;
 import io.anuke.mindustry.world.Tile;
 import io.anuke.mindustry.world.blocks.BlockPart;
+import java.awt.Point;
+import java.awt.geom.Rectangle2D;
+import java.awt.geom.Rectangle2D.Float;
 
 import static io.anuke.mindustry.Vars.tilesize;
 
@@ -97,57 +101,89 @@ public class MapRenderer implements Disposable{
     }
 
     private void render(int wx, int wy){
-        int x = wx / chunkSize, y = wy / chunkSize;
-        IndexedRenderer mesh = chunks[x][y];
-        Tile tile = editor.tiles()[wx][wy];
+        final Point windowPoint = new Point(wx, wy);
+        final Point gridPoint = new Point(wx/chunkSize, wy/chunkSize);
 
-        Team team = tile.getTeam();
-        Block floor = tile.floor();
+        final Point chunkStartPoint = getChunkStartPoint(windowPoint);
+        final int chunkArea = chunkSize * chunkSize;
+
+
+        IndexedRenderer mesh = getMesh(gridPoint);
+        Tile tile = getTile(windowPoint);
         Block wall = tile.block();
 
-        TextureRegion region;
+        int indexWall = chunkStartPoint.x + chunkStartPoint.y;
+        int indexDecal = chunkStartPoint.x  + chunkStartPoint.y + chunkArea;
 
-        int idxWall = (wx % chunkSize) + (wy % chunkSize) * chunkSize;
-        int idxDecal = (wx % chunkSize) + (wy % chunkSize) * chunkSize + chunkSize * chunkSize;
+        renderMeshRegion(windowPoint, mesh, tile, wall, indexWall);
 
-        if(wall != Blocks.air && (wall.synthetic() || wall instanceof BlockPart)){
-            region = !Core.atlas.isFound(wall.editorIcon()) ? Core.atlas.find("clear-editor") : wall.editorIcon();
 
-            if(wall.rotate){
-                mesh.draw(idxWall, region,
-                wx * tilesize + wall.offset(), wy * tilesize + wall.offset(),
-                region.getWidth() * Draw.scl, region.getHeight() * Draw.scl, tile.rotation() * 90 - 90);
-            }else{
-                mesh.draw(idxWall, region,
-                wx * tilesize + wall.offset() + (tilesize - region.getWidth() * Draw.scl) / 2f,
-                wy * tilesize + wall.offset() + (tilesize - region.getHeight() * Draw.scl) / 2f,
-                region.getWidth() * Draw.scl, region.getHeight() * Draw.scl);
-            }
-        }else{
-            region = floor.editorVariantRegions()[Mathf.randomSeed(idxWall, 0, floor.editorVariantRegions().length - 1)];
+        renderTileRegion(windowPoint, mesh, tile, wall, indexWall, indexDecal);
+    }
 
-            mesh.draw(idxWall, region, wx * tilesize, wy * tilesize, 8, 8);
-        }
+    private void renderTileRegion(Point windowPoint, IndexedRenderer mesh, Tile tile, Block wall, int indexWall, int indexDecal) {
+        TextureRegion textureRegion;
+        final boolean isEditorIconExist = Core.atlas.isFound(wall.editorIcon());
 
-        float offsetX = -(wall.size / 3) * tilesize, offsetY = -(wall.size / 3) * tilesize;
+        Float tileRegion = new Float();
+        Team team = tile.getTeam();
+        float offsetSize = -Mathf.floor((float)(wall.size / 3.0)) * tilesize;
+        FloatPoint offset = new FloatPoint(offsetSize, offsetSize);
 
-        if(wall.update || wall.destructible){
+        final boolean isTeamDrawRequired = wall.update || wall.destructible;
+        if(isTeamDrawRequired){
             mesh.setColor(team.color);
-            region = Core.atlas.find("block-border-editor");
-        }else if(!wall.synthetic() && wall != Blocks.air){
-            region = !Core.atlas.isFound(wall.editorIcon()) ? Core.atlas.find("clear-editor") : wall.editorIcon();
-            offsetX = tilesize / 2f - region.getWidth() / 2f * Draw.scl;
-            offsetY = tilesize / 2f - region.getHeight() / 2f * Draw.scl;
-        }else if(wall == Blocks.air && tile.overlay() != null){
-            region = tile.overlay().editorVariantRegions()[Mathf.randomSeed(idxWall, 0, tile.overlay().editorVariantRegions().length - 1)];
+            textureRegion = getRegionInstance("block-border-editor");
+        }else if(!wall.synthetic() && !isAirBlock(wall)){
+            textureRegion = getEditorIcon(wall, isEditorIconExist);
+            offset.x = getMeshOffset(textureRegion.getWidth());
+            offset.y = getMeshOffset(textureRegion.getHeight());
+        }else if(isAirBlock(wall) && tile.overlay() != null){
+            int random = getRandomValue(indexWall, tile.overlay().editorVariantRegions().length);
+            textureRegion = tile.overlay().editorVariantRegions()[random];
         }else{
-            region = Core.atlas.find("clear-editor");
+            textureRegion = getRegionInstance("clear-editor");
         }
 
-        mesh.draw(idxDecal, region,
-            wx * tilesize + offsetX, wy * tilesize + offsetY,
-            region.getWidth() * Draw.scl, region.getHeight() * Draw.scl);
+        tileRegion.x = windowPoint.x * tilesize + offset.x;
+        tileRegion.y = windowPoint.y * tilesize + offset.y;
+        tileRegion.width = textureRegion.getWidth() * Draw.scl;
+        tileRegion.height = textureRegion.getHeight() * Draw.scl;
+
+        drawMesh(mesh, tile, textureRegion, indexDecal, tileRegion, false);
         mesh.setColor(Color.WHITE);
+    }
+
+
+    private void renderMeshRegion(Point windowPoint, IndexedRenderer mesh, Tile tile, Block wall, int indexWall) {
+        TextureRegion textureRegion;
+        final boolean isBlockPart = (wall.synthetic() || wall instanceof BlockPart);
+        final boolean isEditorIconExist = Core.atlas.isFound(wall.editorIcon());
+
+        Float meshRegion = new Float();
+        boolean needsRotate = false;
+        Block floor = tile.floor();
+
+        meshRegion.x = windowPoint.x * tilesize;
+        meshRegion.y = windowPoint.y * tilesize;
+        if(!isAirBlock(wall) && isBlockPart){
+            textureRegion = getEditorIcon(wall, isEditorIconExist);
+            needsRotate = wall.rotate;
+            meshRegion.x += wall.offset();
+            meshRegion.y += wall.offset();
+            if (!needsRotate) {
+              meshRegion.x += getMeshOffset(textureRegion.getWidth());
+              meshRegion.y += getMeshOffset(textureRegion.getHeight());
+            }
+            meshRegion.width = textureRegion.getWidth() * Draw.scl;
+            meshRegion.height = textureRegion.getHeight() * Draw.scl;
+        }else{
+            int random = getRandomValue(indexWall, floor.editorVariantRegions().length);
+            textureRegion = floor.editorVariantRegions()[random];
+            meshRegion.width = tilesize;
+            meshRegion.height = tilesize;
+        }
+        drawMesh(mesh, tile, textureRegion, indexWall, meshRegion, needsRotate);
     }
 
     @Override
@@ -161,6 +197,68 @@ public class MapRenderer implements Disposable{
                     chunks[x][y].dispose();
                 }
             }
+        }
+    }
+
+    private void drawMesh(IndexedRenderer mesh, Tile tile, TextureRegion textureRegion,
+        int index, Rectangle2D.Float meshRegion, boolean needsRotate) {
+        if(needsRotate){
+            final float rotationDegree = tile.rotation() * 90 - 90;
+            mesh.draw(index, textureRegion,
+                      meshRegion.x,
+                      meshRegion.y,
+                      meshRegion.width,
+                      meshRegion.height,
+                      rotationDegree);
+        }else{
+            mesh.draw(index, textureRegion,
+                      meshRegion.x,
+                      meshRegion.y,
+                      meshRegion.width,
+                      meshRegion.height);
+        }
+    }
+
+    private int getRandomValue(int index, int length) {
+        return Mathf.randomSeed(index, 0, length - 1);
+    }
+
+    private Tile getTile(Point point){
+        return editor.tiles()[point.x][point.y];
+    }
+
+    private IndexedRenderer getMesh(Point point) {
+        return chunks[point.x][point.y];
+    }
+
+    private Point getChunkStartPoint(Point point) {
+        int startX = (point.x % chunkSize);
+        int startY = (point.y % chunkSize) * chunkSize;
+        return new Point(startX, startY);
+    }
+
+    private boolean isAirBlock(Block block) {
+        return block.equals(Blocks.air);
+    }
+
+    private AtlasRegion getRegionInstance(String name) {
+        return Core.atlas.find(name);
+    }
+
+    private float getMeshOffset(float size) {
+        return (tilesize - size * Draw.scl) / 2f;
+    }
+
+    private TextureRegion getEditorIcon(Block wall, boolean isEditorIconExist) {
+        return isEditorIconExist ? wall.editorIcon() : getRegionInstance("clear-editor");
+    }
+
+    private class FloatPoint{
+        private float x;
+        private float y;
+        private FloatPoint(float x, float y) {
+            this.x = x;
+            this.y = y;
         }
     }
 }


### PR DESCRIPTION
# Method refactoring reason

I have checked the cyclomatic complexity of `MapRenderer.java` file through the analysis program which is a plugin of IntelliJ. The result shows the below table.

method | ev(G)<sup>[1](#f1)</sup> | iv(G)<sup>[2](#f2)</sup> | v(G)<sup>[3](#f3)</sup>
-- | -- | -- | --
draw(float,float,float,float) | **4**| 4 | 5
dispose() | 2 | 4 | 5
resize(int,int) | 1 | 4 | 6
MapRenderer.updateAll() | 1 | 3 | 3
MapRenderer.MapRenderer(MapEditor) | 1 | 1 | 1
**render(int,int)** | 1 | **12** | **13**
updatePoint(int,int) | 1 | 1 | 1
-- | -- | -- | --
*Total* | 11 | 29 | 34
*Average* | 1.571428571 | 4.142857143 | 4.857142857

Summarize is looks like the below graph.

![PieChart](https://user-images.githubusercontent.com/16631264/58383517-e6b68a00-8012-11e9-85f6-209a54b46895.png)

As you can see only one `render` method has **almost 40%** of cyclomatic complexity in this file. Therefore, I refactor this method and reduce the cyclomatic complexity.

# Changed list

Unfortunately, I can't fully understand your code. So, I think that you can think the some of the names are really odd. I ask for your understanding regarding this matter. Following contents are related in essential changes of my pull requests.

**1. I packed some formula**
    - Your code is really compact and reasonable. But some of the formulae was hard to read. So I pack that formula. An example is like below.

```java
// BEFORE
float offsetX = -(wall.size / 3) * tilesize, offsetY = -(wall.size / 3) * tilesize;

// AFTER
float offsetSize = -Mathf.floor((float)(wall.size / 3.0)) * tilesize;
FloatPoint offset = new FloatPoint(offsetSize, offsetSize);
```

**2. Add some `Point` and `Rectangle` class**
   - `Point` class separated built-in and nested class `FloatPoint`. Because of the former doesn't handle the float value. So, I added the handle the float value class like the latter. Furthermore, I don't want to interfere with your overall system. As a result, I made the latter with nested class.
   - `Rectangle` class is related in the region. I checked that `mesh.draw` has `x, y, width, height`. So, I added the appropriate class to make more efficient to map `mesh.draw` parameters.

**3. Separate two-part**
   - I separate the inner 'render' method to two-part(`renderMeshRegion`, `renderTileRegion`). I thought that these changes are necessary. But I don't feel that this naming is true. **With all due respect, please confirm this naming.**

# Result

After I did this, the metric changes like below.

method | ev(G)<sup>[1](#f1)</sup> | iv(G)<sup>[2](#f2)</sup> | v(G)<sup>[3](#f3)</sup>
-- | -- | -- | --
dispose() | 2 | 4 | 5
draw(float,float,float,float) | 4 | 4 | 5
drawMesh(...) | 1 | 2 | 2
resize(int,int) | 1 | 4 | 6
updateAll() | 1 | 3 | 3
updatePoint(int,int) | 1 | 1 | 1
**FloatPoint.FloatPoint(float,float)** | 1 | 1 | 1
**getChunkStartPoint(Point)** | 1 | 1 | 1
**getEditorIcon(Block,boolean)** | 1 | 2 | 2
**getMesh(Point)** | 1 | 1 | 1
**getMeshOffset(float)** | 1 | 1 | 1
**getRandomValue(int,int)** | 1 | 1 | 1
**getRegionInstance(String)** | 1 | 1 | 1
**getTile(Point)** | 1 | 1 | 1
**isAirBlock(Block)** | 1 | 1 | 1
**MapRenderer(MapEditor)** | 1 | 1 | 1
**render(int,int)** | 1 | 1 | 1
**renderMeshRegion(...)** | 1 | 5 | 5
**renderTileRegion(...)** | 1 | 6 | 7
-- | -- | -- | --
*Total* | 23 | 41 | 46
*Average* | 1.210526316 | 2.157894737 | 2.421052632

Summarize is looks like the below graph.

![PieChart2](https://user-images.githubusercontent.com/16631264/58384141-52035a80-8019-11e9-9347-13fc295dcb26.png)

Unlike before, you can see that the values are evenly distributed. And I expect that my request will have a positive impact on your future changes in the `editor`.

*I am looking forward to your positive response.*

---

<a name="f1">1</a>: Essential Cyclomatic Complexity
<a name="f2">2</a>: Design Complexity
<a name="f2">3</a>: Cyclomatic Complexity
