### PR TITLE
Warn if any core is under attack, the pull

### DIFF
--- a/core/src/io/anuke/mindustry/ui/fragments/HudFragment.java
+++ b/core/src/io/anuke/mindustry/ui/fragments/HudFragment.java
@@ -30,6 +30,7 @@ import io.anuke.mindustry.type.*;
 import io.anuke.mindustry.ui.*;
 import io.anuke.mindustry.ui.Cicon;
 import io.anuke.mindustry.ui.dialogs.*;
+import io.anuke.mindustry.world.Tile;
 
 import static io.anuke.mindustry.Vars.*;
 
@@ -43,7 +44,7 @@ public class HudFragment extends Fragment{
     private float dsize = 47.2f;
 
     private float coreAttackTime;
-    private float lastCoreHP;
+    private float lastTotalCoreHP;
     private Team lastTeam;
     private float coreAttackOpacity = 0f;
     private long lastToast;
@@ -288,7 +289,7 @@ public class HudFragment extends Fragment{
             Events.on(StateChangeEvent.class, event -> {
                 if(event.to == State.menu || event.from == State.menu){
                     coreAttackTime = 0f;
-                    lastCoreHP = Float.NaN;
+                    lastTotalCoreHP = Float.NaN;
                 }
             });
 
@@ -298,18 +299,21 @@ public class HudFragment extends Fragment{
                     return false;
                 }
 
-                float curr = state.teams.get(player.getTeam()).cores.first().entity.health;
+                float curr = 0f;
+                for(Tile core : state.teams.get(waveTeam).cores){
+                    curr += core.entity.health;
+                }
 
                 if(lastTeam != player.getTeam()){
-                    lastCoreHP = curr;
+                    lastTotalCoreHP = curr;
                     lastTeam = player.getTeam();
                     return false;
                 }
 
-                if(!Float.isNaN(lastCoreHP) && curr < lastCoreHP){
+                if(!Float.isNaN(lastTotalCoreHP) && curr < lastTotalCoreHP){
                     coreAttackTime = notifDuration;
                 }
-                lastCoreHP = curr;
+                lastTotalCoreHP = curr;
 
                 t.getColor().a = coreAttackOpacity;
                 if(coreAttackTime > 0){

--- a/core/src/io/anuke/mindustry/ui/fragments/HudFragment.java
+++ b/core/src/io/anuke/mindustry/ui/fragments/HudFragment.java
@@ -300,7 +300,7 @@ public class HudFragment extends Fragment{
                 }
 
                 float curr = 0f;
-                for(Tile core : state.teams.get(waveTeam).cores){
+                for(Tile core : state.teams.get(player.getTeam()).cores){
                     curr += core.entity.health;
                 }
 


### PR DESCRIPTION
I wasn't sure on how to best implement this, hence i originally made https://github.com/Anuken/Mindustry/issues/1036 as an issue without code, but now here we are: this pull takes all allied cores into account, its primary caveat is that technically if you repair one of your cores while another is under attack you won't be notified, but its arguably better than only checking the first core 🐡 