### PR TITLE
Make chat show/hide setting vaiable

### DIFF
--- a/core/src/io/anuke/mindustry/core/NetClient.java
+++ b/core/src/io/anuke/mindustry/core/NetClient.java
@@ -49,6 +49,8 @@ public class NetClient implements ApplicationListener{
     private float timeoutTime = 0f;
     /** Last sent client snapshot ID. */
     private int lastSent;
+    /** Chat show/hide setting */
+    public static boolean visual = true;
 
     /** List of entities that were removed, and need not be added while syncing. */
     private IntSet removed = new IntSet();
@@ -168,7 +170,7 @@ public class NetClient implements ApplicationListener{
 
             //invoke event for all clients but also locally
             //this is required so other clients get the correct name even if they don't know who's sending it yet
-            Call.sendMessage(message, colorizeName(player.id, player.name), player);
+            if(visual) Call.sendMessage(message, colorizeName(player.id, player.name), player);
         }else{
             //log command to console but with brackets
             Log.info("<&y{0}: &lm{1}&lg>", player.name, message);


### PR DESCRIPTION
I've thought of other ways, but nothing like that.

Usage
``NetClient.visual = true/false;``
If you want to show chat
```
Events.on(PlayerChatEvent.class, e -> {
    Call.sendMessage(e.message, colorizeName(e.player.id, e.player.name), e.player);
});
```

If you want bad words filtering
```
Events.on(PlayerChatEvent.class, e -> {
    if(!e.message.equals("where's your mom?"){
        Call.sendMessage(e.message, colorizeName(e.player.id, e.player.name), e.player);
    }
});
```

This can be a bad thing, but it's a must.