### PR TITLE
Calculate powerbalance before batteries interfere

### DIFF
--- a/core/src/io/anuke/mindustry/world/blocks/power/PowerGraph.java
+++ b/core/src/io/anuke/mindustry/world/blocks/power/PowerGraph.java
@@ -192,6 +192,8 @@ public class PowerGraph{
         lastPowerNeeded = powerNeeded;
         lastPowerProduced = powerProduced;
 
+        powerBalance.addValue((lastPowerProduced - lastPowerNeeded) / Time.delta());
+
         if(!(consumers.size == 0 && producers.size == 0 && batteries.size == 0)){
 
             if(!Mathf.equal(powerNeeded, powerProduced)){
@@ -206,8 +208,6 @@ public class PowerGraph{
 
             distributePower(powerNeeded, powerProduced);
         }
-
-        powerBalance.addValue((lastPowerProduced - lastPowerNeeded) / Time.delta());
     }
 
     public void add(PowerGraph graph){


### PR DESCRIPTION
This allows the power node(s) to display the amount of power being used while there is still charge in the batteries.

Its useful to be able to see at what rate batteries are draining and not just by looking at the `K` bar for a while to try to notice a change.

And it is especially useful with diodes, when charging your main network its not uncommon to see `+0/s` basically everywhere, giving a poor indication of the actual usage of the network.

To my knowledge this chance is fully (backwards)compatible and is purely visual.

It should make the diodes slightly less horrible than they are in their current state. 🙂  