### PR TITLE
💼 Optionally show resources ingame

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -621,6 +621,7 @@ setting.vsync.name = VSync
 setting.pixelate.name = Pixelate[lightgray] (disables animations)
 setting.minimap.name = Show Minimap
 setting.position.name = Show Player Position
+setting.resources.name = Show Available Resources
 setting.musicvol.name = Music Volume
 setting.ambientvol.name = Ambient Volume
 setting.mutemusic.name = Mute Music

--- a/core/src/io/anuke/mindustry/ui/ItemsDisplay.java
+++ b/core/src/io/anuke/mindustry/ui/ItemsDisplay.java
@@ -38,15 +38,24 @@ public class ItemsDisplay extends Table{
             int i = 0;
             for(Item item : content.items()){
                 if(item.type == ItemType.material && data.isUnlocked(item)){
-                    t.label(() -> format(item)).left().minWidth(50);
-                    t.addImage(item.icon(Cicon.small)).size(8 * 3).padLeft(4).padRight(4);
                     if(campaign){
+                        t.label(() -> format(item)).left().minWidth(50);
+                        t.addImage(item.icon(Cicon.small)).size(8 * 3).padLeft(4).padRight(4);
                         t.add(item.localizedName()).color(Color.lightGray).left();
                         t.row();
-                    } else {
+                    }else if(mobile){
                         if (++i % 2 == 0){
+                            t.label(() -> format(item)).left().minWidth(50);
+                            t.addImage(item.icon(Cicon.small)).size(8 * 3).padLeft(4).padRight(4);
                             t.row();
+                        }else{
+                            t.addImage(item.icon(Cicon.small)).size(8 * 3).padLeft(4).padRight(4);
+                            t.label(() -> format(item)).left().minWidth(50);
                         }
+                    }else{
+                        t.label(() -> format(item)).left().minWidth(50);
+                        t.addImage(item.icon(Cicon.small)).size(8 * 3).padLeft(4).padRight(4);
+                        t.row();
                     }
                 }
             }

--- a/core/src/io/anuke/mindustry/ui/ItemsDisplay.java
+++ b/core/src/io/anuke/mindustry/ui/ItemsDisplay.java
@@ -35,14 +35,19 @@ public class ItemsDisplay extends Table{
                 t.row();
             }
 
+            int i = 0;
             for(Item item : content.items()){
                 if(item.type == ItemType.material && data.isUnlocked(item)){
                     t.label(() -> format(item)).left().minWidth(50);
                     t.addImage(item.icon(Cicon.small)).size(8 * 3).padLeft(4).padRight(4);
                     if(campaign){
                         t.add(item.localizedName()).color(Color.lightGray).left();
+                        t.row();
+                    } else {
+                        if (++i % 2 == 0){
+                            t.row();
+                        }
                     }
-                    t.row();
                 }
             }
         });

--- a/core/src/io/anuke/mindustry/ui/ItemsDisplay.java
+++ b/core/src/io/anuke/mindustry/ui/ItemsDisplay.java
@@ -39,7 +39,9 @@ public class ItemsDisplay extends Table{
                 if(item.type == ItemType.material && data.isUnlocked(item)){
                     t.label(() -> format(item)).left().minWidth(50);
                     t.addImage(item.icon(Cicon.small)).size(8 * 3).padLeft(4).padRight(4);
-                    t.add(item.localizedName()).color(Color.lightGray).left();
+                    if(campaign){
+                        t.add(item.localizedName()).color(Color.lightGray).left();
+                    }
                     t.row();
                 }
             }

