### PR TITLE
Keep items on conveyor when upgrading

### DIFF
--- a/core/src/io/anuke/mindustry/world/Build.java
+++ b/core/src/io/anuke/mindustry/world/Build.java
@@ -4,6 +4,7 @@ import io.anuke.annotations.Annotations.Loc;
 import io.anuke.annotations.Annotations.Remote;
 import io.anuke.arc.Core;
 import io.anuke.arc.Events;
+import io.anuke.arc.collection.LongArray;
 import io.anuke.arc.math.Mathf;
 import io.anuke.arc.math.geom.*;
 import io.anuke.mindustry.content.Blocks;
@@ -12,6 +13,7 @@ import io.anuke.mindustry.game.EventType.BlockBuildBeginEvent;
 import io.anuke.mindustry.game.Team;
 import io.anuke.mindustry.world.blocks.BuildBlock;
 import io.anuke.mindustry.world.blocks.BuildBlock.BuildEntity;
+import io.anuke.mindustry.world.blocks.distribution.Conveyor;
 
 import static io.anuke.mindustry.Vars.*;
 
@@ -60,8 +62,15 @@ public class Build{
         Block previous = tile.block();
         Block sub = BuildBlock.get(result.size);
 
-        world.setBlock(tile, sub, team, rotation);
-        tile.<BuildEntity>entity().setConstruct(previous, result);
+        if(previous instanceof Conveyor && result instanceof Conveyor){
+            LongArray convey = ((Conveyor.ConveyorEntity) tile.entity).convey;
+
+            world.setBlock(tile, sub, team, rotation);
+            tile.<BuildEntity>entity().setConstruct(previous, result, after -> ((Conveyor.ConveyorEntity) tile.entity).convey = convey);
+        }else {
+            world.setBlock(tile, sub, team, rotation);
+            tile.<BuildEntity>entity().setConstruct(previous, result);
+        }
 
         Core.app.post(() -> Events.fire(new BlockBuildBeginEvent(tile, team, false)));
     }

--- a/core/src/io/anuke/mindustry/world/blocks/BuildBlock.java
+++ b/core/src/io/anuke/mindustry/world/blocks/BuildBlock.java
@@ -4,6 +4,7 @@ import io.anuke.annotations.Annotations.*;
 import io.anuke.arc.*;
 import io.anuke.arc.Graphics.*;
 import io.anuke.arc.Graphics.Cursor.*;
+import io.anuke.arc.func.Cons;
 import io.anuke.arc.graphics.g2d.*;
 import io.anuke.arc.math.*;
 import io.anuke.arc.util.ArcAnnotate.*;
@@ -219,6 +220,8 @@ public class BuildBlock extends Block{
         public Block previous;
         public int builderID = -1;
 
+        public Cons<Tile> after = (tile) -> {};
+
         private float[] accumulator;
         private float[] totalAccumulator;
 
@@ -246,6 +249,7 @@ public class BuildBlock extends Block{
 
             if(progress >= 1f || state.rules.infiniteResources){
                 constructed(tile, cblock, builderID, tile.rotation(), builder.getTeam(), configured);
+                this.after.get(tile);
                 return true;
             }
             return false;
@@ -322,6 +326,11 @@ public class BuildBlock extends Block{
 
         public float progress(){
             return progress;
+        }
+
+        public void setConstruct(Block previous, Block block, Cons<Tile> cons){
+            setConstruct(previous, block);
+            this.after = cons;
         }
 
         public void setConstruct(Block previous, Block block){

--- a/core/src/io/anuke/mindustry/world/blocks/distribution/Conveyor.java
+++ b/core/src/io/anuke/mindustry/world/blocks/distribution/Conveyor.java
@@ -349,7 +349,7 @@ public class Conveyor extends Block implements Autotiler{
 
     public static class ConveyorEntity extends TileEntity{
 
-        LongArray convey = new LongArray();
+        public LongArray convey = new LongArray();
         byte lastInserted;
         float minitem = 1;
 


### PR DESCRIPTION
https://feathub.com/Anuken/Mindustry/+234
https://feathub.com/Anuken/Mindustry/+206

This is a just technical proof of concept, do not take this way to serious.

It carries over conveyor contents when the previous and next building block are both conveyors.

This is useful when lets say upgrading an incoming belt of titanium heading into your core without slowing your progress since you're killing the required titanium needed for upgrading while you're upgrading.

But it also has a flip side, often when you want to get rid of items on a conveyor (e.g. `sand/coal/scrap` mixed in) its common practice to just up/down grade the conveyor to get rid of those items, this pull would prevent that, hence the draft / technical proof of concept.

A different approach would be to send all the items (that are capable of entering the core) directly to the core when destroying a conveyor/block containing those items, similar to the "dropping of" of a player / mining drone inventory.

But since that might feel like teleportation somewhat it would maybe make sense to grab the items from the belt and put them into the inventory of the player, but that leaves edge cases for when multiple items are on the belt, since units can only carry one (afaik), and of course the carry limit comes into play.

I'd love to collect some thoughts on this topic 📥 

![Nov-12-2019 11-24-11](https://user-images.githubusercontent.com/3179271/68663459-fc772780-053e-11ea-91b4-c2cbc1cb4c30.gif)
