### PR TITLE
🥌 Do not count color codes toward maximum name length

### DIFF
--- a/core/src/io/anuke/mindustry/core/NetServer.java
+++ b/core/src/io/anuke/mindustry/core/NetServer.java
@@ -689,7 +689,7 @@ public class NetServer implements ApplicationListener{
 
         StringBuilder result = new StringBuilder();
         int curChar = 0;
-        while(curChar < name.length() && result.toString().getBytes().length < maxNameLength){
+        while(curChar < name.length() && result.toString().getBytes().length < (maxNameLength + name.length() - name.replaceAll("(\\[.*?\\])", "").length())){
             result.append(name.charAt(curChar++));
         }
         return result.toString();


### PR DESCRIPTION
The player limit is there for a reason (of course), but i was wondering which. 🤔 

- **purely visual length** then it would do no harm to subtract the length of formatting codes.
- **packet length something** yea then i can understand why color codes get counted along.

This pull is intended for those with names longer than 4 chars and wish to individually color them.

I kept this pull in draft mode since the regex that determines how many are actually colors is a bit crude and easy to exploit by just wrapping ones entire name within `[]`, let hear & share some thoughts. 😇 