### PR TITLE
Add 1 plastanium to armored conduits recipe

### DIFF
--- a/core/src/io/anuke/mindustry/content/Blocks.java
+++ b/core/src/io/anuke/mindustry/content/Blocks.java
@@ -990,7 +990,7 @@ public class Blocks implements ContentList{
         }};
 
         platedConduit = new io.anuke.mindustry.world.blocks.liquid.ArmoredConduit("plated-conduit"){{
-            requirements(Category.liquid, ItemStack.with(Items.thorium, 2, Items.metaglass, 1));
+            requirements(Category.liquid, ItemStack.with(Items.thorium, 2, Items.metaglass, 1, Items.plastanium, 1));
             liquidCapacity = 16f;
             liquidPressure = 1.025f;
             health = 220;


### PR DESCRIPTION
Armored conveyors use `plastanium` as well in their recipe as well, and the past few days i've been almost always pretty much able to skip phase conduits completely since we already had thorium on hand, i think it would be a positive chance to modify its recipe to match the conveyor equivalent 🤔 