### PR TITLE
Let version string be translatable.

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -20,6 +20,8 @@ gameover = Game Over
 gameover.pvp = The[accent] {0}[] team is victorious!
 highscore = [accent]New highscore!
 copied = Copied.
+version.custom = [#fc8140aa]custom build
+version.build = [#ffffffba]{0} build {1}
 
 load.sound = Sounds
 load.map = Maps

--- a/core/src/io/anuke/mindustry/ui/fragments/MenuFragment.java
+++ b/core/src/io/anuke/mindustry/ui/fragments/MenuFragment.java
@@ -61,7 +61,8 @@ public class MenuFragment extends Fragment{
             parent.fill(c -> c.bottom().right().addButton("", Styles.discordt, ui.discord::show).size(84, 45));
         }
 
-        String versionText = "[#ffffffba]" + ((Version.build == -1) ? "[#fc8140aa]custom build" : (Version.type.equals("official") ? Version.modifier : Version.type) + " build " + Version.build + (Version.revision == 0 ? "" : "." + Version.revision));
+        String versionText = (Version.build == -1) ? Core.bundles.get("version.custombuild") : Core.bundles.format("version.build", (Version.type == "official") ? Version.modifier : Version.type, Version.build + (Version.revision == 0 ? "" : ("." + Version.revision)));
+        //String versionText = "[#ffffffba]" + ((Version.build == -1) ? "[#fc8140aa]custom build" : (Version.type.equals("official") ? Version.modifier : Version.type) + " build " + Version.build + (Version.revision == 0 ? "" : "." + Version.revision));
 
         parent.fill((x, y, w, h) -> {
             TextureRegion logo = Core.atlas.find("logo");

--- a/core/src/io/anuke/mindustry/ui/fragments/MenuFragment.java
+++ b/core/src/io/anuke/mindustry/ui/fragments/MenuFragment.java
@@ -61,8 +61,7 @@ public class MenuFragment extends Fragment{
             parent.fill(c -> c.bottom().right().addButton("", Styles.discordt, ui.discord::show).size(84, 45));
         }
 
-        String versionText = (Version.build == -1) ? Core.bundles.get("version.custombuild") : Core.bundles.format("version.build", (Version.type == "official") ? Version.modifier : Version.type, Version.build + (Version.revision == 0 ? "" : ("." + Version.revision)));
-        //String versionText = "[#ffffffba]" + ((Version.build == -1) ? "[#fc8140aa]custom build" : (Version.type.equals("official") ? Version.modifier : Version.type) + " build " + Version.build + (Version.revision == 0 ? "" : "." + Version.revision));
+        String versionText = (Version.build == -1) ? Core.bundle.get("version.build") : Core.bundle.format("version.build", (Version.type.equals("official")) ? Version.modifier : Version.type, Version.build + (Version.revision == 0 ? "" : ("." + Version.revision)));
 
         parent.fill((x, y, w, h) -> {
             TextureRegion logo = Core.atlas.find("logo");


### PR DESCRIPTION
Version string can now be half translated (version type ("release") cant be translated right now, will add if you want it).

See below for example (not in pr for obvious reasons :])
![screenshot](https://user-images.githubusercontent.com/39013340/71309820-8353d580-2404-11ea-9118-11ee3ce4921a.png)
