### PR TITLE
Fix key hints to display friendly names instead of internal names

### DIFF
--- a/core/src/io/anuke/mindustry/input/DesktopInput.java
+++ b/core/src/io/anuke/mindustry/input/DesktopInput.java
@@ -48,11 +48,11 @@ public class DesktopInput extends InputHandler{
             t.touchable(() -> t.getColor().a < 0.1f ? Touchable.disabled : Touchable.childrenOnly);
             t.table(Styles.black6, b -> {
                 b.defaults().left();
-                b.label(() -> Core.bundle.format(!player.isBuilding ?  "resumebuilding" : "pausebuilding", Core.keybinds.get(Binding.pause_building).key.name())).style(Styles.outlineLabel);
+                b.label(() -> Core.bundle.format(!player.isBuilding ?  "resumebuilding" : "pausebuilding", Core.keybinds.get(Binding.pause_building).key.toString())).style(Styles.outlineLabel);
                 b.row();
-                b.add(Core.bundle.format("cancelbuilding", Core.keybinds.get(Binding.clear_building).key.name())).style(Styles.outlineLabel);
+                b.add(Core.bundle.format("cancelbuilding", Core.keybinds.get(Binding.clear_building).key.toString())).style(Styles.outlineLabel);
                 b.row();
-                b.add(Core.bundle.format("selectschematic", Core.keybinds.get(Binding.schematic_select).key.name())).style(Styles.outlineLabel);
+                b.add(Core.bundle.format("selectschematic", Core.keybinds.get(Binding.schematic_select).key.toString())).style(Styles.outlineLabel);
             }).margin(10f);
         });
 
@@ -62,8 +62,8 @@ public class DesktopInput extends InputHandler{
             t.table(Styles.black6, b -> {
                 b.defaults().left();
                 b.add(Core.bundle.format("schematic.flip",
-                Core.keybinds.get(Binding.schematic_flip_x).key.name(),
-                Core.keybinds.get(Binding.schematic_flip_y).key.name())).style(Styles.outlineLabel);
+                Core.keybinds.get(Binding.schematic_flip_x).key.toString(),
+                Core.keybinds.get(Binding.schematic_flip_y).key.toString())).style(Styles.outlineLabel);
                 b.row();
                 b.table(a -> {
                     a.addImageTextButton("$schematic.add", Icon.saveSmall, this::showSchematicSave).colspan(2).size(250f, 50f).disabled(f -> lastSchematic == null || lastSchematic.file != null);


### PR DESCRIPTION
`Core.keybinds.get(Binding).key.name()` gives the [enum name](https://github.com/Anuken/Arc/blob/master/arc-core/src/io/anuke/arc/input/KeyCode.java) instead of the user-friendly name. This becomes a problem when the player binds controls to keys like "L-Shift", "[", "1", etc. which will display as "SHIFT_LEFT", "LEFT_BRACKET", "NUM_1", etc.

Using `toString()` instead fixes it, but I'm not sure if this is the correct fix, as [KeybindDialog.java](https://github.com/Anuken/Arc/blob/master/arc-core/src/io/anuke/arc/scene/ui/KeybindDialog.java) does it differently.