### PR TITLE
let boolean and double be used by mods

### DIFF
--- a/tools/src/mindustry/tools/ScriptStubGenerator.java
+++ b/tools/src/mindustry/tools/ScriptStubGenerator.java
@@ -24,7 +24,7 @@ public class ScriptStubGenerator{
         String base = "mindustry";
         Array<String> blacklist = Array.with("plugin", "mod", "net", "io", "tools");
         Array<String> nameBlacklist = Array.with("ClientLauncher", "NetClient", "NetServer", "ClassAccess");
-        Array<Class<?>> whitelist = Array.with(Draw.class, Fill.class, Lines.class, Core.class, TextureAtlas.class, TextureRegion.class, Time.class, System.class, PrintStream.class,
+        Array<Class<?>> whitelist = Array.with(Boolean.class, Double.class, Draw.class, Fill.class, Lines.class, Core.class, TextureAtlas.class, TextureRegion.class, Time.class, System.class, PrintStream.class,
             AtlasRegion.class, String.class, Mathf.class, Angles.class, Color.class, Runnable.class, Object.class, Icon.class, Tex.class,
             Sounds.class, Musics.class, Call.class, Texture.class, TextureData.class, Pixmap.class, I18NBundle.class, Interval.class, DataInput.class, DataOutput.class, DataInputStream.class, DataOutputStream.class);
         Array<String> nopackage = Array.with("java.lang", "java");


### PR DESCRIPTION
why do i even have to do this jesus christ
see my meltdown when scripting a multiple weapon mech for more context
before: crash because REEE YOU CANT USE java.lang.Boolean/Double
after: :) it work