### PR TITLE
Conservative Generators

### DIFF
--- a/core/src/io/anuke/mindustry/world/Block.java
+++ b/core/src/io/anuke/mindustry/world/Block.java
@@ -561,7 +561,7 @@ public class Block extends BlockStorage{
             float capacity = cons.capacity;
 
             bars.add("power", entity -> new Bar(() -> buffered ? Core.bundle.format("bar.poweramount", Float.isNaN(entity.power.status * capacity) ? "<ERROR>" : (int)(entity.power.status * capacity)) :
-                Core.bundle.get("bar.power"), () -> Pal.powerBar, () -> Mathf.zero(cons.requestedPower(entity)) && entity.power.graph.getPowerProduced() + entity.power.graph.getBatteryStored() > 0f ? 1f : entity.power.status));
+                Core.bundle.get("bar.power"), () -> Pal.powerBar, () -> Mathf.zero(cons.requestedPower(entity)) && entity.power.graph.getPowerProduced().total + entity.power.graph.getBatteryStored() > 0f ? 1f : entity.power.status));
         }
 
         if(hasItems && configurable){

--- a/core/src/io/anuke/mindustry/world/blocks/power/BurnerGenerator.java
+++ b/core/src/io/anuke/mindustry/world/blocks/power/BurnerGenerator.java
@@ -7,6 +7,7 @@ public class BurnerGenerator extends ItemLiquidGenerator{
 
     public BurnerGenerator(String name){
         super(true, false, name);
+        isConservative = true;
     }
 
     @Override

--- a/core/src/io/anuke/mindustry/world/blocks/power/ItemLiquidGenerator.java
+++ b/core/src/io/anuke/mindustry/world/blocks/power/ItemLiquidGenerator.java
@@ -92,6 +92,14 @@ public class ItemLiquidGenerator extends PowerGenerator{
     }
 
     @Override
+    public void conservePower(final Tile tile, final float percentage){
+        if(!isConservative) return;
+        if(Mathf.zero(getPowerProduction(tile))) return;
+        final GeneratorEntity entity = tile.entity();
+        entity.generateTime += Math.min(1f / itemDuration * entity.delta(), entity.generateTime) * percentage;
+    }
+
+    @Override
     public void update(Tile tile){
         ItemLiquidGeneratorEntity entity = tile.entity();
 

--- a/core/src/io/anuke/mindustry/world/blocks/power/PowerGenerator.java
+++ b/core/src/io/anuke/mindustry/world/blocks/power/PowerGenerator.java
@@ -2,6 +2,7 @@ package io.anuke.mindustry.world.blocks.power;
 
 import io.anuke.arc.Core;
 import io.anuke.arc.collection.EnumSet;
+import io.anuke.arc.math.Mathf;
 import io.anuke.arc.util.Strings;
 import io.anuke.mindustry.entities.type.TileEntity;
 import io.anuke.mindustry.graphics.Pal;
@@ -46,6 +47,9 @@ public class PowerGenerator extends PowerDistributor{
     @Override
     public float getPowerProduction(Tile tile){
         return powerProduction * tile.<GeneratorEntity>entity().productionEfficiency;
+    }
+
+    public void conservePower(final Tile tile, final float percentage){
     }
 
     @Override

--- a/core/src/io/anuke/mindustry/world/blocks/power/PowerGenerator.java
+++ b/core/src/io/anuke/mindustry/world/blocks/power/PowerGenerator.java
@@ -15,6 +15,7 @@ public class PowerGenerator extends PowerDistributor{
     /** The amount of power produced per tick in case of an efficiency of 1.0, which represents 100%. */
     protected float powerProduction;
     public BlockStat generationType = BlockStat.basePowerGeneration;
+    boolean isConservative = false;
 
     public PowerGenerator(String name){
         super(name);

--- a/core/src/io/anuke/mindustry/world/blocks/power/PowerGraph.java
+++ b/core/src/io/anuke/mindustry/world/blocks/power/PowerGraph.java
@@ -210,18 +210,18 @@ public class PowerGraph{
         lastPowerProduced = powerProduced.total;
 
         if(!(consumers.size == 0 && producers.size == 0 && batteries.size == 0)){
-
+            float powerToConsume = powerProduced.total;
             if(!Mathf.equal(powerNeeded, powerProduced.total)){
                 if(powerNeeded > powerProduced.total){
-                    float powerBatteryUsed = useBatteries(powerNeeded - powerProduced.total);
-                    powerProduced.total += powerBatteryUsed;
-                    lastPowerProduced += powerBatteryUsed;
+                    final float batteryPowerUsed = useBatteries(powerNeeded - powerProduced.total);
+                    lastPowerProduced = powerToConsume = powerProduced.total + batteryPowerUsed;
                 }else if(powerProduced.total > powerNeeded){
-                    powerProduced.total -= chargeBatteries(powerProduced.total - powerNeeded);
+                    final float batteryChargeGained = chargeBatteries(powerProduced.total - powerNeeded);
+                    powerToConsume = powerProduced.total - batteryChargeGained;
                 }
             }
 
-            distributePower(powerNeeded, powerProduced.total);
+            distributePower(powerNeeded, powerToConsume);
         }
 
         powerBalance.addValue((lastPowerProduced - lastPowerNeeded) / Time.delta());

--- a/core/src/io/anuke/mindustry/world/blocks/power/PowerGraph.java
+++ b/core/src/io/anuke/mindustry/world/blocks/power/PowerGraph.java
@@ -188,6 +188,16 @@ public class PowerGraph{
         }
     }
 
+    public void conserveGeneration(final float percentage){
+        for(Tile producer : producers){
+            if(producer.entity == null) continue;
+            if(!(producer.block() instanceof PowerGenerator)) continue;
+            final PowerGenerator block = (PowerGenerator)producer.block();
+            if(!block.isConservative) continue;
+            block.conservePower(producer, percentage);
+        }
+    }
+
     public void update(){
         if(Core.graphics.getFrameId() == lastFrameUpdated){
             return;
@@ -218,6 +228,9 @@ public class PowerGraph{
                 }else if(powerProduced.total > powerNeeded){
                     final float batteryChargeGained = chargeBatteries(powerProduced.total - powerNeeded);
                     powerToConsume = powerProduced.total - batteryChargeGained;
+                    if(powerNeeded + batteryChargeGained < powerProduced.total && !Mathf.zero(powerProduced.optional)){
+                        conserveGeneration(Mathf.clamp(1 - (powerNeeded + batteryChargeGained - powerProduced.mandatory) / powerProduced.optional));
+                    }
                 }
             }
 

--- a/tests/src/test/java/power/PowerTests.java
+++ b/tests/src/test/java/power/PowerTests.java
@@ -58,7 +58,7 @@ public class PowerTests extends PowerTestFixture{
             powerGraph.add(producerTile);
             powerGraph.add(directConsumerTile);
 
-            assertEquals(producedPower * Time.delta(), powerGraph.getPowerProduced(), Mathf.FLOAT_ROUNDING_ERROR);
+            assertEquals(producedPower * Time.delta(), powerGraph.getPowerProduced().total, Mathf.FLOAT_ROUNDING_ERROR);
             assertEquals(requiredPower * Time.delta(), powerGraph.getPowerNeeded(), Mathf.FLOAT_ROUNDING_ERROR);
 
             // Update and check for the expected power status of the consumer


### PR DESCRIPTION
Implementation of https://github.com/Anuken/Mindustry/issues/804

When the power needed plus the power put into batteries is less than the
total generation capacity, conservative generators will conserve a
portion of their input items proportional to the percentage of optional
conservative power generation, which is unused. The conservation is
carried out based on extending the amount of time until the generators
will consume an additional item of fuel. So for example if the power
needed is 50% of the production capacity which is entirely conservative
then the generators will take 2x as long between consuming items of
fuel.