### PR TITLE
[server] uuid security level

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -122,6 +122,9 @@ mod.scripts.unsupported = Your device does not support mod scripts. Some mods wi
 
 about.button = About
 name = Name:
+securitylevel = Security Level:
+securitylevel.improved = Security level improved.
+securitylevel.changed = [accent]{0}[] -> [accent]{1}[]
 noname = Pick a[accent] player name[] first.
 filename = File Name:
 unlocked = New content unlocked!

--- a/core/src/io/anuke/mindustry/core/NetClient.java
+++ b/core/src/io/anuke/mindustry/core/NetClient.java
@@ -75,10 +75,15 @@ public class NetClient implements ApplicationListener{
                 net.disconnect();
             });
 
+            Metadata meta = new Metadata();
+            meta.categories.put("mod", mods.getMetaStrings());
+            meta.categories.put("securitylevel", new StringMap(){{
+                put("checkpoint", Integer.toString(Core.settings.getInt("securitylevel-checkpoint", 0)));
+            }});
+
             ConnectPacket c = new ConnectPacket();
             c.name = player.name;
-            c.meta().addAll(mods.getMetaStrings());
-            c.meta().add("securitylevel-checkpoint:" + Core.settings.getInt("securitylevel-checkpoint", 0));
+            c.mods = meta.pack();
             c.mobile = mobile;
             c.versionType = Version.type;
             c.color = Color.rgba8888(player.color);

