### PR TITLE
Add TapEvent/TapConfigEvent

### DIFF
--- a/core/src/io/anuke/mindustry/game/EventType.java
+++ b/core/src/io/anuke/mindustry/game/EventType.java
@@ -141,6 +141,30 @@ public class EventType{
             this.player = player;
         }
     }
+    
+    /** Called when the player taps a block. */
+    public static class TapEvent{
+        public final Tile tile;
+        public final Player player;
+
+        public TapEvent(Tile tile, Player player){
+            this.tile = tile;
+            this.player = player;
+        }
+    }
+    
+    /** Called when the player sets a specific block. */
+    public static class TapConfigEvent{
+        public final Tile tile;
+        public final Player player;
+        public final int value;
+
+        public TapConfigEvent(Tile tile, Player player, int value){
+            this.tile = tile;
+            this.player = player;
+            this.value = value;
+        }
+    }
 
     public static class GameOverEvent{
         public final Team winner;

--- a/core/src/io/anuke/mindustry/input/InputHandler.java
+++ b/core/src/io/anuke/mindustry/input/InputHandler.java
@@ -144,12 +144,14 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         if(tile == null || player == null) return;
         if(!Units.canInteract(player, tile)) return;
         tile.block().tapped(tile, player);
+        Core.app.post(() -> Events.fire(new TapEvent(tile, player)));
     }
 
     @Remote(targets = Loc.both, called = Loc.both, forward = true)
     public static void onTileConfig(Player player, Tile tile, int value){
         if(tile == null || !Units.canInteract(player, tile)) return;
         tile.block().configured(tile, player, value);
+        Core.app.post(() -> Events.fire(new TapConfigEvent(tile, player, value)));
     }
 
     public Eachable<BuildRequest> allRequests(){


### PR DESCRIPTION
![test](https://user-images.githubusercontent.com/44261958/68485498-c279fd00-0282-11ea-896b-ff032783e268.gif)
Q: Why is this necessary?
A: The destruction of griefers is evolving.
I can no longer catch griefers with existing Events, so i need to add events.
Todo: withdraw event

## Available methods for this event
* Blocking/detect change mass-driver change
* Blocking/detect change Bridge/Phase conveyor/conduit
* Blocking/detect change sorter