### PR TITLE
[drone] firefighter

### DIFF
--- a/core/src/io/anuke/mindustry/content/Blocks.java
+++ b/core/src/io/anuke/mindustry/content/Blocks.java
@@ -1650,6 +1650,8 @@ public class Blocks implements ContentList{
             maxSpawn = 1;
             consumes.power(1.2f);
             consumes.items(new ItemStack(Items.silicon, 30), new ItemStack(Items.lead, 30));
+            hasLiquids = true;
+            consumes.add((new ConsumeLiquidFilter(Liquid::canExtinguish, 0f)).optional(true, false));
         }};
 
         phantomFactory = new UnitFactory("phantom-factory"){{

--- a/core/src/io/anuke/mindustry/content/UnitTypes.java
+++ b/core/src/io/anuke/mindustry/content/UnitTypes.java
@@ -41,6 +41,7 @@ public class UnitTypes implements ContentList{
             health = 100;
             engineSize = 1.8f;
             engineOffset = 5.7f;
+            liquidCapacity = 5;
             weapon = new Weapon(){{
                 length = 1.5f;
                 reload = 40f;
@@ -50,6 +51,17 @@ public class UnitTypes implements ContentList{
                 recoil = 2f;
                 bullet = Bullets.healBulletBig;
                 shootSound = Sounds.pew;
+            }};
+            secondary = new Weapon(){{
+                length = 1.5f;
+                reload = 10f;
+                width = 0.5f;
+                alternate = true;
+                ejectEffect = Fx.none;
+                recoil = 2f;
+                inaccuracy = 20f;
+                bullet = Bullets.cryoShot;
+                shootSound = Sounds.splash;
             }};
         }};
 

--- a/core/src/io/anuke/mindustry/entities/type/BaseUnit.java
+++ b/core/src/io/anuke/mindustry/entities/type/BaseUnit.java
@@ -238,6 +238,11 @@ public abstract class BaseUnit extends Unit implements ShooterTrait{
     }
 
     @Override
+    public Weapon getSecondary(){
+        return type.secondary;
+    }
+
+    @Override
     public TextureRegion getIconRegion(){
         return type.icon(Cicon.full);
     }
@@ -245,6 +250,11 @@ public abstract class BaseUnit extends Unit implements ShooterTrait{
     @Override
     public int getItemCapacity(){
         return type.itemCapacity;
+    }
+
+    @Override
+    public int getLiquidCapacity(){
+        return type.liquidCapacity;
     }
 
     @Override

--- a/core/src/io/anuke/mindustry/entities/type/Player.java
+++ b/core/src/io/anuke/mindustry/entities/type/Player.java
@@ -154,6 +154,11 @@ public class Player extends Unit implements BuilderMinerTrait, ShooterTrait{
     }
 
     @Override
+    public Weapon getSecondary(){
+        return null;
+    }
+
+    @Override
     public float getMinePower(){
         return mech.mineSpeed;
     }
@@ -165,6 +170,11 @@ public class Player extends Unit implements BuilderMinerTrait, ShooterTrait{
 
     @Override
     public int getItemCapacity(){
+        return mech.itemCapacity;
+    }
+
+    @Override
+    public int getLiquidCapacity(){
         return mech.itemCapacity;
     }
 

--- a/core/src/io/anuke/mindustry/entities/type/Unit.java
+++ b/core/src/io/anuke/mindustry/entities/type/Unit.java
@@ -46,6 +46,7 @@ public abstract class Unit extends DestructibleEntity implements SaveTrait, Targ
     protected final Interpolator interpolator = new Interpolator();
     protected final Statuses status = new Statuses();
     protected final ItemStack item = new ItemStack(content.item(0), 0);
+    protected final LiquidStack liquid = new LiquidStack(content.liquid(0), 0);
 
     protected Team team = Team.sharded;
     protected float drownTime, hitTime;
@@ -400,6 +401,7 @@ public abstract class Unit extends DestructibleEntity implements SaveTrait, Targ
         Draw.rect(getPowerCellRegion(), x, y, rotation - 90);
         Draw.color();
 
+        drawBackLiquids(liquid.amount > 0 ? 1f : 0f, false);
         drawBackItems(item.amount > 0 ? 1f : 0f, false);
 
         drawLight();
@@ -408,6 +410,39 @@ public abstract class Unit extends DestructibleEntity implements SaveTrait, Targ
     public void drawLight(){
         renderer.lights.add(x, y, 50f, Pal.powerLight, 0.6f);
     }
+
+    public void drawBackLiquids(float itemtime, boolean number){
+        //draw back items
+        if(itemtime > 0.01f && liquid.liquid != null){
+            float backTrns = 5f;
+            float size = (itemSize + Mathf.absin(Time.time(), 5f, 1f)) * itemtime;
+
+            Draw.mixcol(Pal.accent, Mathf.absin(Time.time(), 5f, 0.5f));
+            Draw.rect(liquid.liquid.icon(Cicon.medium),
+            x + Angles.trnsx(rotation + 180f, backTrns),
+            y + Angles.trnsy(rotation + 180f, backTrns),
+            size, size, rotation);
+
+            Draw.mixcol();
+
+            Lines.stroke(1f, Pal.accent);
+            Lines.circle(
+            x + Angles.trnsx(rotation + 180f, backTrns),
+            y + Angles.trnsy(rotation + 180f, backTrns),
+            (3f + Mathf.absin(Time.time(), 5f, 1f)) * itemtime);
+
+            if(number){
+                Fonts.outline.draw(liquid.amount + "",
+                x + Angles.trnsx(rotation + 180f, backTrns),
+                y + Angles.trnsy(rotation + 180f, backTrns) - 3,
+                Pal.accent, 0.25f * itemtime / Scl.scl(1f), false, Align.center
+                );
+            }
+        }
+
+        Draw.reset();
+    }
+
 
     public void drawBackItems(float itemtime, boolean number){
         //draw back items
@@ -465,7 +500,11 @@ public abstract class Unit extends DestructibleEntity implements SaveTrait, Targ
 
     public abstract Weapon getWeapon();
 
+    public abstract Weapon getSecondary();
+
     public abstract int getItemCapacity();
+
+    public abstract int getLiquidCapacity();
 
     public abstract float mass();
 

--- a/core/src/io/anuke/mindustry/entities/type/base/RepairDrone.java
+++ b/core/src/io/anuke/mindustry/entities/type/base/RepairDrone.java
@@ -1,6 +1,9 @@
 package io.anuke.mindustry.entities.type.base;
 
+import io.anuke.arc.*;
 import io.anuke.arc.collection.*;
+import io.anuke.arc.graphics.*;
+import io.anuke.arc.graphics.g2d.*;
 import io.anuke.arc.math.*;
 import io.anuke.arc.math.geom.*;
 import io.anuke.arc.util.*;
@@ -10,6 +13,7 @@ import io.anuke.mindustry.entities.effect.*;
 import io.anuke.mindustry.entities.type.*;
 import io.anuke.mindustry.entities.units.UnitState;
 import io.anuke.mindustry.gen.*;
+import io.anuke.mindustry.graphics.*;
 import io.anuke.mindustry.type.*;
 import io.anuke.mindustry.world.Pos;
 import io.anuke.mindustry.world.Tile;
@@ -77,6 +81,7 @@ public class RepairDrone extends BaseDrone{
                 if(target.dst(RepairDrone.this) > type.range){
                     circle(type.range * 0.9f);
                 }else{
+
                     if(Mathf.chance(Time.delta() * 0.25)){
                         liquid.liquid = getSpawner().entity.liquids.current();
 
@@ -123,6 +128,20 @@ public class RepairDrone extends BaseDrone{
             }
         }
     };
+
+    @Override
+    public void drawUnder(){
+        super.drawUnder();
+
+        if(state.current() != refill || target.dst(RepairDrone.this) > type.range) return;
+
+        float flashScl = 0.3f;
+        Draw.color(Color.lightGray, liquid.liquid.color, 1f - flashScl + Mathf.absin(Time.time(), 0.5f, flashScl));
+        Draw.blend(Blending.additive);
+        Drawf.laser(Core.atlas.find("minelaser"), Core.atlas.find("minelaser-end"), x, y, getSpawner().drawx(), getSpawner().drawy(), 0.75f);
+        Draw.blend();
+        Draw.color();
+    }
 
     private Array<Fire> fires(){
         return fireGroup.all();

--- a/core/src/io/anuke/mindustry/entities/type/base/RepairDrone.java
+++ b/core/src/io/anuke/mindustry/entities/type/base/RepairDrone.java
@@ -133,7 +133,8 @@ public class RepairDrone extends BaseDrone{
     public void drawUnder(){
         super.drawUnder();
 
-        if(state.current() != refill || target.dst(RepairDrone.this) > type.range) return;
+        if(target == null) return;
+        if(state.current() != refill || target.dst(RepairDrone.this) > type.range || target != getSpawner()) return;
 
         float flashScl = 0.3f;
         Draw.color(Color.lightGray, liquid.liquid.color, 1f - flashScl + Mathf.absin(Time.time(), 0.5f, flashScl));

--- a/core/src/io/anuke/mindustry/entities/type/base/RepairDrone.java
+++ b/core/src/io/anuke/mindustry/entities/type/base/RepairDrone.java
@@ -1,27 +1,45 @@
 package io.anuke.mindustry.entities.type.base;
 
-import io.anuke.mindustry.entities.Units;
-import io.anuke.mindustry.entities.type.TileEntity;
+import io.anuke.arc.collection.*;
+import io.anuke.arc.math.*;
+import io.anuke.arc.math.geom.*;
+import io.anuke.arc.util.*;
+import io.anuke.mindustry.content.*;
+import io.anuke.mindustry.entities.*;
+import io.anuke.mindustry.entities.effect.*;
+import io.anuke.mindustry.entities.type.*;
 import io.anuke.mindustry.entities.units.UnitState;
+import io.anuke.mindustry.gen.*;
+import io.anuke.mindustry.type.*;
 import io.anuke.mindustry.world.Pos;
 import io.anuke.mindustry.world.Tile;
 import io.anuke.mindustry.world.blocks.*;
 
 import java.io.*;
 
-import static io.anuke.mindustry.Vars.world;
+import static io.anuke.mindustry.Vars.*;
 
 public class RepairDrone extends BaseDrone{
+    private Unit unit = (Unit)this;
+    private Fire smoke;
+    private Float nozzle = 0.05f;
+
     public final UnitState repair = new UnitState(){
 
         public void entered(){
             target = null;
+            liquid.amount = 0;
         }
 
         public void update(){
 
             if(retarget()){
-                target = Units.findDamagedTile(team, x, y);
+                if(fires().isEmpty()){
+                    target = Units.findDamagedTile(team, x, y);
+                }else{
+                    setState(refill);
+                    return;
+                }
             }
 
             if(target instanceof TileEntity && ((TileEntity)target).block instanceof BuildBlock){
@@ -44,6 +62,76 @@ public class RepairDrone extends BaseDrone{
             }
         }
     };
+
+    public final UnitState refill = new UnitState(){
+        @Override
+        public void update(){
+
+            if(fires().isEmpty()){
+                setState(repair);
+                return;
+            }
+
+            if(getSpawner() != null){
+                target = getSpawner();
+                if(target.dst(RepairDrone.this) > type.range){
+                    circle(type.range * 0.9f);
+                }else{
+                    if(Mathf.chance(Time.delta() * 0.25)){
+                        liquid.liquid = getSpawner().entity.liquids.current();
+
+                        if(getSpawner().entity.liquids.total() >= nozzle){
+                            Call.transferItemEffect(Items.titanium, target.getX(), target.getY(), unit);
+                            getSpawner().entity.liquids.remove(liquid.liquid, nozzle);
+                            liquid.amount = Mathf.clamp(liquid.amount += nozzle, 0, getLiquidCapacity());
+                        }
+                    }
+                    if(liquid.amount == getLiquidCapacity()) setState(firefight);
+                }
+            }
+        }
+    };
+
+    public final UnitState firefight = new UnitState(){
+
+        @Override
+        public void entered(){
+            target = null;
+        }
+
+        @Override
+        public void update(){
+
+            if(fires().isEmpty()){
+                setState(repair);
+                return;
+            }
+
+            if(retarget()){
+                smoke = Geometry.findClosest(x, y, fires());
+                target = world.tileWorld(smoke.x, smoke.y);
+            }
+
+            if(target != null){
+                if(target.dst(RepairDrone.this) > type.range){
+                    circle(type.range * 0.9f);
+                }else{
+                    getSecondary().update(RepairDrone.this, target.getX(), target.getY());
+                    liquid.amount = Mathf.clamp(liquid.amount -= nozzle / 5, 0, getLiquidCapacity());
+                    if(liquid.amount == 0) setState(refill);
+                }
+            }
+        }
+    };
+
+    private Array<Fire> fires(){
+        return fireGroup.all();
+    }
+
+    @Override
+    public Weapon getWeapon(){
+        return state.current() == repair ? super.getWeapon() : getSecondary();
+    }
 
     @Override
     public boolean shouldRotate(){

--- a/core/src/io/anuke/mindustry/type/Mech.java
+++ b/core/src/io/anuke/mindustry/type/Mech.java
@@ -28,6 +28,7 @@ public class Mech extends UnlockableContent{
     public float buildPower = 1f;
     public Color engineColor = Pal.boostTo;
     public int itemCapacity = 30;
+    public int liquidCapacity = 0;
     public boolean turnCursor = true;
     public boolean canHeal = false;
     public float compoundSpeed, compoundSpeedBoost;

--- a/core/src/io/anuke/mindustry/type/UnitType.java
+++ b/core/src/io/anuke/mindustry/type/UnitType.java
@@ -35,9 +35,10 @@ public class UnitType extends UnlockableContent{
     public float maxVelocity = 5f;
     public float retreatPercent = 0.6f;
     public int itemCapacity = 30;
+    public int liquidCapacity = 0;
     public ObjectSet<Item> toMine = ObjectSet.with(Items.lead, Items.copper);
     public float buildPower = 0.3f, minePower = 0.7f;
-    public @NonNull Weapon weapon;
+    public @NonNull Weapon weapon, secondary;
     public float weaponOffsetY, engineOffset = 6f, engineSize = 2f;
     public ObjectSet<StatusEffect> immunities = new ObjectSet<>();
     public Sound deathSound = Sounds.bang;


### PR DESCRIPTION
> prototype (not backwards compatible, liquid module got added to a block)

This pull allows spirit repair drones to optionally firefight by supplying their factories with the appropriate liquid.

caveats:
- laser/refueling looks ugly
- unit carrying a liquid uses the droplet
- spray does not look that nice
- empty factory liquids locks the drones in place
- will also try to extinguish fires in enemy bases
- improper liquid handling 
- hacky weapon logic
- other stuff i'm forgetting

![Dec-21-2019 13-35-58](https://user-images.githubusercontent.com/3179271/71308000-e8a0ca00-23f6-11ea-9b90-feb18b5cc074.gif)

https://feathub.com/Anuken/Mindustry/+87
