### PR TITLE
Display pump output during placement

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -547,6 +547,7 @@ blocks.ammo = Ammo
 
 bar.drilltierreq = Better Drill Required
 bar.drillspeed = Drill Speed: {0}/s
+bar.pumpspeed = Pump Speed: {0}/s
 bar.efficiency = Efficiency: {0}%
 bar.powerbalance = Power: {0}/s
 bar.powerstored = Stored: {0}/{1}

--- a/core/src/io/anuke/mindustry/world/blocks/production/Pump.java
+++ b/core/src/io/anuke/mindustry/world/blocks/production/Pump.java
@@ -2,13 +2,18 @@ package io.anuke.mindustry.world.blocks.production;
 
 import io.anuke.arc.Core;
 import io.anuke.arc.collection.Array;
+import io.anuke.arc.graphics.Color;
 import io.anuke.arc.graphics.g2d.Draw;
 import io.anuke.arc.graphics.g2d.TextureRegion;
 import io.anuke.mindustry.graphics.Layer;
 import io.anuke.mindustry.type.Liquid;
+import io.anuke.mindustry.ui.Cicon;
 import io.anuke.mindustry.world.Tile;
 import io.anuke.mindustry.world.blocks.LiquidBlock;
 import io.anuke.mindustry.world.meta.*;
+
+import static io.anuke.mindustry.Vars.tilesize;
+import static io.anuke.mindustry.Vars.world;
 
 public class Pump extends LiquidBlock{
     protected final Array<Tile> drawTiles = new Array<>();
@@ -47,6 +52,31 @@ public class Pump extends LiquidBlock{
         Draw.alpha(tile.entity.liquids.total() / liquidCapacity);
         Draw.rect(liquidRegion, tile.drawx(), tile.drawy());
         Draw.color();
+    }
+
+    @Override
+    public void drawPlace(int x, int y, int rotation, boolean valid) {
+        super.drawPlace(x, y, rotation, valid);
+        Tile tile = world.tile(x, y);
+
+        float tiles = 0f;
+        Liquid liquidDrop = null;
+
+        for(Tile other : tile.getLinkedTilesAs(this, tempTiles)){
+            if(isValid(other)){
+                liquidDrop = other.floor().liquidDrop;
+                tiles++;
+            }
+        }
+
+        if (liquidDrop != null){
+            float width = drawPlaceText(Core.bundle.formatFloat("bar.pumpspeed", tiles * pumpAmount / size / size * 60f, 0), x, y, valid);
+            float dx = x * tilesize + offset() - width/2f - 4f, dy = y * tilesize + offset() + size * tilesize / 2f + 5;
+            Draw.mixcol(Color.darkGray, 1f);
+            Draw.rect(liquidDrop.icon(Cicon.small), dx, dy - 1);
+            Draw.reset();
+            Draw.rect(liquidDrop.icon(Cicon.small), dx, dy);
+        }
     }
 
     @Override


### PR DESCRIPTION
Since the drill output actually is actually influenced by how many liquid tiles its over, it would make sense to communicate that fact to the player. (similar to the output of drills)

![Screen Shot 2019-11-05 at 17 17 57](https://user-images.githubusercontent.com/3179271/68225214-60a26480-fff0-11e9-9a5c-02bcc84325a3.png)
![Nov-05-2019 17-26-49](https://user-images.githubusercontent.com/3179271/68225940-7cf2d100-fff1-11e9-9082-c553e252e0b0.gif)
