### PR TITLE
🃏 Prevent inverted sorter chaining

### DIFF
--- a/core/src/io/anuke/mindustry/world/blocks/distribution/Sorter.java
+++ b/core/src/io/anuke/mindustry/world/blocks/distribution/Sorter.java
@@ -82,6 +82,10 @@ public class Sorter extends Block{
         return other != null && other.block() instanceof Sorter && other.<SorterEntity>entity().sortItem == tile.<SorterEntity>entity().sortItem;
     }
 
+    boolean isInvertedSorter(Tile other){
+        return other != null && other.block() instanceof Sorter && ((Sorter) other.block()).invert;
+    }
+
     Tile getTileTarget(Item item, Tile dest, Tile source, boolean flip){
         SorterEntity entity = dest.entity();
 
@@ -90,10 +94,16 @@ public class Sorter extends Block{
         Tile to;
 
         if((item == entity.sortItem) != invert){
-            //prevent 3-chains
+            //prevent normal 3-chains
             if(isSame(dest, source) && isSame(dest, dest.getNearby(dir))){
                 return null;
             }
+
+            //prevent invert 3-chains
+            if (isInvertedSorter(source) && isInvertedSorter(dest.getNearby(dir))){
+                return null;
+            }
+
             to = dest.getNearby(dir);
         }else{
             Tile a = dest.getNearby(Mathf.mod(dir - 1, 4));


### PR DESCRIPTION
A little to often on servers nowadays the inverted sorters get abused to make what could only be described as a `core 🐍`, of course there will be people hating me for making this pull thus taking away their toy, but i believe its for the best 🤔 

**abomination**
![Screen Shot 2019-10-29 at 14 25 02](https://user-images.githubusercontent.com/3179271/67771109-f457bc00-fa57-11e9-922e-5620f49ddce1.png)
**before**
![Oct-29-2019 14-18-30](https://user-images.githubusercontent.com/3179271/67770821-6c71b200-fa57-11e9-9d7e-bf783fcc78cc.gif)
**after**
![Oct-29-2019 14-18-35](https://user-images.githubusercontent.com/3179271/67770835-71366600-fa57-11e9-80d1-697725cf0eaa.gif)
(code is not pretty, but it works, no idea if it has unintended side-effects, the above examples should be most if not all use cases, and those appear fine, hopefully this can assist in finding a solution 😗)