--- a/core/src/io/anuke/mindustry/ui/ItemsDisplay.java
+++ b/core/src/io/anuke/mindustry/ui/ItemsDisplay.java
@@ -11,8 +11,14 @@ import static io.anuke.mindustry.Vars.*;
 /** Displays a list of items, e.g. launched items.*/
 public class ItemsDisplay extends Table{
     private StringBuilder builder = new StringBuilder();
+    public boolean campaign = true;
 
     public ItemsDisplay(){
+        rebuild();
+    }
+
+    public ItemsDisplay(boolean campaign) {
+        this.campaign = campaign;
         rebuild();
     }
 
@@ -22,12 +28,16 @@ public class ItemsDisplay extends Table{
         margin(0);
 
         table(Tex.button,t -> {
-            t.margin(10).marginLeft(15).marginTop(15f);
-            t.label(() -> state.is(State.menu) ? "$launcheditems" : "$launchinfo").colspan(3).padBottom(4).left().colspan(3).width(210f).wrap();
-            t.row();
+
+            if(campaign){
+                t.margin(10).marginLeft(15).marginTop(15f);
+                t.label(() -> state.is(State.menu) ? "$launcheditems" : "$launchinfo").colspan(3).padBottom(4).left().colspan(3).width(210f).wrap();
+                t.row();
+            }
+
             for(Item item : content.items()){
                 if(item.type == ItemType.material && data.isUnlocked(item)){
-                    t.label(() -> format(item)).left();
+                    t.label(() -> format(item)).left().minWidth(50);
                     t.addImage(item.icon(Cicon.small)).size(8 * 3).padLeft(4).padRight(4);
                     t.add(item.localizedName()).color(Color.lightGray).left();
                     t.row();
@@ -38,10 +48,16 @@ public class ItemsDisplay extends Table{
 
     private String format(Item item){
         builder.setLength(0);
-        builder.append(ui.formatAmount(data.items().get(item, 0)));
-        if(!state.is(State.menu) && !state.teams.get(player.getTeam()).cores.isEmpty() && state.teams.get(player.getTeam()).cores.first().entity != null && state.teams.get(player.getTeam()).cores.first().entity.items.get(item) > 0){
-            builder.append(" [unlaunched]+ ");
-            builder.append(ui.formatAmount(state.teams.get(player.getTeam()).cores.first().entity.items.get(item)));
+        if(campaign){
+            builder.append(ui.formatAmount(data.items().get(item, 0)));
+            if(!state.is(State.menu) && !state.teams.get(player.getTeam()).cores.isEmpty() && state.teams.get(player.getTeam()).cores.first().entity != null && state.teams.get(player.getTeam()).cores.first().entity.items.get(item) > 0){
+                builder.append(" [unlaunched]+ ");
+                builder.append(ui.formatAmount(state.teams.get(player.getTeam()).cores.first().entity.items.get(item)));
+            }
+        } else {
+            if(!state.is(State.menu) && !state.teams.get(player.getTeam()).cores.isEmpty() && state.teams.get(player.getTeam()).cores.first().entity != null){
+                builder.append(ui.formatAmount(state.teams.get(player.getTeam()).cores.first().entity.items.get(item)));
+            }
         }
         return builder.toString();
     }

--- a/core/src/io/anuke/mindustry/ui/ItemsDisplay.java
+++ b/core/src/io/anuke/mindustry/ui/ItemsDisplay.java
@@ -44,13 +44,10 @@ public class ItemsDisplay extends Table{
                         t.add(item.localizedName()).color(Color.lightGray).left();
                         t.row();
                     }else if(mobile){
+                        t.addImage(item.icon(Cicon.small)).size(8 * 3).padLeft(4).padRight(4);
+                        t.label(() -> format(item)).left().minWidth(50);
                         if (++i % 2 == 0){
-                            t.label(() -> format(item)).left().minWidth(50);
-                            t.addImage(item.icon(Cicon.small)).size(8 * 3).padLeft(4).padRight(4);
                             t.row();
-                        }else{
-                            t.addImage(item.icon(Cicon.small)).size(8 * 3).padLeft(4).padRight(4);
-                            t.label(() -> format(item)).left().minWidth(50);
                         }
                     }else{
                         t.label(() -> format(item)).left().minWidth(50);

--- a/core/src/io/anuke/mindustry/ui/dialogs/SettingsMenuDialog.java
+++ b/core/src/io/anuke/mindustry/ui/dialogs/SettingsMenuDialog.java
@@ -295,6 +295,7 @@ public class SettingsMenuDialog extends SettingsDialog{
         graphics.checkPref("playerchat", true);
         graphics.checkPref("minimap", !mobile);
         graphics.checkPref("position", false);
+        graphics.checkPref("resources", false);
         graphics.checkPref("fps", false);
         graphics.checkPref("indicators", true);
         graphics.checkPref("animatedwater", !mobile);

--- a/core/src/io/anuke/mindustry/ui/fragments/HudFragment.java
+++ b/core/src/io/anuke/mindustry/ui/fragments/HudFragment.java
@@ -257,9 +257,17 @@ public class HudFragment extends Fragment{
             t.add(new Minimap());
             t.row();
             //position
+            t.top().right();
             t.label(() -> world.toTile(player.x) + "," + world.toTile(player.y))
                 .visible(() -> Core.settings.getBool("position") && !state.rules.tutorial);
-            t.top().right();
+        });
+
+        // resources
+        parent.fill(t -> {
+            t.visible(() -> Core.settings.getBool("resources") && !state.rules.tutorial);
+            t.add(new ItemsDisplay(false));
+            t.row();
+            t.bottom().left();
         });
 
         //spawner warning


### PR DESCRIPTION
![Screen Shot 2019-10-30 at 20 18 56](https://user-images.githubusercontent.com/3179271/67891317-a5428180-fb52-11e9-9f82-de639bd35b7c.png)
This is just a small modification i made to my client (just now) and will be using it in my custom builds, and i thought i would just share it (yay open source), not intended to be merged unless you think its useful (code is a bit crude), i personally find it neat that i now can view the resources of my team without having to take a peek at the core all the time or hover over a handful of buildings in the menu to get a glimpse, this also communicates nonverbaly that your team might be running out of a certain resource so you can act accordingly & ahead of time, instead of suddenly not being able to build anything anymore. (`false/off` by default)
