### PR TITLE
Fixes bug which let phase conveyor operate with any non-zero power; now requires full power to work

### DIFF
--- a/core/src/io/anuke/mindustry/plugin/Plugins.java
+++ b/core/src/io/anuke/mindustry/plugin/Plugins.java
@@ -67,7 +67,7 @@ public class Plugins{
         URLClassLoader classLoader = new URLClassLoader(new URL[]{jar.file().toURI().toURL()}, ClassLoader.getSystemClassLoader());
         Class<?> main = classLoader.loadClass(meta.main);
         metas.put(main, meta);
-        return new LoadedPlugin(jar, zip, (Plugin)main.newInstance(), meta);
+        return new LoadedPlugin(jar, zip, (Plugin)main.getDeclaredConstructor().newInstance(), meta);
     }
 
     /** Represents a plugin that has been loaded from a jar file.*/

--- a/core/src/io/anuke/mindustry/world/blocks/distribution/ItemBridge.java
+++ b/core/src/io/anuke/mindustry/world/blocks/distribution/ItemBridge.java
@@ -177,7 +177,7 @@ public class ItemBridge extends Block{
             entity.uptime = 0f;
         }else{
 
-            if(entity.cons.valid() && Mathf.isZero(1f - entity.power.satisfaction)){
+            if(entity.cons.valid() && (!hasPower || Mathf.isZero(1f - entity.power.satisfaction))){
                 entity.uptime = Mathf.lerpDelta(entity.uptime, 1f, 0.04f);
             }else{
                 entity.uptime = Mathf.lerpDelta(entity.uptime, 0f, 0.02f);

--- a/core/src/io/anuke/mindustry/world/blocks/distribution/ItemBridge.java
+++ b/core/src/io/anuke/mindustry/world/blocks/distribution/ItemBridge.java
@@ -24,7 +24,6 @@ public class ItemBridge extends Block{
     protected int timerTransport = timers++;
     protected int range;
     protected float transportTime = 2f;
-    protected IntArray removals = new IntArray();
     protected TextureRegion endRegion, bridgeRegion, arrowRegion;
 
     private static int lastPlaced = Pos.invalid;
@@ -162,20 +161,14 @@ public class ItemBridge extends Block{
         entity.time += entity.cycleSpeed * entity.delta();
         entity.time2 += (entity.cycleSpeed - 1f) * entity.delta();
 
-        removals.clear();
-
         IntSetIterator it = entity.incoming.iterator();
-
         while(it.hasNext){
             int i = it.next();
             Tile other = world.tile(i);
             if(!linkValid(tile, other, false)){
-                removals.add(i);
+                it.remove();
             }
         }
-
-        for(int j = 0; j < removals.size; j++)
-            entity.incoming.remove(removals.get(j));
 
         Tile other = world.tile(entity.link);
         if(!linkValid(tile, other)){
@@ -184,7 +177,7 @@ public class ItemBridge extends Block{
             entity.uptime = 0f;
         }else{
 
-            if(entity.cons.valid()){
+            if(entity.cons.valid() && Mathf.isZero(1f - entity.power.satisfaction)){
                 entity.uptime = Mathf.lerpDelta(entity.uptime, 1f, 0.04f);
             }else{
                 entity.uptime = Mathf.lerpDelta(entity.uptime, 0f, 0.02f);


### PR DESCRIPTION
AnnaLaura reported this bug a few weeks ago.

Instead of making it binary, we could degrade the throughput by scaling the transport by the `satisfaction`, but this is the easiest fix.

I noticed that Phased Conduit has the same problem, but the code looks like it does scale by `satisfaction`.  However, I can't measure any perf difference betwen a barely-powered and fully powered liquid bridge, so I'm not sure how the code works.