### PR TITLE
Change item amount display of Block Inventories to show decimals

### DIFF
--- a/core/src/io/anuke/mindustry/ui/fragments/BlockInventoryFragment.java
+++ b/core/src/io/anuke/mindustry/ui/fragments/BlockInventoryFragment.java
@@ -196,11 +196,11 @@ public class BlockInventoryFragment extends Fragment{
         if(f >= 10000000){
             return (int)(f / 1000000f) + "[gray]mil[]";
         }else if(f >= 1000000){
-            return (Math.floor(f / 100000) / 10f) + "[gray]mil[]";
+            return Strings.fixed((float) Math.floor(f / 100000) / 10f, 1) + "[gray]mil[]";
         }else if(f >= 10000){
             return (int)(f / 1000) + "k";
         }else if(f >= 1000){
-            return (Math.floor(f / 100) / 10) + "k";
+            return Strings.fixed((float) Math.floor(f / 100) / 10f, 1) + "k";
         }else{
             return (int)f + "";
         }

--- a/core/src/io/anuke/mindustry/ui/fragments/BlockInventoryFragment.java
+++ b/core/src/io/anuke/mindustry/ui/fragments/BlockInventoryFragment.java
@@ -193,10 +193,14 @@ public class BlockInventoryFragment extends Fragment{
 
     private String round(float f){
         f = (int)f;
-        if(f >= 1000000){
+        if(f >= 10000000){
             return (int)(f / 1000000f) + "[gray]mil[]";
-        }else if(f >= 1000){
+        }else if(f >= 1000000){
+            return (Math.floor(f / 100000) / 10f) + "[gray]mil[]";
+        }else if(f >= 10000){
             return (int)(f / 1000) + "k";
+        }else if(f >= 1000){
+            return (Math.floor(f / 100) / 10) + "k";
         }else{
             return (int)f + "";
         }


### PR DESCRIPTION
To improve a more precise understanding how many items are in certain
blocks, this change will alter the rounding of those item amounts.

It will display the decimals if the amount is between 1000 and 9999
also between 1 million and 9,9 million.

![java_2019-10-01_13-13-11](https://user-images.githubusercontent.com/5092856/65958519-d9d9f500-e44f-11e9-8240-449efb1b608b.png)
