### PR TITLE
Use current directory explicitly for bundle updator

### DIFF
--- a/tools/src/mindustry/tools/BundleLauncher.java
+++ b/tools/src/mindustry/tools/BundleLauncher.java
@@ -15,7 +15,7 @@ public class BundleLauncher{
         OrderedMap<String, String> base = new OrderedMap<>();
         PropertiesUtils.load(base, new InputStreamReader(new FileInputStream(file)));
         Array<String> removals = new Array<>();
-        Fi.get("").walk(child -> {
+        Fi.get(".").walk(child -> {
             if(child.name().equals("bundle.properties") || child.isDirectory() || child.toString().contains("output"))
                 return;
 


### PR DESCRIPTION
> it ~~works~~ broke on my machine

Something i ran into with the bundles, this apparently fixed it 🤔 (on a mac)

```
Exception in thread "main" arc.util.ArcRuntimeException: Error reading file:  (absolute)
        at arc.files.Fi.read(Fi.java:207)
        at arc.files.Fi.reader(Fi.java:255)
        at mindustry.tools.BundleLauncher.lambda$main$1(BundleLauncher.java:25)
        at arc.files.Fi.walk(Fi.java:537)
        at mindustry.tools.BundleLauncher.main(BundleLauncher.java:18)
Caused by: java.io.FileNotFoundException:  (No such file or directory)
        at java.base/java.io.FileInputStream.open0(Native Method)
        at java.base/java.io.FileInputStream.open(FileInputStream.java:196)
        at java.base/java.io.FileInputStream.<init>(FileInputStream.java:139)
        at arc.files.Fi.read(Fi.java:203)
        ... 4 more
```