### PR TITLE
Add max connections stat to power nodes

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -522,6 +522,7 @@ blocks.shootrange = Range
 blocks.size = Size
 blocks.liquidcapacity = Liquid Capacity
 blocks.powerrange = Power Range
+blocks.powerconnections = Max Connections
 blocks.poweruse = Power Use
 blocks.powerdamage = Power/Damage
 blocks.itemcapacity = Item Capacity

--- a/core/assets/bundles/bundle_cs.properties
+++ b/core/assets/bundles/bundle_cs.properties
@@ -501,6 +501,7 @@ blocks.shootrange = Dostřel
 blocks.size = velikost
 blocks.liquidcapacity = Kapacita tekutin
 blocks.powerrange = Rozsah energie
+blocks.powerconnections = Max Connections
 blocks.poweruse = Spotřebuje energie
 blocks.powerdamage = Energie na poškození
 blocks.itemcapacity = kapacita předmětů

--- a/core/assets/bundles/bundle_de.properties
+++ b/core/assets/bundles/bundle_de.properties
@@ -501,6 +501,7 @@ blocks.shootrange = Reichweite
 blocks.size = Größe
 blocks.liquidcapacity = Flüssigkeitskapazität
 blocks.powerrange = Stromreichweite
+blocks.powerconnections = Max Connections
 blocks.poweruse = Stromverbrauch
 blocks.powerdamage = Stromverbrauch/Schadenspunkt
 blocks.itemcapacity = Materialkapazität

--- a/core/assets/bundles/bundle_es.properties
+++ b/core/assets/bundles/bundle_es.properties
@@ -501,6 +501,7 @@ blocks.shootrange = Rango de Disparo
 blocks.size = Tamaño
 blocks.liquidcapacity = Capacidad de Líquidos
 blocks.powerrange = Rango de Energía
+blocks.powerconnections = Max Connections
 blocks.poweruse = Consumo de Energía
 blocks.powerdamage = Energía/Daño
 blocks.itemcapacity = Capacidad de Objetos

--- a/core/assets/bundles/bundle_et.properties
+++ b/core/assets/bundles/bundle_et.properties
@@ -501,6 +501,7 @@ blocks.shootrange = Ulatus
 blocks.size = Suurus
 blocks.liquidcapacity = Vedelike mahutavus
 blocks.powerrange = Energia ulatus
+blocks.powerconnections = Max Connections
 blocks.poweruse = Energiatarve
 blocks.powerdamage = Energiatarve hävituspunkti kohta
 blocks.itemcapacity = Ressursside mahutavus

--- a/core/assets/bundles/bundle_eu.properties
+++ b/core/assets/bundles/bundle_eu.properties
@@ -501,6 +501,7 @@ blocks.shootrange = Irismena
 blocks.size = Neurria
 blocks.liquidcapacity = Likido-edukiera
 blocks.powerrange = Energia irismena
+blocks.powerconnections = Max Connections
 blocks.poweruse = Energia-erabilera
 blocks.powerdamage = Energia/Kaltea
 blocks.itemcapacity = Elementu-edukiera

--- a/core/assets/bundles/bundle_fr.properties
+++ b/core/assets/bundles/bundle_fr.properties
@@ -518,6 +518,7 @@ blocks.shootrange = Portée
 blocks.size = Taille
 blocks.liquidcapacity = Capacité liquide
 blocks.powerrange = Portée électrique
+blocks.powerconnections = Max Connections
 blocks.poweruse = Énergie utilisée
 blocks.powerdamage = Énergie/Dégâts
 blocks.itemcapacity = Stockage

--- a/core/assets/bundles/bundle_fr_BE.properties
+++ b/core/assets/bundles/bundle_fr_BE.properties
@@ -501,6 +501,7 @@ blocks.shootrange = Portée
 blocks.size = Taille
 blocks.liquidcapacity = Capacité en liquide
 blocks.powerrange = Distance de transmission
+blocks.powerconnections = Max Connections
 blocks.poweruse = Énergie utilisée
 blocks.powerdamage = Énergie/Dégâts
 blocks.itemcapacity = Stockage

--- a/core/assets/bundles/bundle_in_ID.properties
+++ b/core/assets/bundles/bundle_in_ID.properties
@@ -501,6 +501,7 @@ blocks.shootrange = Jarak
 blocks.size = Ukuran
 blocks.liquidcapacity = Kapasitas Zat Cair
 blocks.powerrange = Jarak Tenaga
+blocks.powerconnections = Max Connections
 blocks.poweruse = Penggunaan Tenaga
 blocks.powerdamage = Tenaga/Pukulan
 blocks.itemcapacity = Kapasitas Item

