### PR TITLE
Add ability to rotate each block in a line

### DIFF
--- a/core/src/io/anuke/mindustry/input/DesktopInput.java
+++ b/core/src/io/anuke/mindustry/input/DesktopInput.java
@@ -237,11 +237,9 @@ public class DesktopInput extends InputHandler{
         }
 
         if (mode == placing && block != null){
-            if (!overrideLineRotation && !Core.input.keyDown(Binding.diagonal_placement) && (selectX != cursorX || selectY != cursorY)){
-                if ((int) Core.input.axisTap(Binding.rotate) != 0){
-                    rotation = ((int)((Angles.angle(selectX, selectY, cursorX, cursorY) + 45) / 90f)) % 4;
-                    overrideLineRotation = true;
-                }
+            if (!overrideLineRotation && !Core.input.keyDown(Binding.diagonal_placement) && (selectX != cursorX || selectY != cursorY) && ((int) Core.input.axisTap(Binding.rotate) != 0)){
+                rotation = ((int)((Angles.angle(selectX, selectY, cursorX, cursorY) + 45) / 90f)) % 4;
+                overrideLineRotation = true;
             }
         }else{
             overrideLineRotation = false;

--- a/core/src/io/anuke/mindustry/input/DesktopInput.java
+++ b/core/src/io/anuke/mindustry/input/DesktopInput.java
@@ -236,6 +236,17 @@ public class DesktopInput extends InputHandler{
             selectY = tileY(Core.input.mouseY());
         }
 
+        if (mode == placing && block != null){
+            if (!overrideLineRotation && !Core.input.keyDown(Binding.diagonal_placement) && (selectX != cursorX || selectY != cursorY)){
+                if ((int) Core.input.axisTap(Binding.rotate) != 0){
+                    rotation = ((int)((Angles.angle(selectX, selectY, cursorX, cursorY) + 45) / 90f)) % 4;
+                    overrideLineRotation = true;
+                }
+            }
+        }else{
+            overrideLineRotation = false;
+        }
+
         if(Core.input.keyRelease(Binding.break_block) || Core.input.keyRelease(Binding.select)){
 
             if(mode == placing && block != null){ //touch up while placing, place everything in selection

--- a/core/src/io/anuke/mindustry/input/InputHandler.java
+++ b/core/src/io/anuke/mindustry/input/InputHandler.java
@@ -38,6 +38,7 @@ public abstract class InputHandler implements InputProcessor{
     public final OverlayFragment frag = new OverlayFragment();
 
     public Block block;
+    public boolean overrideLineRotation;
     public int rotation;
     public boolean droppingItem;
 
@@ -364,7 +365,7 @@ public abstract class InputHandler implements InputProcessor{
 
         float angle = Angles.angle(startX, startY, endX, endY);
         int baseRotation = rotation;
-        if (diagonal){
+        if (!overrideLineRotation || diagonal){
                 baseRotation = (startX == endX && startY == endY) ? rotation : ((int)((angle + 45) / 90f)) % 4;
         }
 
@@ -380,7 +381,7 @@ public abstract class InputHandler implements InputProcessor{
             Point2 next = i == points.size - 1 ? null : points.get(i + 1);
             line.x = point.x;
             line.y = point.y;
-            if (diagonal){
+            if (!overrideLineRotation || diagonal){
                 line.rotation = next != null ? Tile.relativeTo(point.x, point.y, next.x, next.y) : baseRotation;
             }else{
                 line.rotation = rotation;

--- a/core/src/io/anuke/mindustry/input/InputHandler.java
+++ b/core/src/io/anuke/mindustry/input/InputHandler.java
@@ -363,7 +363,10 @@ public abstract class InputHandler implements InputProcessor{
         }
 
         float angle = Angles.angle(startX, startY, endX, endY);
-        int baseRotation = (startX == endX && startY == endY) ? rotation : ((int)((angle + 45) / 90f)) % 4;
+        int baseRotation = rotation;
+        if (diagonal){
+                baseRotation = (startX == endX && startY == endY) ? rotation : ((int)((angle + 45) / 90f)) % 4;
+        }
 
         Tmp.r3.set(-1, -1, 0, 0);
 
@@ -377,7 +380,11 @@ public abstract class InputHandler implements InputProcessor{
             Point2 next = i == points.size - 1 ? null : points.get(i + 1);
             line.x = point.x;
             line.y = point.y;
-            line.rotation = next != null ? Tile.relativeTo(point.x, point.y, next.x, next.y) : baseRotation;
+            if (diagonal){
+                line.rotation = next != null ? Tile.relativeTo(point.x, point.y, next.x, next.y) : baseRotation;
+            }else{
+                line.rotation = rotation;
+            }
             line.last = next == null;
             cons.accept(line);
 


### PR DESCRIPTION
This PR lets you rotate each block in a straight line placement.

![rotateLine](https://user-images.githubusercontent.com/31429825/65367147-f66d6600-dbe1-11e9-97f2-081601e2d5e5.gif)

It's very handy for situations like the one above.

~This isn't ready to merge, since as it is now, drawing a straight line won't automatically set the rotation.~

I have a few ideas for improving it, but since it's my first PR here, I wanted to check first if this kind of feature is okay.

For one thing, should I move this to DesktopInput, or would it make sense to have this feature on mobile as well?