### PR TITLE
Adding the feature to switch doors using a logic controller

### DIFF
--- a/core/src/io/anuke/mindustry/world/blocks/defense/Door.java
+++ b/core/src/io/anuke/mindustry/world/blocks/defense/Door.java
@@ -97,10 +97,10 @@ public class Door extends Wall{
         DoorEntity entity = tile.entity();
 
         if((entity.lastSignal != tile.entity.enabled()) && tile.entity.timer.get(timerToggle, 30f)){
+            entity.lastSignal = tile.entity.enabled();
             if(entity.open != tile.entity.enabled()){
                 Call.onDoorToggle(null, tile, !entity.open);
             }
-            entity.lastSignal = tile.entity.enabled();
         }
     }
 

--- a/core/src/io/anuke/mindustry/world/blocks/defense/Door.java
+++ b/core/src/io/anuke/mindustry/world/blocks/defense/Door.java
@@ -28,9 +28,11 @@ public class Door extends Wall{
 
     public Door(String name){
         super(name);
+        update = true;
         solid = false;
         solidifes = true;
         consumesTap = true;
+        controllable = true;
         entityType = DoorEntity::new;
     }
 
@@ -90,8 +92,21 @@ public class Door extends Wall{
         Call.onDoorToggle(null, tile, !entity.open);
     }
 
+    @Override
+    public void update(Tile tile){
+        DoorEntity entity = tile.entity();
+
+        if((entity.lastSignal != tile.entity.enabled()) && tile.entity.timer.get(timerToggle, 30f)){
+            if(entity.open != tile.entity.enabled()){
+                Call.onDoorToggle(null, tile, !entity.open);
+            }
+            entity.lastSignal = tile.entity.enabled();
+        }
+    }
+
     public class DoorEntity extends TileEntity{
         public boolean open = false;
+        public boolean lastSignal = true;
 
         @Override
         public void write(DataOutput stream) throws IOException{


### PR DESCRIPTION
- [x] _Compiled and tested_

- 1) the **Player** and the **controller** can _equal_ access to the door switch.
- 2) the controller has the same _click delay_ as the player.
- 3) if controller reversed the signal _on positive_ - the door will is **open**, if reversed _on empty_ the door **closes**.
- 4) the Controller also switches the door provided that its signal has _changed_ (if the controller signal does not change and the player switches the door, then the **3** point is _ignored_ until the controller signal changes)
- 5) If there is a situation that the door did **not have time to switch** because of the delay and the signal **does not comply** with the rule of paragraph **3** **_AND_** the player does not switch the door _manually_, the door will change its state to the correct one after the delay.

[**> A short video showing the principle of operation <** (YouTube)](https://youtu.be/V7WosSEv1lw)