--- a/core/assets/bundles/bundle_it.properties
+++ b/core/assets/bundles/bundle_it.properties
@@ -502,6 +502,7 @@ blocks.shootrange = Raggio
 blocks.size = Grandezza
 blocks.liquidcapacity = Capacità del liquido
 blocks.powerrange = Raggio Energia
+blocks.powerconnections = Max Connections
 blocks.poweruse = Utilizzo energia
 blocks.powerdamage = Energia/Danno
 blocks.itemcapacity = Capacità

--- a/core/assets/bundles/bundle_ja.properties
+++ b/core/assets/bundles/bundle_ja.properties
@@ -501,6 +501,7 @@ blocks.shootrange = 範囲
 blocks.size = 大きさ
 blocks.liquidcapacity = 液体容量
 blocks.powerrange = 電力範囲
+blocks.powerconnections = Max Connections
 blocks.poweruse = 電力使用量
 blocks.powerdamage = 電力/ダメージ
 blocks.itemcapacity = アイテム容量

--- a/core/assets/bundles/bundle_ko.properties
+++ b/core/assets/bundles/bundle_ko.properties
@@ -521,6 +521,7 @@ blocks.shootrange = 사거리
 blocks.size = 크기
 blocks.liquidcapacity = 액체 용량
 blocks.powerrange = 전력 범위
+blocks.powerconnections = Max Connections
 blocks.poweruse = 전력 사용
 blocks.powerdamage = 전력/데미지
 blocks.itemcapacity = 저장 용량

--- a/core/assets/bundles/bundle_nl.properties
+++ b/core/assets/bundles/bundle_nl.properties
@@ -501,6 +501,7 @@ blocks.shootrange = Range
 blocks.size = Size
 blocks.liquidcapacity = Liquid Capacity
 blocks.powerrange = Power Range
+blocks.powerconnections = Max Connections
 blocks.poweruse = Power Use
 blocks.powerdamage = Power/Damage
 blocks.itemcapacity = Item Capacity

--- a/core/assets/bundles/bundle_nl_BE.properties
+++ b/core/assets/bundles/bundle_nl_BE.properties
@@ -501,6 +501,7 @@ blocks.shootrange = Range
 blocks.size = Size
 blocks.liquidcapacity = Liquid Capacity
 blocks.powerrange = Power Range
+blocks.powerconnections = Max Connections
 blocks.poweruse = Power Use
 blocks.powerdamage = Power/Damage
 blocks.itemcapacity = Item Capacity

--- a/core/assets/bundles/bundle_pl.properties
+++ b/core/assets/bundles/bundle_pl.properties
@@ -501,6 +501,7 @@ blocks.shootrange = Zasięg
 blocks.size = Rozmiar
 blocks.liquidcapacity = Pojemność cieczy
 blocks.powerrange = Zakres mocy
+blocks.powerconnections = Max Connections
 blocks.poweruse = Zużycie prądu
 blocks.powerdamage = Moc/Zniszczenia
 blocks.itemcapacity = Pojemność przedmiotów

--- a/core/assets/bundles/bundle_pt.properties
+++ b/core/assets/bundles/bundle_pt.properties
@@ -501,6 +501,7 @@ blocks.shootrange = Alcance
 blocks.size = Tamanho
 blocks.liquidcapacity = Capacidade de Líquido
 blocks.powerrange = Alcance da Energia
+blocks.powerconnections = Max Connections
 blocks.poweruse = Uso de energia
 blocks.powerdamage = Dano/Poder
 blocks.itemcapacity = Capacidade de Itens

--- a/core/assets/bundles/bundle_pt_BR.properties
+++ b/core/assets/bundles/bundle_pt_BR.properties
@@ -501,6 +501,7 @@ blocks.shootrange = Alcance
 blocks.size = Tamanho
 blocks.liquidcapacity = Capacidade de Líquido
 blocks.powerrange = Alcance da Energia
+blocks.powerconnections = Max Connections
 blocks.poweruse = Uso de energia
 blocks.powerdamage = Dano/Poder
 blocks.itemcapacity = Capacidade de Itens

--- a/core/assets/bundles/bundle_ru.properties
+++ b/core/assets/bundles/bundle_ru.properties
@@ -520,6 +520,7 @@ blocks.shootrange = Радиус действия
 blocks.size = Размер
 blocks.liquidcapacity = Вместимость жидкости
 blocks.powerrange = Диапазон передачи энергии
+blocks.powerconnections = Max Connections
 blocks.poweruse = Потребляет энергии
 blocks.powerdamage = Энергия/урон
 blocks.itemcapacity = Вместимость предметов

