### PR TITLE
slightly reduced cooldown between votekick

### DIFF
--- a/core/src/io/anuke/mindustry/core/NetServer.java
+++ b/core/src/io/anuke/mindustry/core/NetServer.java
@@ -292,7 +292,7 @@ public class NetServer implements ApplicationListener{
         }
 
         //cooldown between votes
-        int voteTime = 60 * 5;
+        int voteTime = 60 * 3;
         Timekeeper vtime = new Timekeeper(voteTime);
         //current kick sessions
         VoteSession[] currentlyKicking = {null};


### PR DESCRIPTION
Currently if a votekick fails someone can grief for a solid five minutes before they are able to be votekicked again

this isn't a particularly good solution so i may start working on a slightly more effective system.

similar request from https://feathub.com/Anuken/Mindustry/+115