### PR TITLE
'arilleryPlastic' -> 'artilleryPlastic'

### DIFF
--- a/core/src/io/anuke/mindustry/content/Blocks.java
+++ b/core/src/io/anuke/mindustry/content/Blocks.java
@@ -1542,7 +1542,7 @@ public class Blocks implements ContentList{
             Items.silicon, Bullets.artilleryHoming,
             Items.pyratite, Bullets.artilleryIncendiary,
             Items.blastCompound, Bullets.artilleryExplosive,
-            Items.plastanium, Bullets.arilleryPlastic
+            Items.plastanium, Bullets.artilleryPlastic
             );
             size = 3;
             shots = 4;

--- a/core/src/io/anuke/mindustry/content/Bullets.java
+++ b/core/src/io/anuke/mindustry/content/Bullets.java
@@ -18,7 +18,7 @@ public class Bullets implements ContentList{
     public static BulletType
 
     //artillery
-    artilleryDense, arilleryPlastic, artilleryPlasticFrag, artilleryHoming, artilleryIncendiary, artilleryExplosive, artilleryUnit,
+    artilleryDense, artilleryPlastic, artilleryPlasticFrag, artilleryHoming, artilleryIncendiary, artilleryExplosive, artilleryUnit,
 
     //flak
     flakScrap, flakLead, flakPlastic, flakExplosive, flakSurge, flakGlass, glassFrag,
@@ -65,7 +65,7 @@ public class Bullets implements ContentList{
             despawnEffect = Fx.none;
         }};
 
-        arilleryPlastic = new ArtilleryBulletType(3.4f, 0, "shell"){{
+        artilleryPlastic = new ArtilleryBulletType(3.4f, 0, "shell"){{
             hitEffect = Fx.plasticExplosion;
             knockback = 1f;
             lifetime = 55f;


### PR DESCRIPTION
Simple typo. All usages have been corrected.