### PR TITLE
Minor code cleanup and fail-fast NPE validation for status effects

### DIFF
--- a/core/src/io/anuke/mindustry/Validate.java
+++ b/core/src/io/anuke/mindustry/Validate.java
@@ -1,0 +1,21 @@
+package io.anuke.mindustry;
+
+/**
+ * Utility methods for parameter and expression validation.  API copied from Apache Lang Validate
+ * https://commons.apache.org/proper/commons-lang/javadocs/api-3.9/org/apache/commons/lang3/Validate.html
+ */
+public class Validate{
+    /**
+     * Returns value or throws NPE if it is null
+     * @param value the variable to validate
+     * @param name  the variable name
+     * @param <T>   the type of value
+     * @return      value
+     */
+    public static <T> T notNull(T value, String name){
+        if(value == null){
+            throw new NullPointerException(name);
+        }
+        return value;
+    }
+}

--- a/core/src/io/anuke/mindustry/entities/units/Statuses.java
+++ b/core/src/io/anuke/mindustry/entities/units/Statuses.java
@@ -124,7 +124,7 @@ public class Statuses implements Saveable{
 
     @Override
     public void readSave(DataInput stream, byte version) throws IOException{
-        statuses.forEach(Pools::free);
+        statuses.each(Pools::free);
         statuses.clear();
 
         byte amount = stream.readByte();
@@ -140,8 +140,7 @@ public class Statuses implements Saveable{
      * @param effect    the status effect
      * @param time      the effect duration
      */
-    private void addStatus(StatusEffect effect, float time)
-    {
+    private void addStatus(StatusEffect effect, float time){
         StatusEntry entry = Pools.obtain(StatusEntry.class, StatusEntry::new);
         statuses.add(entry.set(effect, time));
     }

--- a/core/src/io/anuke/mindustry/type/StatusEffect.java
+++ b/core/src/io/anuke/mindustry/type/StatusEffect.java
@@ -60,8 +60,8 @@ public class StatusEffect extends Content{
         transInit.add(new Object[]{effect, handler});
     }
 
-    @SafeVarargs
-    protected final void opposite(Supplier<StatusEffect>... effect){
+    @SuppressWarnings("unchecked")
+    protected void opposite(Supplier<StatusEffect>... effect){
         for(Supplier<StatusEffect> sup : effect){
             trans(sup, (unit, time, newTime, result) -> {
                 time -= newTime * 0.5f;

--- a/core/src/io/anuke/mindustry/type/StatusEffect.java
+++ b/core/src/io/anuke/mindustry/type/StatusEffect.java
@@ -60,8 +60,8 @@ public class StatusEffect extends Content{
         transInit.add(new Object[]{effect, handler});
     }
 
-    @SuppressWarnings("unchecked")
-    protected void opposite(Supplier... effect){
+    @SafeVarargs
+    protected final void opposite(Supplier<StatusEffect>... effect){
         for(Supplier<StatusEffect> sup : effect){
             trans(sup, (unit, time, newTime, result) -> {
                 time -= newTime * 0.5f;


### PR DESCRIPTION
This PR undoes your band-aid for null status effects, but adds earlier validation to help debugging.  Alternatively, when a null effect is requested, we can set it to none instead and dump a stack trace, but then it will be less obvious when something blows up, and we will have to rely on users being diligent and sending traces.