### PR TITLE
Add gradle property jvmArgs

### DIFF
--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -28,6 +28,10 @@ task run(dependsOn: classes, type: JavaExec){
         args Eval.me(project.getProperties()["args"])
     }
 
+    if(project.hasProperty("jvmArgs")){
+        jvmArgs((List<String>)Eval.me(project.getProperties()["jvmArgs"]))
+    }
+
     if(args.contains("debug")){
         main = "io.anuke.mindustry.DebugLauncher"
     }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -19,6 +19,9 @@ task run(dependsOn: classes, type: JavaExec){
     if(project.hasProperty("appArgs")){
         args Eval.me(appArgs)
     }
+    if(project.hasProperty("jvmArgs")){
+        jvmArgs((List<String>)Eval.me(project.getProperties()["jvmArgs"]))
+    }
 }
 
 task debug(dependsOn: classes, type: JavaExec){


### PR DESCRIPTION
Allows specifying additional arguments for the vm, which would make using tools such as HotSwapAgent and dcevm easier.
Example: `run -PjvmArgs='["-XXaltjvm=dcevm"]'`