### PR TITLE
Estimate and display conveyor resource flow

### DIFF
--- a/core/src/mindustry/world/blocks/distribution/Conveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/Conveyor.java
@@ -254,22 +254,27 @@ public class Conveyor extends Block implements Autotiler{
         // TODO It seems, the better way is using the real framerate, rather
         // then simply 60
         float flowEstimationBegin = currentTime - flowEstimationWindow * 60.0f;
-        for(Item item: entity.itemHistory.keys()){
-            FloatArray itemHistory = entity.itemHistory.get(item);
-            int removeUpUntilIndex = -1;
-            for(int index = 0; index < itemHistory.size; index ++){
-                if(itemHistory.get(index) < flowEstimationBegin){
-                    removeUpUntilIndex = index;
-                }else{
-                    break;
+        for(ObjectMap.Entry<Item, FloatArray> entry: entity.itemHistory){
+            Item item = entry.key;
+            FloatArray itemHistory = entry.value;
+            if(itemHistory.size > 0){
+                int removeUpUntilIndex = -1;
+                for(int index = 0; index < itemHistory.size; index ++){
+                    if(itemHistory.get(index) < flowEstimationBegin){
+                        removeUpUntilIndex = index;
+                    }else{
+                        break;
+                    }
                 }
-            }
-            if(removeUpUntilIndex >= 0){
-                itemHistory.removeRange(0, removeUpUntilIndex);
-            }
+                if(removeUpUntilIndex >= 0){
+                    itemHistory.removeRange(0, removeUpUntilIndex);
+                }
 
-            float flow = itemHistory.size / flowEstimationWindow;
-            entity.flowPerItem.put(item, flow);
+                float flow = itemHistory.size / flowEstimationWindow;
+                entity.flowPerItem.put(item, flow);
+            }else{
+                entity.flowPerItem.put(item, 0.0f);
+            }
         }
 
     }

--- a/core/src/mindustry/world/blocks/distribution/Conveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/Conveyor.java
@@ -6,6 +6,7 @@ import arc.func.*;
 import arc.graphics.g2d.*;
 import arc.math.*;
 import arc.math.geom.*;
+import arc.scene.ui.layout.*;
 import arc.util.*;
 import mindustry.content.*;
 import mindustry.entities.traits.BuilderTrait.*;
@@ -368,6 +369,21 @@ public class Conveyor extends Block implements Autotiler{
         //this item must be greater than anything there...
         entity.convey.add(result);
         entity.lastInserted = (byte)(entity.convey.size - 1);
+    }
+
+    @Override
+    public void display(Tile tile, Table table){
+        super.display(tile, table);
+
+        ConveyorEntity entity = tile.ent();
+        if(entity != null){
+            table.row();
+            table.table().update(flowTable -> {
+                flowTable.clear();
+                flowTable.add("Flow").left().growX();
+                flowTable.add(entity.flow + "/s");
+            }).growX();
+        }
     }
 
     public static class ConveyorEntity extends TileEntity{

--- a/core/src/mindustry/world/blocks/distribution/Conveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/Conveyor.java
@@ -258,8 +258,9 @@ public class Conveyor extends Block implements Autotiler{
             FloatArray itemHistory = entity.itemHistory.get(item);
             int removeUpUntilIndex = -1;
             for(int index = 0; index < itemHistory.size; index ++){
-                if(itemHistory.get(index) >= flowEstimationBegin){
-                    removeUpUntilIndex = index - 1;
+                if(itemHistory.get(index) < flowEstimationBegin){
+                    removeUpUntilIndex = index;
+                }else{
                     break;
                 }
             }

--- a/core/src/mindustry/world/blocks/distribution/Conveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/Conveyor.java
@@ -330,12 +330,6 @@ public class Conveyor extends Block implements Autotiler{
 
     @Override
     public boolean acceptItem(Item item, Tile tile, Tile source){
-        if(item != null){
-            ConveyorEntity entity = tile.ent();
-            float currentTime = Time.time();
-            FloatArray flowItemHistory = entity.flowItemHistory;
-            flowItemHistory.add(currentTime);
-        }
         int direction = source == null ? 0 : Math.abs(source.relativeTo(tile.x, tile.y) - tile.rotation());
         float minitem = tile.<ConveyorEntity>ent().minitem;
         return (((direction == 0) && minitem > itemSpace) ||
@@ -344,6 +338,11 @@ public class Conveyor extends Block implements Autotiler{
 
     @Override
     public void handleItem(Item item, Tile tile, Tile source){
+        ConveyorEntity entity = tile.ent();
+        float currentTime = Time.time();
+        FloatArray flowItemHistory = entity.flowItemHistory;
+        flowItemHistory.add(currentTime);
+
         byte rotation = tile.rotation();
 
         int ch = Math.abs(source.relativeTo(tile.x, tile.y) - rotation);
@@ -352,7 +351,6 @@ public class Conveyor extends Block implements Autotiler{
         float pos = ch == 0 ? 0 : ch % 2 == 1 ? 0.5f : 1f;
         float y = (ang == -1 || ang == 3) ? 1 : (ang == 1 || ang == -3) ? -1 : 0;
 
-        ConveyorEntity entity = tile.ent();
         entity.noSleep();
         long result = ItemPos.packItem(item, y * 0.9f, pos);
 

--- a/core/src/mindustry/world/blocks/distribution/Conveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/Conveyor.java
@@ -272,6 +272,10 @@ public class Conveyor extends Block implements Autotiler{
 
                 float flow = itemHistory.size / flowEstimationWindow;
                 entity.flowPerItem.put(item, flow);
+
+                // Reset sleep timer, otherwise the flow estimation won't
+                // converge to zero before the tile turned to sleep
+                entity.noSleep();
             }else{
                 entity.flowPerItem.put(item, 0.0f);
             }

--- a/core/src/mindustry/world/blocks/distribution/Conveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/Conveyor.java
@@ -27,6 +27,9 @@ import static mindustry.Vars.*;
 public class Conveyor extends Block implements Autotiler{
     private static final float itemSpace = 0.4f;
     private static final float minmove = 1f / (Short.MAX_VALUE - 2);
+    // Longer window makes the estimation less responsinve, while shorter
+    // window makes it less precise
+    private static final float flowEstimationWindow = 10.0f; // seconds
     private static ItemPos drawpos = new ItemPos();
     private static ItemPos pos1 = new ItemPos();
     private static ItemPos pos2 = new ItemPos();
@@ -248,9 +251,6 @@ public class Conveyor extends Block implements Autotiler{
         if(minremove != Integer.MAX_VALUE) entity.convey.truncate(minremove);
 
         float currentTime = Time.time();
-        // Longer window makes the estimation less responsinve, while
-        // shorter window makes it less precise
-        float flowEstimationWindow = 10.0f;
         // TODO It seems, the better way is using the real framerate, rather
         // then simply 60
         float flowEstimationBegin = currentTime - flowEstimationWindow * 60.0f;


### PR DESCRIPTION
Motivation

Knowing an approximate amount of resources, traveled through a conveyor block, may give an insight on how many upstream consumer blocks need to be built to exploit the whole flow capacity. Also it may tell, whether the conveyor is going to be clogged, if not enough consumers were built.

The flow per each item is being shown in the PlacementFragment, when the mouse hovers above a conveyor block:
![video](https://user-images.githubusercontent.com/6650803/71644007-5654cc00-2cfc-11ea-8d5b-26e4b2d10e78.gif)


Should it be optional for each block? For example, by having a block configuration UI, that turns on/off the function. This may save some CPU time and memory.