### PR TITLE
Bump gradle from 3.4.1 to 3.5.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript{
     }
 
     dependencies{
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.5.2'
     }
 }
 


### PR DESCRIPTION
Bumps gradle from 3.4.1 to 3.5.2.

Potentially has bug fixes or performance improvements.