### PR TITLE
Add "Reload Mods" button to Mods dialog.

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -110,6 +110,7 @@ mod.nowdisabled = [scarlet]Mod '{0}' is missing dependencies:[accent] {1}\n[ligh
 mod.enable = Enable
 mod.requiresrestart = The game will now close to apply the mod changes.
 mod.reloadrequired = [scarlet]Reload Required
+mod.reloadmods = [orange]Reload Mods
 mod.import = Import Mod
 mod.import.github = Import GitHub Mod
 mod.item.remove = This item is part of the[accent] '{0}'[] mod. To remove it, uninstall that mod.

--- a/core/src/io/anuke/mindustry/mod/Mods.java
+++ b/core/src/io/anuke/mindustry/mod/Mods.java
@@ -226,7 +226,6 @@ public class Mods implements Loadable{
         this.requiresReload = requiresReload;
     }
 
-
     /** Loads all mods from the folder, but does not call any methods on them.*/
     public void load(){
         for(Fi file : modDirectory.list()){

--- a/core/src/io/anuke/mindustry/mod/Mods.java
+++ b/core/src/io/anuke/mindustry/mod/Mods.java
@@ -221,7 +221,11 @@ public class Mods implements Loadable{
     public boolean requiresReload(){
         return requiresReload;
     }
-    
+
+    public void requiresReload(boolean requiresReload){
+        this.requiresReload = requiresReload;
+    }
+
 
     /** Loads all mods from the folder, but does not call any methods on them.*/
     public void load(){

--- a/core/src/io/anuke/mindustry/mod/Mods.java
+++ b/core/src/io/anuke/mindustry/mod/Mods.java
@@ -221,6 +221,7 @@ public class Mods implements Loadable{
     public boolean requiresReload(){
         return requiresReload;
     }
+    
 
     /** Loads all mods from the folder, but does not call any methods on them.*/
     public void load(){

--- a/core/src/io/anuke/mindustry/ui/dialogs/ModsDialog.java
+++ b/core/src/io/anuke/mindustry/ui/dialogs/ModsDialog.java
@@ -104,7 +104,8 @@ public class ModsDialog extends FloatingDialog{
     void setup(){
         cont.clear();
         cont.defaults().width(mobile ? 500 : 560f).pad(4);
-        cont.add("$mod.reloadrequired").visible(mods::requiresReload).center().get().setAlignment(Align.center);
+		cont.add("$mod.reloadrequired").visible(mods::requiresReload).center().get().setAlignment(Align.center);
+		cont.row();
         cont.addButton("$mod.reloadmods", () -> {
             mods.requiresReload(true);
         }).visible(() -> {

--- a/core/src/io/anuke/mindustry/ui/dialogs/ModsDialog.java
+++ b/core/src/io/anuke/mindustry/ui/dialogs/ModsDialog.java
@@ -105,6 +105,11 @@ public class ModsDialog extends FloatingDialog{
         cont.clear();
         cont.defaults().width(mobile ? 500 : 560f).pad(4);
         cont.add("$mod.reloadrequired").visible(mods::requiresReload).center().get().setAlignment(Align.center);
+        cont.addButton("$mod.reloadmods", () -> {
+            mods.requiresReload(true);
+        }).visible(() -> {
+            return !mods.requiresReload(); // Analogous to !mods::requiresReload
+        }).center().get();
         cont.row();
         if(!mods.list().isEmpty()){
             cont.pane(table -> {


### PR DESCRIPTION
Currently, to reload mods you need to either:
* Restart Mindustry
* Disable a mod, scroll down to find it and enable it

This pr adds a Reload Mods button that does this all in 1 click.
(Ideally it would just "overlap" the Reload Required text when its not visible but we can't have nice things as it's beyond my knowledge)
See video for use [here](https://cdn.discordapp.com/attachments/396416151032299521/659121850630012949/Capture_195342.mp4).