--- a/core/assets/bundles/bundle_sv.properties
+++ b/core/assets/bundles/bundle_sv.properties
@@ -501,6 +501,7 @@ blocks.shootrange = Range
 blocks.size = Storlek
 blocks.liquidcapacity = Liquid Capacity
 blocks.powerrange = Power Range
+blocks.powerconnections = Max Connections
 blocks.poweruse = Power Use
 blocks.powerdamage = Power/Damage
 blocks.itemcapacity = Item Capacity

--- a/core/assets/bundles/bundle_tk.properties
+++ b/core/assets/bundles/bundle_tk.properties
@@ -501,6 +501,7 @@ blocks.shootrange = Menzil
 blocks.size = Buyukluk
 blocks.liquidcapacity = Sivi kapasitesi
 blocks.powerrange = Menzil
+blocks.powerconnections = Max Connections
 blocks.poweruse = Guc kullanimi
 blocks.powerdamage = Power/Damage
 blocks.itemcapacity = Esya kapasitesi

--- a/core/assets/bundles/bundle_tr.properties
+++ b/core/assets/bundles/bundle_tr.properties
@@ -516,6 +516,7 @@ blocks.shootrange = Menzil
 blocks.size = Boyut
 blocks.liquidcapacity = Sıvı Kapasitesi
 blocks.powerrange = Enerji Menzili
+blocks.powerconnections = Max Connections
 blocks.poweruse = Enerji Kullanımı
 blocks.powerdamage = Enerji/Hasar
 blocks.itemcapacity = Eşya Kapasitesi

--- a/core/assets/bundles/bundle_uk_UA.properties
+++ b/core/assets/bundles/bundle_uk_UA.properties
@@ -513,6 +513,7 @@ blocks.shootrange = Діапазон дії
 blocks.size = Розмір
 blocks.liquidcapacity = Місткість рідини
 blocks.powerrange = Діапазон передачі енергії
+blocks.powerconnections = Max Connections
 blocks.poweruse = Енергії використовує
 blocks.powerdamage = Енергія/урон
 blocks.itemcapacity = Місткість предметів

--- a/core/assets/bundles/bundle_zh_CN.properties
+++ b/core/assets/bundles/bundle_zh_CN.properties
@@ -501,6 +501,7 @@ blocks.shootrange = 范围
 blocks.size = 尺寸
 blocks.liquidcapacity = 液体容量
 blocks.powerrange = 能量范围
+blocks.powerconnections = Max Connections
 blocks.poweruse = 能量使用
 blocks.powerdamage = 功率/损伤
 blocks.itemcapacity = 物品容量

--- a/core/assets/bundles/bundle_zh_TW.properties
+++ b/core/assets/bundles/bundle_zh_TW.properties
@@ -507,6 +507,7 @@ blocks.shootrange = 範圍
 blocks.size = 尺寸
 blocks.liquidcapacity = 液體容量
 blocks.powerrange = 輸出範圍
+blocks.powerconnections = Max Connections
 blocks.poweruse = 能量使用
 blocks.powerdamage = 能量/傷害
 blocks.itemcapacity = 物品容量

--- a/core/src/io/anuke/mindustry/world/blocks/power/PowerNode.java
+++ b/core/src/io/anuke/mindustry/world/blocks/power/PowerNode.java
@@ -151,6 +151,7 @@ public class PowerNode extends PowerBlock{
         super.setStats();
 
         stats.add(BlockStat.powerRange, laserRange, StatUnit.blocks);
+        stats.add(BlockStat.powerConnections, maxNodes, StatUnit.none);
     }
 
     @Override

--- a/core/src/io/anuke/mindustry/world/meta/BlockStat.java
+++ b/core/src/io/anuke/mindustry/world/meta/BlockStat.java
@@ -21,6 +21,7 @@ public enum BlockStat{
     powerUse(StatCategory.power),
     powerDamage(StatCategory.power),
     powerRange(StatCategory.power),
+    powerConnections(StatCategory.power),
     basePowerGeneration(StatCategory.power),
 
     input(StatCategory.crafting),


### PR DESCRIPTION
Exposes the `maxNodes` stat of power nodes to the player as "Max Connections". I think this is useful info for players, especially the surge tower's 2 connection maximum. Even though the other power nodes have a lot of connections available, it's still easy to go over the limit with 1x1 blocks like arc turrets, batteries, solar panels, etc.

## Added
* PowerNode.java: 1 new stat
* BlockStat.java: 1 new stat type
* Related untranslated localization text