### PR TITLE
⚔️ Fix stuttering conveyors between teams

### DIFF
--- a/core/src/io/anuke/mindustry/world/blocks/distribution/Conveyor.java
+++ b/core/src/io/anuke/mindustry/world/blocks/distribution/Conveyor.java
@@ -225,7 +225,7 @@ public class Conveyor extends Block implements Autotiler{
             }else{
                 value = pos.pack();
 
-                if(pos.y < entity.minitem)
+                if(pos.y < entity.minitem && (next != null && tile.getTeam() != next.getTeam()))
                     entity.minitem = pos.y;
                 entity.convey.set(i, value);
             }

--- a/core/src/io/anuke/mindustry/world/blocks/distribution/Conveyor.java
+++ b/core/src/io/anuke/mindustry/world/blocks/distribution/Conveyor.java
@@ -183,7 +183,7 @@ public class Conveyor extends Block implements Autotiler{
         Tile next = tile.getNearby(tile.rotation());
         if(next != null) next = next.link();
 
-        float nextMax = next != null && next.block() instanceof Conveyor ? 1f - Math.max(itemSpace - next.<ConveyorEntity>entity().minitem, 0) : 1f;
+        float nextMax = next != null && next.block() instanceof Conveyor && tile.getTeam() == next.getTeam() ? 1f - Math.max(itemSpace - next.<ConveyorEntity>entity().minitem, 0) : 1f;
         int minremove = Integer.MAX_VALUE;
 
         for(int i = entity.convey.size - 1; i >= 0; i--){
@@ -225,7 +225,7 @@ public class Conveyor extends Block implements Autotiler{
             }else{
                 value = pos.pack();
 
-                if(pos.y < entity.minitem && (next != null && tile.getTeam() != next.getTeam()))
+                if(pos.y < entity.minitem)
                     entity.minitem = pos.y;
                 entity.convey.set(i, value);
             }


### PR DESCRIPTION
**backstory**

A few days ago on an assault map i made an attempt to "steal" resources from an item source with a conveyor of my own, when that didn't work i repurposed that line for ammo, and not soon after noticed this bug:

**before**
![Oct-21-2019 18-44-54](https://user-images.githubusercontent.com/3179271/67225130-efc94d00-f432-11e9-8ff2-8b6e5889ef6e.gif)

**after**
![Oct-21-2019 18-45-00](https://user-images.githubusercontent.com/3179271/67225139-f5269780-f432-11e9-8929-54eab29aa86d.gif)

**〃**
![Oct-21-2019 19-39-02](https://user-images.githubusercontent.com/3179271/67228940-9238fe80-f43a-11e9-823a-09d631df0b92.gif)
