### PR TITLE
Fixes minimap zoom bug

### DIFF
--- a/core/src/io/anuke/mindustry/ui/dialogs/MinimapDialog.java
+++ b/core/src/io/anuke/mindustry/ui/dialogs/MinimapDialog.java
@@ -26,6 +26,7 @@ public class MinimapDialog extends FloatingDialog{
 
     void setup(){
         cont.clearChildren();
+        cont.clearListeners();
 
         cont.table(Tex.pane,t -> {
             t.addRect((x, y, width, height) -> {


### PR DESCRIPTION
This bug appears to primarily affect desktop users, since mobile allows for full map scrolling during pause.  The number of listeners increased every time the minimap was opened, which would cause each scroll event to get multiplied by the number of listeners.  Clearing the listeners fixes the problem.