### PR TITLE
make turnCursor: false mechs not cross eyed

### DIFF
--- a/core/src/mindustry/entities/type/Player.java
+++ b/core/src/mindustry/entities/type/Player.java
@@ -637,7 +637,7 @@ public class Player extends Unit implements BuilderMinerTrait, ShooterTrait{
         if(!state.isEditor() && isShooting() && mech.canShoot(this)){
             if(!mech.turnCursor){
                 //shoot forward ignoring cursor
-                mech.weapon.update(this, x + Angles.trnsx(rotation, 1f), y + Angles.trnsy(rotation, 1f));
+                mech.weapon.update(this, x + Angles.trnsx(rotation, mech.weapon.targetDistance), y + Angles.trnsy(rotation, mech.weapon.targetDistance));
             }else{
                 mech.weapon.update(this, pointerX, pointerY);
             }

--- a/core/src/mindustry/type/Weapon.java
+++ b/core/src/mindustry/type/Weapon.java
@@ -55,6 +55,8 @@ public class Weapon{
     public float shotDelay = 0;
     /** whether shooter rotation is ignored when shooting. */
     public boolean ignoreRotation = false;
+    /** if turnCursor is false for a mech, how far away will the weapon target. */
+    public float targetDistance = 1f;
 
     public Sound shootSound = Sounds.pew;
 


### PR DESCRIPTION
before it was hardcoded for a mech to target 1 unit in front of it if turnCursor was false
now, it can be configured (still 1 by default)
targetDistance variable lets you set how far a mech will try and shoot!