### PR TITLE
Make offline force projector use no boost

### DIFF
--- a/core/src/io/anuke/mindustry/world/blocks/defense/ForceProjector.java
+++ b/core/src/io/anuke/mindustry/world/blocks/defense/ForceProjector.java
@@ -99,7 +99,7 @@ public class ForceProjector extends Block{
 
         entity.phaseHeat = Mathf.lerpDelta(entity.phaseHeat, Mathf.num(phaseValid), 0.1f);
 
-        if(phaseValid && !entity.broken && entity.timer.get(timerUse, phaseUseTime)){
+        if(phaseValid && !entity.broken && entity.timer.get(timerUse, phaseUseTime) && entity.efficiency() > 0){
             entity.cons.trigger();
         }
 


### PR DESCRIPTION
Mimiced check in the mending & overdrive projector.

<img width="835" alt="Screen Shot 2019-11-19 at 08 54 53" src="https://user-images.githubusercontent.com/3179271/69127286-49f91480-0aaa-11ea-9545-546cdc65ba8c.png">
