### PR TITLE
Fixed link to "bleeding edge live builds."

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ _[Wiki](https://mindustrygame.github.io/wiki)_
 
 ### Building
 
-Bleeding-edge live builds are generated automatically for every commit. You can see them [here](https://jenkins.hellomouse.net/job/mindustry/).
+Bleeding-edge live builds are generated automatically for every commit. You can see them [here](https://github.com/Anuken/MindustryBuilds/releases). Old builds might still be on [jenkins](https://jenkins.hellomouse.net/job/mindustry/).
 
 If you'd rather compile on your own, follow these instructions.
 First, make sure you have Java 8 and JDK 8 installed. Open a terminal in the root directory, `cd` to the Mindustry folder and run the following commands:


### PR DESCRIPTION
Old target (Jenkins) says that it is no longer up to date and that we should look at github instead.