### PR TITLE
[multiplayer] techtree

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -767,6 +767,7 @@ rules.title.unit = Units
 rules.title.experimental = Experimental
 rules.lighting = Lighting
 rules.ambientlight = Ambient Light
+rules.techtree = Use tech tree
 
 content.item.name = Items
 content.liquid.name = Liquids

--- a/core/src/io/anuke/mindustry/content/Blocks.java
+++ b/core/src/io/anuke/mindustry/content/Blocks.java
@@ -1276,7 +1276,7 @@ public class Blocks implements ContentList{
         }};
 
         launchPad = new LaunchPad("launch-pad"){{
-            requirements(Category.effect, BuildVisibility.campaignOnly, ItemStack.with(Items.copper, 250, Items.silicon, 75, Items.lead, 100));
+            requirements(Category.effect, BuildVisibility.techtreeOnly, ItemStack.with(Items.copper, 250, Items.silicon, 75, Items.lead, 100));
             size = 3;
             itemCapacity = 100;
             launchTime = 60f * 16;
@@ -1285,7 +1285,7 @@ public class Blocks implements ContentList{
         }};
 
         launchPadLarge = new LaunchPad("launch-pad-large"){{
-            requirements(Category.effect, BuildVisibility.campaignOnly, ItemStack.with(Items.titanium, 200, Items.silicon, 150, Items.lead, 250, Items.plastanium, 75));
+            requirements(Category.effect, BuildVisibility.techtreeOnly, ItemStack.with(Items.titanium, 200, Items.silicon, 150, Items.lead, 250, Items.plastanium, 75));
             size = 4;
             itemCapacity = 250;
             launchTime = 60f * 14;

--- a/core/src/io/anuke/mindustry/game/GlobalData.java
+++ b/core/src/io/anuke/mindustry/game/GlobalData.java
@@ -95,8 +95,12 @@ public class GlobalData{
     }
 
     public boolean hasItems(ItemStack[] stacks){
+        return hasItems(items, stacks);
+    }
+
+    public boolean hasItems(ObjectIntMap<Item> source, ItemStack[] stacks){
         for(ItemStack stack : stacks){
-            if(!has(stack.item, stack.amount)){
+            if(!has(source, stack.item, stack.amount)){
                 return false;
             }
         }
@@ -105,10 +109,13 @@ public class GlobalData{
     }
 
     public void removeItems(ItemStack[] stacks){
+        removeItems(items, stacks);
+    }
+
+    public void removeItems(ObjectIntMap<Item> source, ItemStack[] stacks){
         for(ItemStack stack : stacks){
-            items.getAndIncrement(stack.item, 0, -stack.amount);
+            source.getAndIncrement(stack.item, 0, -stack.amount);
         }
-        modified = true;
     }
 
     public void removeItems(Array<ItemStack> stacks){
@@ -120,6 +127,10 @@ public class GlobalData{
 
     public boolean has(Item item, int amount){
         return items.get(item, 0) >= amount;
+    }
+
+    public boolean has(ObjectIntMap<Item> source, Item item, int amount){
+        return source.get(item, 0) >= amount;
     }
 
     public ObjectIntMap<Item> items(){

--- a/core/src/io/anuke/mindustry/game/Rules.java
+++ b/core/src/io/anuke/mindustry/game/Rules.java
@@ -78,6 +78,16 @@ public class Rules{
     public boolean lighting = false;
     /** Ambient light color, used when lighting is enabled. */
     public Color ambientLight = new Color(0.01f, 0.01f, 0.04f, 0.99f);
+    /** Use the techtree or unlock everything. */
+    public boolean techtree = true;
+    /** Which blocks are unlocked in the tech tree by default. */
+    public Array<Block> unlocked = new Array<Block>(){{
+        add(Blocks.combustionGenerator);
+        add(Blocks.router, Blocks.launchPad);
+        add(Blocks.graphitePress, Blocks.siliconSmelter);
+    }};
+    /** Launched items. */
+    public ObjectIntMap<Item> launched = new ObjectIntMap<>();
 
     /** Copies this ruleset exactly. Not very efficient at all, do not use often. */
     public Rules copy(){

--- a/core/src/io/anuke/mindustry/game/Rules.java
+++ b/core/src/io/anuke/mindustry/game/Rules.java
@@ -79,13 +79,9 @@ public class Rules{
     /** Ambient light color, used when lighting is enabled. */
     public Color ambientLight = new Color(0.01f, 0.01f, 0.04f, 0.99f);
     /** Use the techtree or unlock everything. */
-    public boolean techtree = true;
-    /** Which blocks are unlocked in the tech tree by default. */
-    public Array<Block> unlocked = new Array<Block>(){{
-        add(Blocks.combustionGenerator);
-        add(Blocks.router, Blocks.launchPad);
-        add(Blocks.graphitePress, Blocks.siliconSmelter);
-    }};
+    public boolean techtree = false;
+    /** Which blocks are unlocked in the tech tree. */
+    public Array<Block> unlocked = new Array<>();
     /** Launched items. */
     public ObjectIntMap<Item> launched = new ObjectIntMap<>();
 

--- a/core/src/io/anuke/mindustry/ui/ItemsDisplay.java
+++ b/core/src/io/anuke/mindustry/ui/ItemsDisplay.java
@@ -23,7 +23,7 @@ public class ItemsDisplay extends Table{
 
         table(Tex.button,t -> {
             t.margin(10).marginLeft(15).marginTop(15f);
-            t.label(() -> state.is(State.menu) ? "$launcheditems" : "$launchinfo").colspan(3).padBottom(4).left().colspan(3).width(210f).wrap();
+            t.label(() -> state.is(State.menu) || state.rules.techtree ? "$launcheditems" : "$launchinfo").colspan(3).padBottom(4).left().colspan(3).width(210f).wrap();
             t.row();
             for(Item item : content.items()){
                 if(item.type == ItemType.material && data.isUnlocked(item)){
@@ -38,10 +38,12 @@ public class ItemsDisplay extends Table{
 
     private String format(Item item){
         builder.setLength(0);
-        builder.append(ui.formatAmount(data.items().get(item, 0)));
+        builder.append(ui.formatAmount(state.rules.techtree ? state.rules.launched.get(item, 0) : data.items().get(item, 0)));
         if(!state.is(State.menu) && !state.teams.get(player.getTeam()).cores.isEmpty() && state.teams.get(player.getTeam()).cores.first().entity != null && state.teams.get(player.getTeam()).cores.first().entity.items.get(item) > 0){
-            builder.append(" [unlaunched]+ ");
-            builder.append(ui.formatAmount(state.teams.get(player.getTeam()).cores.first().entity.items.get(item)));
+            if(!state.rules.techtree){
+                builder.append(" [unlaunched]+ ");
+                builder.append(ui.formatAmount(state.teams.get(player.getTeam()).cores.first().entity.items.get(item)));
+            }
         }
         return builder.toString();
     }

--- a/core/src/io/anuke/mindustry/ui/dialogs/PausedDialog.java
+++ b/core/src/io/anuke/mindustry/ui/dialogs/PausedDialog.java
@@ -41,7 +41,7 @@ public class PausedDialog extends FloatingDialog{
             cont.addButton("$back", this::hide).colspan(2).width(dw * 2 + 20f);
 
             cont.row();
-            if(world.isZone()){
+            if(world.isZone() || state.rules.techtree){
                 cont.addButton("$techtree", ui.tech::show);
             }else{
                 cont.addButton("$database", ui.database::show);

--- a/core/src/io/anuke/mindustry/ui/dialogs/TechTreeDialog.java
+++ b/core/src/io/anuke/mindustry/ui/dialogs/TechTreeDialog.java
@@ -1,5 +1,6 @@
 package io.anuke.mindustry.ui.dialogs;
 
+import io.anuke.annotations.Annotations.*;
 import io.anuke.arc.*;
 import io.anuke.arc.collection.*;
 import io.anuke.arc.graphics.*;
@@ -24,6 +25,7 @@ import io.anuke.mindustry.ui.*;
 import io.anuke.mindustry.ui.Cicon;
 import io.anuke.mindustry.ui.layout.*;
 import io.anuke.mindustry.ui.layout.TreeLayout.*;
+import io.anuke.mindustry.world.*;
 
 import static io.anuke.mindustry.Vars.*;
 
@@ -287,9 +289,13 @@ public class TechTreeDialog extends FloatingDialog{
 
         void unlock(TechNode node){
             if(state.rules.techtree){
-                state.rules.unlocked.add(node.block);
-                data.removeItems(state.rules.launched, node.requirements);
-                Call.onSetRules(state.rules);
+                if(net.server()){
+                    state.rules.unlocked.add(node.block);
+                    data.removeItems(state.rules.launched, node.requirements);
+                    Call.onSetRules(state.rules);
+                }else{
+//                    Call.unlockTechtreeBlock(node.block);
+                }
             }else{
                 data.unlockContent(node.block);
                 data.removeItems(node.requirements);
@@ -304,6 +310,11 @@ public class TechTreeDialog extends FloatingDialog{
             Sounds.unlock.play();
             Events.fire(new ResearchEvent(node.block));
         }
+
+//        @Remote(targets = Loc.server, called = Loc.both)
+//        void unlockTechtreeBlock(Block block){
+//            unlock(nodes.select(node -> node.node.block == block).first().node);
+//        }
 
         void rebuild(){
             ImageButton button = hoverNode;

--- a/core/src/io/anuke/mindustry/ui/dialogs/TechTreeDialog.java
+++ b/core/src/io/anuke/mindustry/ui/dialogs/TechTreeDialog.java
@@ -161,7 +161,7 @@ public class TechTreeDialog extends FloatingDialog{
     }
 
     boolean locked(TechNode node){
-        return node.block.locked();
+        return state.rules.techtree ? (!state.rules.unlocked.contains(node.block) && !node.block.alwaysUnlocked()) : node.block.locked();
     }
 
     class LayoutNode extends TreeNode<LayoutNode>{
@@ -228,7 +228,7 @@ public class TechTreeDialog extends FloatingDialog{
                                 }
                             });
                         }
-                    }else if(data.hasItems(node.node.requirements) && locked(node.node)){
+                    }else if(data.hasItems(state.rules.techtree ? state.rules.launched : data.items(), node.node.requirements) && locked(node.node)){
                         unlock(node.node);
                     }
                 });
@@ -286,8 +286,15 @@ public class TechTreeDialog extends FloatingDialog{
         }
 
         void unlock(TechNode node){
-            data.unlockContent(node.block);
-            data.removeItems(node.requirements);
+            if(state.rules.techtree){
+                state.rules.unlocked.add(node.block);
+                data.removeItems(state.rules.launched, node.requirements);
+                Call.onSetRules(state.rules);
+            }else{
+                data.unlockContent(node.block);
+                data.removeItems(node.requirements);
+            }
+
             showToast(Core.bundle.format("researched", node.block.localizedName));
             checkNodes(root);
             hoverNode = null;
@@ -339,7 +346,7 @@ public class TechTreeDialog extends FloatingDialog{
                                     list.addImage(req.item.icon(Cicon.small)).size(8 * 3).padRight(3);
                                     list.add(req.item.localizedName).color(Color.lightGray);
                                     list.label(() -> " " + Math.min(data.getItem(req.item), req.amount) + " / " + req.amount)
-                                    .update(l -> l.setColor(data.has(req.item, req.amount) ? Color.lightGray : Color.scarlet));
+                                    .update(l -> l.setColor(data.has(state.rules.techtree ? state.rules.launched : data.items(), req.item, req.amount) ? Color.lightGray : Color.scarlet));
                                 }).fillX().left();
                                 t.row();
                             }

--- a/core/src/io/anuke/mindustry/ui/fragments/PlacementFragment.java
+++ b/core/src/io/anuke/mindustry/ui/fragments/PlacementFragment.java
@@ -426,6 +426,7 @@ public class PlacementFragment extends Fragment{
     }
 
     boolean unlocked(Block block){
+        if(state.rules.techtree) return state.rules.unlocked.contains(block) || block.alwaysUnlocked;
         return !world.isZone() || data.isUnlocked(block);
     }
 

--- a/core/src/io/anuke/mindustry/world/blocks/storage/LaunchPad.java
+++ b/core/src/io/anuke/mindustry/world/blocks/storage/LaunchPad.java
@@ -10,6 +10,7 @@ import io.anuke.mindustry.content.Fx;
 import io.anuke.mindustry.entities.Effects;
 import io.anuke.mindustry.entities.type.TileEntity;
 import io.anuke.mindustry.game.EventType.*;
+import io.anuke.mindustry.gen.*;
 import io.anuke.mindustry.graphics.Pal;
 import io.anuke.mindustry.type.Item;
 import io.anuke.mindustry.type.ItemType;
@@ -17,8 +18,7 @@ import io.anuke.mindustry.world.Tile;
 import io.anuke.mindustry.world.meta.BlockStat;
 import io.anuke.mindustry.world.meta.StatUnit;
 
-import static io.anuke.mindustry.Vars.data;
-import static io.anuke.mindustry.Vars.world;
+import static io.anuke.mindustry.Vars.*;
 
 public class LaunchPad extends StorageBlock{
     public final int timerLaunch = timers++;
@@ -73,12 +73,17 @@ public class LaunchPad extends StorageBlock{
     public void update(Tile tile){
         TileEntity entity = tile.entity;
 
-        if(world.isZone() && entity.cons.valid() && world.isZone() && entity.items.total() >= itemCapacity && entity.timer.get(timerLaunch, launchTime / entity.timeScale)){
+        if((world.isZone() || state.rules.techtree) && entity.cons.valid() && (world.isZone() || state.rules.techtree) && entity.items.total() >= itemCapacity && entity.timer.get(timerLaunch, launchTime / entity.timeScale)){
             for(Item item : Vars.content.items()){
                 Events.fire(Trigger.itemLaunch);
                 Effects.effect(Fx.padlaunch, tile);
                 int used = Math.min(entity.items.get(item), itemCapacity);
-                data.addItem(item, used);
+                if(state.rules.techtree){
+                    state.rules.launched.getAndIncrement(item, 0, used);
+                    Call.onSetRules(state.rules);
+                }else{
+                    data.addItem(item, used);
+                }
                 entity.items.remove(item, used);
                 Events.fire(new LaunchItemEvent(item, used));
             }

--- a/core/src/io/anuke/mindustry/world/meta/BuildVisibility.java
+++ b/core/src/io/anuke/mindustry/world/meta/BuildVisibility.java
@@ -8,7 +8,7 @@ public enum BuildVisibility{
     shown(() -> true),
     debugOnly(() -> false),
     sandboxOnly(() -> Vars.state.rules.infiniteResources),
-    campaignOnly(() -> Vars.world.isZone()),
+    techtreeOnly(() -> Vars.world.isZone() || Vars.state.rules.techtree),
     lightingOnly(() -> Vars.state.rules.lighting);
 
     private final Boolp visible;


### PR DESCRIPTION
> prototype (no negative reactions plox, its not meant as a serious merge candidate in this stage)

**random list**
- a rough draft that makes the techtree available in custom games & multiplayer
- unlocks some blocks by default so you can actually launch stuff to research with
- due to me not being smart enough only the server host can research (not player/admins)
- launched items are essentially lost and can never be called down again
- probably a bit unstable and messy, but it works somewhat reliably, feel free to pull & test :)
- custom rule dialog should probably use an interactive techtree instead of a bannedblocks
- should probably have an alert or something if another player researches something
- maybe requiring a vote on what to spend the riches on when playing multiplayer?
- probably needs some balancing since all the work does not get carried over, yet
- other stuff probably
- oh and here are some pics from the custom game (aka: not campaign) V

![Screen Shot 2019-12-21 at 10 39 32](https://user-images.githubusercontent.com/3179271/71306243-4248ca80-23de-11ea-9c2a-b2eb0687d40c.png)
![Screen Shot 2019-12-21 at 10 39 42](https://user-images.githubusercontent.com/3179271/71306246-4379f780-23de-11ea-99bf-baad049ae8bf.png)
![Screen Shot 2019-12-21 at 10 39 50](https://user-images.githubusercontent.com/3179271/71306247-44ab2480-23de-11ea-8b54-1610e255444a.png)
