### PR TITLE
Allow for toggling the visibility of power line lasers

### DIFF
--- a/core/src/io/anuke/mindustry/input/Binding.java
+++ b/core/src/io/anuke/mindustry/input/Binding.java
@@ -36,7 +36,7 @@ public enum Binding implements KeyBind{
     chat_history_prev(KeyCode.UP),
     chat_history_next(KeyCode.DOWN),
     chat_scroll(new Axis(KeyCode.SCROLL)),
-
+    toggle_power_lines(KeyCode.F7),
     ;
 
     private final KeybindValue defaultValue;

--- a/core/src/io/anuke/mindustry/input/Binding.java
+++ b/core/src/io/anuke/mindustry/input/Binding.java
@@ -31,12 +31,12 @@ public enum Binding implements KeyBind{
     minimap(KeyCode.M),
     toggle_menus(KeyCode.C),
     screenshot(KeyCode.P),
+    toggle_power_lines(KeyCode.F7),
     player_list(KeyCode.TAB, "multiplayer"),
     chat(KeyCode.ENTER),
     chat_history_prev(KeyCode.UP),
     chat_history_next(KeyCode.DOWN),
     chat_scroll(new Axis(KeyCode.SCROLL)),
-    toggle_power_lines(KeyCode.F7),
     ;
 
     private final KeybindValue defaultValue;

--- a/core/src/io/anuke/mindustry/input/DesktopInput.java
+++ b/core/src/io/anuke/mindustry/input/DesktopInput.java
@@ -432,11 +432,9 @@ public class DesktopInput extends InputHandler{
 
         if(Core.input.keyTap(Binding.toggle_power_lines)){
             if(Core.settings.getInt("lasersopacity") == 0){
-                Core.settings.put("lasersopacity", Core.settings.getInt("preferredlaseropacity"));
+                Core.settings.put("lasersopacity", Core.settings.getInt("preferredlaseropacity", 100));
             }else{
-                if(!Core.settings.has("preferredlaseropacity")){
-                    Core.settings.put("preferredlaseropacity", Core.settings.getInt("lasersopacity"));
-                }
+                Core.settings.put("preferredlaseropacity", Core.settings.getInt("lasersopacity"));
                 Core.settings.put("lasersopacity", 0);
             }
         }

--- a/core/src/io/anuke/mindustry/input/DesktopInput.java
+++ b/core/src/io/anuke/mindustry/input/DesktopInput.java
@@ -429,6 +429,17 @@ public class DesktopInput extends InputHandler{
 
             mode = none;
         }
+
+        if(Core.input.keyTap(Binding.toggle_power_lines)){
+            if(Core.settings.getInt("lasersopacity") == 0){
+                Core.settings.put("lasersopacity", Core.settings.getInt("preferredlaseropacity"));
+            }else{
+                if(!Core.settings.has("preferredlaseropacity")){
+                    Core.settings.put("preferredlaseropacity", Core.settings.getInt("lasersopacity"));
+                }
+                Core.settings.put("lasersopacity", 0);
+            }
+        }
     }
 
     @Override

--- a/core/src/io/anuke/mindustry/ui/dialogs/SettingsMenuDialog.java
+++ b/core/src/io/anuke/mindustry/ui/dialogs/SettingsMenuDialog.java
@@ -259,7 +259,12 @@ public class SettingsMenuDialog extends SettingsDialog{
         });
         graphics.sliderPref("fpscap", 240, 15, 245, 5, s -> (s > 240 ? Core.bundle.get("setting.fpscap.none") : Core.bundle.format("setting.fpscap.text", s)));
         graphics.sliderPref("chatopacity", 100, 0, 100, 5, s -> s + "%");
-        graphics.sliderPref("lasersopacity", 100, 0, 100, 5, s -> s + "%");
+        graphics.sliderPref("lasersopacity", 100, 0, 100, 5, s -> {
+            if(ui.settings != null){
+                Core.settings.put("preferredlaseropacity", s);
+            }
+            return s + "%";
+        });
 
         if(!mobile){
             graphics.checkPref("vsync", true, b -> Core.graphics.setVSync(b));


### PR DESCRIPTION
Configurable key-bind in controls and obeys the power line opacity setting.
The key-bind defaults to F7.

![ezgif com-resize](https://user-images.githubusercontent.com/2303421/68522810-db33e400-027d-11ea-86d3-21fb2e1a1508.gif)

