### PR TITLE
Make Esc mirror back button behavior in settings

### DIFF
--- a/core/src/io/anuke/mindustry/ui/dialogs/SettingsMenuDialog.java
+++ b/core/src/io/anuke/mindustry/ui/dialogs/SettingsMenuDialog.java
@@ -360,7 +360,11 @@ public class SettingsMenuDialog extends SettingsDialog{
 
         keyDown(key -> {
             if(key == KeyCode.ESCAPE || key == KeyCode.BACK){
-                hide();
+                if(prefs.getChildren().first() != menu){
+                    back();
+                }else{
+                    hide();
+                }
             }
         });
     }


### PR DESCRIPTION
Currently, pressing Esc in game, graphics, and sound settings drops you out of settings altogether, while pressing it in language, controls, and game data takes you back to settings, same as if clicking the back button. This PR makes it consistently take you back to settings.