--- a/core/src/io/anuke/mindustry/core/NetClient.java
+++ b/core/src/io/anuke/mindustry/core/NetClient.java
@@ -79,6 +79,7 @@ public class NetClient implements ApplicationListener{
             meta.categories.put("mod", mods.getMetaStrings());
             meta.categories.put("securitylevel", new StringMap(){{
                 put("checkpoint", Integer.toString(Core.settings.getInt("securitylevel-checkpoint", 0)));
+                put("version", "sha1");
             }});
 
             ConnectPacket c = new ConnectPacket();

--- a/core/src/io/anuke/mindustry/core/NetClient.java
+++ b/core/src/io/anuke/mindustry/core/NetClient.java
@@ -78,7 +78,7 @@ public class NetClient implements ApplicationListener{
             Metadata meta = new Metadata();
             meta.categories.put("mod", mods.getMetaStrings());
             meta.categories.put("securitylevel", new StringMap(){{
-                put("checkpoint", Integer.toString(Core.settings.getInt("securitylevel-checkpoint", 0)));
+                put("salt", Integer.toString(Core.settings.getInt("securitylevel-salt", 0)));
                 put("version", "sha1");
             }});
 

--- a/core/src/io/anuke/mindustry/core/NetClient.java
+++ b/core/src/io/anuke/mindustry/core/NetClient.java
@@ -79,6 +79,7 @@ public class NetClient implements ApplicationListener{
             meta.categories.put("mod", mods.getMetaStrings());
             meta.categories.put("securitylevel", new StringMap(){{
                 put("salt", Integer.toString(Core.settings.getInt("securitylevel-salt", 0)));
+                put("claim", Integer.toString(Player.securityLevel(platform.getUUID(), Integer.parseInt(get("salt")))));
                 put("version", "sha1");
             }});
 

--- a/core/src/io/anuke/mindustry/core/NetClient.java
+++ b/core/src/io/anuke/mindustry/core/NetClient.java
@@ -77,8 +77,8 @@ public class NetClient implements ApplicationListener{
 
             ConnectPacket c = new ConnectPacket();
             c.name = player.name;
-            c.mods = mods.getModStrings();
-            c.mods.add("securitylevel:" + Core.settings.getInt("securitylevel-checkpoint", 0));
+            c.meta().addAll(mods.getMetaStrings());
+            c.meta().add("securitylevel-checkpoint:" + Core.settings.getInt("securitylevel-checkpoint", 0));
             c.mobile = mobile;
             c.versionType = Version.type;
             c.color = Color.rgba8888(player.color);

--- a/core/src/io/anuke/mindustry/core/NetClient.java
+++ b/core/src/io/anuke/mindustry/core/NetClient.java
@@ -78,6 +78,7 @@ public class NetClient implements ApplicationListener{
             ConnectPacket c = new ConnectPacket();
             c.name = player.name;
             c.mods = mods.getModStrings();
+            c.mods.add("securitylevel:" + Core.settings.getInt("securitylevel-checkpoint", 0));
             c.mobile = mobile;
             c.versionType = Version.type;
             c.color = Color.rgba8888(player.color);

--- a/core/src/io/anuke/mindustry/core/NetServer.java
+++ b/core/src/io/anuke/mindustry/core/NetServer.java
@@ -104,20 +104,14 @@ public class NetServer implements ApplicationListener{
                 return;
             }
 
-            Array<String> extraMods = packet.mods.copy();
-
-            String securityCheckpoint = extraMods.find(mod -> mod.startsWith("securitylevel:"));
-            int securityLevel = 0;
-            if(securityCheckpoint != null){
-                extraMods.remove(securityCheckpoint);
-                securityLevel = Player.securityLevel(packet.uuid, Integer.parseInt(securityCheckpoint.replace("securitylevel:", "")));
-            }
-
-            if(admins.getSecurityLevel() > securityLevel){
-                con.kick("Server requires security level [accent]"+ admins.getSecurityLevel() +"[].");
-                return;
-            }
-
+            Array<String> meta = packet.meta();
+            Array<String> extraMods = new Array<>();
+            Array<String> securityLevel = new Array<>();
+            meta.each(string -> {
+                Log.info(string);
+                if(string.startsWith("mod-")) extraMods.add(string.replace("mod-", ""));
+                if(string.startsWith("securitylevel-")) securityLevel.add(string.replace("securitylevel-", ""));
+            });
 
             Array<String> missingMods = mods.getIncompatibility(extraMods);
 
@@ -148,6 +142,17 @@ public class NetServer implements ApplicationListener{
 
             if(packet.versionType == null || ((packet.version == -1 || !packet.versionType.equals(Version.type)) && Version.build != -1 && !admins.allowsCustomClients())){
                 con.kick(!Version.type.equals(packet.versionType) ? KickReason.typeMismatch : KickReason.customClient);
+                return;
+            }
+
+            String checkpoint = securityLevel.find(mod -> mod.startsWith("checkpoint:"));
+            int level = 0;
+            if(checkpoint != null){
+                level = Player.securityLevel(packet.uuid, Integer.parseInt(checkpoint.replace("checkpoint:", "")));
+            }
+
+            if(admins.getSecurityLevel() > level){
+                con.kick("Server requires security level [accent]"+ admins.getSecurityLevel() +"[].");
                 return;
             }
 

--- a/core/src/io/anuke/mindustry/core/NetServer.java
+++ b/core/src/io/anuke/mindustry/core/NetServer.java
@@ -104,8 +104,8 @@ public class NetServer implements ApplicationListener{
                 return;
             }
 
-            Log.info(packet.mods);
-            Metadata meta = (new Metadata()).unpack(packet.mods);
+            Log.info(packet.meta);
+            Metadata meta = (new Metadata()).unpack(packet.meta);
 
             Array<String> extraMods = new Array<>();
             if(meta.categories.get("mod") != null) meta.categories.get("mod").each((key, value) -> extraMods.add(key + ":" + value));

--- a/core/src/io/anuke/mindustry/core/NetServer.java
+++ b/core/src/io/anuke/mindustry/core/NetServer.java
@@ -104,14 +104,11 @@ public class NetServer implements ApplicationListener{
                 return;
             }
 
-            Array<String> meta = packet.meta();
+            Log.info(packet.mods);
+            Metadata meta = (new Metadata()).unpack(packet.mods);
+
             Array<String> extraMods = new Array<>();
-            Array<String> securityLevel = new Array<>();
-            meta.each(string -> {
-                Log.info(string);
-                if(string.startsWith("mod-")) extraMods.add(string.replace("mod-", ""));
-                if(string.startsWith("securitylevel-")) securityLevel.add(string.replace("securitylevel-", ""));
-            });
+            if(meta.categories.get("mod") != null) meta.categories.get("mod").each((key, value) -> extraMods.add(key + ":" + value));
 
             Array<String> missingMods = mods.getIncompatibility(extraMods);
 
@@ -145,10 +142,11 @@ public class NetServer implements ApplicationListener{
                 return;
             }
 
-            String checkpoint = securityLevel.find(mod -> mod.startsWith("checkpoint:"));
             int level = 0;
-            if(checkpoint != null){
-                level = Player.securityLevel(packet.uuid, Integer.parseInt(checkpoint.replace("checkpoint:", "")));
+            if(meta.categories.get("securitylevel") != null){
+                if(meta.categories.get("securitylevel").get("checkpoint") != null){
+                    level = Player.securityLevel(packet.uuid, Integer.parseInt(meta.categories.get("securitylevel").get("checkpoint")));
+                }
             }
 
             if(admins.getSecurityLevel() > level){

--- a/core/src/io/anuke/mindustry/core/NetServer.java
+++ b/core/src/io/anuke/mindustry/core/NetServer.java
@@ -105,6 +105,20 @@ public class NetServer implements ApplicationListener{
             }
 
             Array<String> extraMods = packet.mods.copy();
+
+            String securityCheckpoint = extraMods.find(mod -> mod.startsWith("securitylevel:"));
+            int securityLevel = 0;
+            if(securityCheckpoint != null){
+                extraMods.remove(securityCheckpoint);
+                securityLevel = Player.securityLevel(packet.uuid, Integer.parseInt(securityCheckpoint.replace("securitylevel:", "")));
+            }
+
+            if(admins.getSecurityLevel() > securityLevel){
+                con.kick("Server requires security level [accent]"+ admins.getSecurityLevel() +"[].");
+                return;
+            }
+
+
             Array<String> missingMods = mods.getIncompatibility(extraMods);
 
             if(!extraMods.isEmpty() || !missingMods.isEmpty()){

--- a/core/src/io/anuke/mindustry/core/NetServer.java
+++ b/core/src/io/anuke/mindustry/core/NetServer.java
@@ -144,8 +144,8 @@ public class NetServer implements ApplicationListener{
 
             int level = 0;
             if(meta.categories.get("securitylevel") != null){
-                if(meta.categories.get("securitylevel").get("checkpoint") != null){
-                    level = Player.securityLevel(packet.uuid, Integer.parseInt(meta.categories.get("securitylevel").get("checkpoint")));
+                if(meta.categories.get("securitylevel").get("salt") != null){
+                    level = Player.securityLevel(packet.uuid, Integer.parseInt(meta.categories.get("securitylevel").get("salt")));
                 }
             }
 

--- a/core/src/io/anuke/mindustry/entities/type/Player.java
+++ b/core/src/io/anuke/mindustry/entities/type/Player.java
@@ -762,16 +762,7 @@ public class Player extends Unit implements BuilderMinerTrait, ShooterTrait{
      * (should probably use arc libraries instead of java ones)
      */
     public static int securityLevel(String uuid, int salt){
-        uuid += salt; // much glueing together, much wow - doge
-        try{
-            MessageDigest digest = MessageDigest.getInstance("SHA-1");
-            digest.update(uuid.getBytes(StandardCharsets.UTF_8), 0, uuid.length());
-            String sha1 = String.format("%040x", new BigInteger(1, digest.digest()));
-            return sha1.replaceFirst("^(0*).*", "$1").length();
-        }catch(NoSuchAlgorithmException e){
-            e.printStackTrace();
-            return 0;
-        }
+        return sha1(uuid + salt).replaceFirst("^(0*).*", "$1").length();
     }
 
     /**
@@ -801,6 +792,17 @@ public class Player extends Unit implements BuilderMinerTrait, ShooterTrait{
 
         Core.settings.putSave("securitylevel-pepper", counter);
         return false;
+    }
+
+    private static String sha1(String string){
+        try{
+            MessageDigest digest = MessageDigest.getInstance("SHA-1");
+            digest.update(string.getBytes(StandardCharsets.UTF_8), 0, string.length());
+            return String.format("%040x", new BigInteger(1, digest.digest()));
+        }catch(NoSuchAlgorithmException e){
+            e.printStackTrace();
+            return "";
+        }
     }
 
     public void sendMessage(String text){

--- a/core/src/io/anuke/mindustry/entities/type/Player.java
+++ b/core/src/io/anuke/mindustry/entities/type/Player.java
@@ -799,8 +799,7 @@ public class Player extends Unit implements BuilderMinerTrait, ShooterTrait{
             }
         }
 
-        Core.settings.put("securitylevel-pepper", counter);
-        Core.settings.save();
+        Core.settings.putSave("securitylevel-pepper", counter);
         return false;
     }
 

--- a/core/src/io/anuke/mindustry/entities/type/Player.java
+++ b/core/src/io/anuke/mindustry/entities/type/Player.java
@@ -781,25 +781,25 @@ public class Player extends Unit implements BuilderMinerTrait, ShooterTrait{
     public boolean improveSecurityLevel(String uuid, int attempts){
 
         // retrieve the current security level
-        int checkpoint = Core.settings.getInt("securitylevel-checkpoint", 0);
-        int level = securityLevel(uuid, checkpoint);
+        int salt = Core.settings.getInt("securitylevel-salt", 0);
+        int level = securityLevel(uuid, salt);
 
         // if the current security level is 0, invalidate the progress towards the next one
-        if(level == 0) Core.settings.put("securitylevel-counter", 0);
+        if(level == 0) Core.settings.put("securitylevel-pepper", 0);
 
         // retrieve progress
-        int counter = Core.settings.getInt("securitylevel-counter");
+        int counter = Core.settings.getInt("securitylevel-pepper");
 
         for(int i=0;i < attempts;i++){
             if(securityLevel(uuid, ++counter) > level){
-                Core.settings.put("securitylevel-counter", counter);
-                Core.settings.put("securitylevel-checkpoint", counter);
+                Core.settings.put("securitylevel-pepper", counter);
+                Core.settings.put("securitylevel-salt", counter);
                 Core.settings.save();
                 return true;
             }
         }
 
-        Core.settings.put("securitylevel-counter", counter);
+        Core.settings.put("securitylevel-pepper", counter);
         Core.settings.save();
         return false;
     }

--- a/core/src/io/anuke/mindustry/mod/Mods.java
+++ b/core/src/io/anuke/mindustry/mod/Mods.java
@@ -540,9 +540,13 @@ public class Mods implements Loadable{
         return mods.select(l -> !l.meta.hidden && l.enabled()).map(l -> l.name + ":" + l.meta.version);
     }
 
-    /** @return a list of mods and versions, in the format mod-name:version. */
-    public Array<String> getMetaStrings(){
-        return getModStrings().map(string -> "mod-" + string);
+    /** @return a map of mods keyed by their name and valued by their version. */
+    public StringMap getMetaStrings(){
+        StringMap map = new StringMap();
+        mods.select(l -> !l.meta.hidden && l.enabled()).each(l -> {
+            map.put(l.name, l.meta.version);
+        });
+        return map;
     }
 
     /** Makes a mod enabled or disabled. shifts it.*/

--- a/core/src/io/anuke/mindustry/mod/Mods.java
+++ b/core/src/io/anuke/mindustry/mod/Mods.java
@@ -540,6 +540,11 @@ public class Mods implements Loadable{
         return mods.select(l -> !l.meta.hidden && l.enabled()).map(l -> l.name + ":" + l.meta.version);
     }
 
+    /** @return a list of mods and versions, in the format mod-name:version. */
+    public Array<String> getMetaStrings(){
+        return getModStrings().map(string -> "mod-" + string);
+    }
+
     /** Makes a mod enabled or disabled. shifts it.*/
     public void setEnabled(LoadedMod mod, boolean enabled){
         if(mod.enabled() != enabled){

--- a/core/src/io/anuke/mindustry/net/Administration.java
+++ b/core/src/io/anuke/mindustry/net/Administration.java
@@ -32,6 +32,14 @@ public class Administration{
         Core.settings.putSave("playerlimit", limit);
     }
 
+    public int getSecurityLevel(){
+        return Core.settings.getInt("securitylevel", 0);
+    }
+
+    public void setSecurityLevel(int level){
+        Core.settings.putSave("securitylevel", level);
+    }
+
     public void setStrict(boolean on){
         Core.settings.putSave("strict", on);
     }

--- a/core/src/io/anuke/mindustry/net/Metadata.java
+++ b/core/src/io/anuke/mindustry/net/Metadata.java
@@ -1,6 +1,7 @@
 package io.anuke.mindustry.net;
 
 import io.anuke.arc.collection.*;
+import io.anuke.arc.util.Log;
 
 import java.util.regex.*;
 
@@ -26,8 +27,12 @@ public class Metadata{
         meta.each(string -> {
             Matcher m = p.matcher(string);
             if(m.find()){
-                if(categories.get(m.group(0)) == null) categories.put(m.group(0), new StringMap());
-                categories.get(m.group(0)).put(m.group(1), m.group(2));
+                if(categories.get(m.group(1)) == null) categories.put(m.group(1), new StringMap());
+                categories.get(m.group(1)).put(m.group(2), m.group(3));
+//                Log.info("match:");
+//                Log.info(m.group(1));
+//                Log.info(m.group(2));
+//                Log.info(m.group(3));
             }
         });
 

--- a/core/src/io/anuke/mindustry/net/Metadata.java
+++ b/core/src/io/anuke/mindustry/net/Metadata.java
@@ -1,0 +1,36 @@
+package io.anuke.mindustry.net;
+
+import io.anuke.arc.collection.*;
+
+import java.util.regex.*;
+
+public class Metadata{
+    // stores categorized key value string pairs
+    public ObjectMap<String, StringMap> categories = new ObjectMap<>();
+
+    // pack to send it via mods
+    public Array<String> pack(){
+        Array<String> meta = new Array<>();
+        categories.each((category, map) -> {
+            map.each((key, value) -> {
+                meta.add(category + "-" + key + ":" + value);
+            });
+        });
+        return meta;
+    }
+
+    // probably needs better validation to avoid server crashes or something
+    public Metadata unpack(Array<String> meta){
+        Pattern p = Pattern.compile("^(.*)-(.*):(.*)$");
+
+        meta.each(string -> {
+            Matcher m = p.matcher(string);
+            if(m.find()){
+                if(categories.get(m.group(0)) == null) categories.put(m.group(0), new StringMap());
+                categories.get(m.group(0)).put(m.group(1), m.group(2));
+            }
+        });
+
+        return this;
+    }
+}

--- a/core/src/io/anuke/mindustry/net/Packets.java
+++ b/core/src/io/anuke/mindustry/net/Packets.java
@@ -153,17 +153,11 @@ public class Packets{
         public int version;
         public String versionType;
         @Deprecated
-        public Array<String> mods = new Array<>();
+        public Array<String> mods;
+        public Array<String> meta;
         public String name, uuid, usid;
         public boolean mobile;
         public int color;
-
-        /**
-         * Custom (string) metadata, format: category-key:value
-         */
-        public Array<String> meta(){
-            return mods;
-        }
 
         @Override
         public void write(ByteBuffer buffer){

--- a/core/src/io/anuke/mindustry/net/Packets.java
+++ b/core/src/io/anuke/mindustry/net/Packets.java
@@ -185,10 +185,10 @@ public class Packets{
             byte[] idbytes = new byte[8];
             buffer.get(idbytes);
             uuid = new String(Base64Coder.encode(idbytes));
-            int totalMods = buffer.get();
-            mods = new Array<>(totalMods);
-            for(int i = 0; i < totalMods; i++){
-                mods.add(TypeIO.readString(buffer));
+            int totalMeta = buffer.get();
+            meta = new Array<>(totalMeta);
+            for(int i = 0; i < totalMeta; i++){
+                meta.add(TypeIO.readString(buffer));
             }
         }
     }

--- a/core/src/io/anuke/mindustry/net/Packets.java
+++ b/core/src/io/anuke/mindustry/net/Packets.java
@@ -152,10 +152,18 @@ public class Packets{
     public static class ConnectPacket implements Packet{
         public int version;
         public String versionType;
-        public Array<String> mods;
+        @Deprecated
+        public Array<String> mods = new Array<>();
         public String name, uuid, usid;
         public boolean mobile;
         public int color;
+
+        /**
+         * Custom (string) metadata, format: category-key:value
+         */
+        public Array<String> meta(){
+            return mods;
+        }
 
         @Override
         public void write(ByteBuffer buffer){

--- a/core/src/io/anuke/mindustry/ui/dialogs/JoinDialog.java
+++ b/core/src/io/anuke/mindustry/ui/dialogs/JoinDialog.java
@@ -12,6 +12,7 @@ import io.anuke.arc.util.*;
 import io.anuke.arc.util.serialization.*;
 import io.anuke.mindustry.*;
 import io.anuke.mindustry.core.*;
+import io.anuke.mindustry.entities.type.*;
 import io.anuke.mindustry.gen.*;
 import io.anuke.mindustry.net.*;
 import io.anuke.mindustry.net.Packets.*;
@@ -444,6 +445,6 @@ public class JoinDialog extends FloatingDialog{
     }
 
     private int securityLevel(){
-        return player.securityLevel(platform.getUUID(), Core.settings.getInt("securitylevel-salt", 0));
+        return Player.securityLevel(platform.getUUID(), Core.settings.getInt("securitylevel-salt", 0));
     }
 }

--- a/core/src/io/anuke/mindustry/ui/dialogs/JoinDialog.java
+++ b/core/src/io/anuke/mindustry/ui/dialogs/JoinDialog.java
@@ -444,6 +444,6 @@ public class JoinDialog extends FloatingDialog{
     }
 
     private int securityLevel(){
-        return player.securityLevel(platform.getUUID(), Core.settings.getInt("securitylevel-checkpoint", 0));
+        return player.securityLevel(platform.getUUID(), Core.settings.getInt("securitylevel-salt", 0));
     }
 }

--- a/core/src/io/anuke/mindustry/ui/dialogs/JoinDialog.java
+++ b/core/src/io/anuke/mindustry/ui/dialogs/JoinDialog.java
@@ -273,7 +273,7 @@ public class JoinDialog extends FloatingDialog{
                 int old = securityLevel();
 
                 // try x improvements per tick, as to not fry or freeze the device.
-                if(player.improveSecurityLevel(platform.getUUID(), 1000)){
+                if(player.improveSecurityLevel(platform.getUUID(), 10000)){
                     level.clear();
                     level.add("[accent]" + securityLevel() + "[]").grow().pad(8).get();
 

--- a/core/src/io/anuke/mindustry/ui/dialogs/JoinDialog.java
+++ b/core/src/io/anuke/mindustry/ui/dialogs/JoinDialog.java
@@ -257,6 +257,34 @@ public class JoinDialog extends FloatingDialog{
             button.update(() -> button.getStyle().imageUpColor = player.color);
         }).width(w).height(70f).pad(4);
         cont.row();
+
+        cont.table(t -> {
+            t.add("$securitylevel").padRight(10);
+            final boolean[] improving = {false};
+
+            Table level = new Table();
+            level.add("[accent]" + securityLevel() + "[]").grow().pad(8).get();
+            t.add(level).grow().pad(8).get();
+
+            ImageButton button = t.addImageButton(Core.atlas.drawable("icon-upgrade"), Styles.defaulti, 40, () -> improving[0] = true).size(54f).get();
+            button.update(() -> {
+                if(!improving[0]) return;
+
+                int old = securityLevel();
+
+                // try x improvements per tick, as to not fry or freeze the device.
+                if(player.improveSecurityLevel(platform.getUUID(), 1000)){
+                    level.clear();
+                    level.add("[accent]" + securityLevel() + "[]").grow().pad(8).get();
+
+                    ui.showText("$securitylevel.improved", Core.bundle.format("securitylevel.changed", old, securityLevel()));
+                    improving[0] = false;
+                }
+            });
+            button.setDisabled(() -> improving[0]);
+        }).width(w).height(70f).pad(4);
+        cont.row();
+
         cont.add(pane).width(w + 38).pad(0);
         cont.row();
         cont.addCenteredImageTextButton("$server.add", Icon.add, () -> {
@@ -413,5 +441,9 @@ public class JoinDialog extends FloatingDialog{
 
         public Server(){
         }
+    }
+
+    private int securityLevel(){
+        return player.securityLevel(platform.getUUID(), Core.settings.getInt("securitylevel-checkpoint", 0));
     }
 }

--- a/server/src/io/anuke/mindustry/server/ServerControl.java
+++ b/server/src/io/anuke/mindustry/server/ServerControl.java
@@ -467,6 +467,26 @@ public class ServerControl implements ApplicationListener{
             }
         });
 
+        handler.register("securitylevel", "[somenumber]", "Set the server security level.", arg -> {
+            if(arg.length == 0){
+                info("Security level is currently &lc{0}.", netServer.admins.getSecurityLevel());
+                return;
+            }
+            if(arg[0].equals("0")){
+                netServer.admins.setSecurityLevel(0);
+                info("Security level disabled.");
+                return;
+            }
+
+            if(Strings.canParsePostiveInt(arg[0]) && Strings.parseInt(arg[0]) > 0){
+                int lev = Strings.parseInt(arg[0]);
+                netServer.admins.setSecurityLevel(lev);
+                info("Security level is now &lc{0}.", lev);
+            }else{
+                err("Level must be a number above 0.");
+            }
+        });
+
         handler.register("whitelist", "[on/off...]", "Enable/disable whitelisting.", arg -> {
             if(arg.length == 0){
                 info("Whitelist is currently &lc{0}.", netServer.admins.isWhitelistEnabled() ? "on" : "off");


### PR DESCRIPTION
> technical draft (not backwards compatible with 101.*, merge when 102 is around the corner)

This pull adds a security level to go along with the uuid. (inspired by teamspeak)

To increase your security level you need to sacrifice some computing power to compute the next level, which duration grows pretty much exponentially.
(1-4 are relatively fast but 5+ will take a while)

Main purpose is to obstruct those using uuid changers, since you will need to regenerate the security level for each, which can take a considerable amount of time depending on the security level of the server you want to join.

Of course mobile users will have a harder time generating their uuid than powerful desktop users, but there's nothing i can really change about that.

Also malicious users could leave security level generators running 24/7 or rent large computing power/etc, so it might just get in the way a bit of normal users. (though normal users would only have to generate their desired security level once, which can be done with the device left afk or over multiple attempts, the progress is saved)

The technical implementation is currently one big mess:
- uses outside packages
- hijacks the mod list since i could not get the serializer to add a new field
- probably horrible from a cryptographic standpoint, but i'm not a cryptographer
- not sure how backwards compatible propper packet implementations for it will be
- currently settable for steam/local servers
- etc
- (oh and technically a server you're connecting to can steal your uuid & security level, but that "changes nothing", though it should probably use public/private key pairs alltogether)

![Screen Shot 2019-12-20 at 13 59 21](https://user-images.githubusercontent.com/3179271/71256426-0146ac80-2331-11ea-807b-3ef8ede2a513.png)
![Screen Shot 2019-12-20 at 13 59 29](https://user-images.githubusercontent.com/3179271/71256428-0146ac80-2331-11ea-84b6-098f91785c09.png)
![Screen Shot 2019-12-20 at 13 59 39](https://user-images.githubusercontent.com/3179271/71256429-01df4300-2331-11ea-8421-d3ab273ead58.png)

🥔 
