### PR TITLE
Update tools:pack path on windows

### DIFF
--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -344,7 +344,7 @@ task pack(dependsOn: classes){
         }
 
         //pack normal sprites
-        TexturePacker.process("core/assets-raw/sprites_out/", "core/assets/sprites/", "sprites.atlas")
+        TexturePacker.process("../core/assets-raw/sprites_out/", "../core/assets/sprites/", "sprites.atlas")
     }
 }
 


### PR DESCRIPTION
Fix path for TexturePacker on windows.
Everywhere else in the build.gradle uses the same relative path.  