### PR TITLE
[chat] dynamic team color

### DIFF
--- a/core/src/io/anuke/mindustry/core/NetClient.java
+++ b/core/src/io/anuke/mindustry/core/NetClient.java
@@ -196,7 +196,7 @@ public class NetClient implements ApplicationListener{
     public static String colorizeName(int id, String name){
         Player player = playerGroup.getByID(id);
         if(name == null || player == null) return null;
-        return "[#" + player.color.toString().toUpperCase() + "]" + name;
+        return "[#" + player.color.toString().toUpperCase() + "]" + name.replace("[teamcolor]", "[#" + player.getTeam().color.toString().toUpperCase() + "]");
     }
 
     @Remote(called = Loc.client, variants = Variant.one)


### PR DESCRIPTION
> prototype, this can be done way better and less hacky, probably, this gets the ball rolling

All this does is replace `[teamcolor]` in the player's name with the color of the team they are in at the time of sending a message, though dynamic variables such as those should probably use something shorter and be usable without typing it yourself, also it shows the tab menu wrongly now, obviously 😗 

![Screen Shot 2019-12-21 at 17 07 29](https://user-images.githubusercontent.com/3179271/71310443-80f97780-2414-11ea-9a92-de046c6fed8e.png)
![Screen Shot 2019-12-21 at 17 11 44](https://user-images.githubusercontent.com/3179271/71310488-fe24ec80-2414-11ea-9674-03d103de25b9.png)

https://feathub.com/Anuken/Mindustry/+487