### PR TITLE
[sandbox] ability to switch team

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -777,6 +777,8 @@ rules.title.unit = Units
 rules.title.experimental = Experimental
 rules.lighting = Lighting
 rules.ambientlight = Ambient Light
+rules.bipartisan.all = Players can switch teams
+rules.bipartisan.admin = Admins can switch teams
 
 content.item.name = Items
 content.liquid.name = Liquids

--- a/core/src/mindustry/game/Rules.java
+++ b/core/src/mindustry/game/Rules.java
@@ -88,6 +88,8 @@ public class Rules{
     public Team waveTeam = Team.crux;
     /** special tags for additional info */
     public StringMap tags = new StringMap();
+    /** wether players can switch teams: 0 = not, 1 = admins, 2 = all */
+    public int bipartisan = 0;
 
     /** Copies this ruleset exactly. Not very efficient at all, do not use often. */
     public Rules copy(){

--- a/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
+++ b/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
@@ -184,6 +184,10 @@ public class CustomRulesDialog extends FloatingDialog{
             b.add("$rules.ambientlight");
         }, () -> ui.picker.show(rules.ambientLight, rules.ambientLight::set)).left().width(250f);
         main.row();
+        
+        check("$rules.bipartisan.all", b -> rules.bipartisan = b ? 2 : 0, () -> rules.bipartisan == 2, () -> rules.bipartisan != 1);
+        main.row();
+        check("$rules.bipartisan.admin", b -> rules.bipartisan = b ? 1 : 0, () -> rules.bipartisan == 1);
     }
 
     void number(String text, Floatc cons, Floatp prov){

--- a/core/src/mindustry/ui/fragments/HudFragment.java
+++ b/core/src/mindustry/ui/fragments/HudFragment.java
@@ -161,8 +161,9 @@ public class HudFragment extends Fragment{
             }
 
             {
-                editorMain.table(Tex.buttonEdge4, t -> {
-                    //t.margin(0f);
+                editorMain.table(Tex.clear, t -> {
+                    t.marginTop(wavesMain.getPrefHeight());
+                    t.marginLeft(10f);
                     t.add("$editor.teams").growX().left();
                     t.row();
                     t.table(teams -> {
@@ -234,7 +235,7 @@ public class HudFragment extends Fragment{
                         });
                     }
                 }).width(dsize * 5 + 4f);
-                editorMain.visible(() -> shown && state.isEditor());
+                editorMain.visible(() -> shown && state.isEditor() || (state.rules.bipartisan == 2 || (state.rules.bipartisan == 1 && player.isAdmin)));
             }
 
             //fps display
@@ -346,7 +347,7 @@ public class HudFragment extends Fragment{
 
     @Remote(targets = Loc.both, forward = true, called = Loc.both)
     public static void setPlayerTeamEditor(Player player, Team team){
-        if(state.isEditor() && player != null){
+        if((state.isEditor() || (state.rules.bipartisan == 2 || (state.rules.bipartisan == 1 && player.isAdmin))) && player != null){
             player.setTeam(team);
         }
     }


### PR DESCRIPTION
> proof of concept, ui is dirty, code could probably need some work, etc, etc

While testing out the plastanium conveyors on my test server the other day (well, actually today) the thought occurred to me that i could merge my other concepts in there as well (e.g. the tractor beam), but that would only be fun to play with if players could switch between teams.

This is currently only possible if the mode is set to editor, but it would make sense to allow this for sandbox mode (though not by default) as well.

But to prevent abuse its possible to allow only admins to switch teams (in this initial draft)

Not all quadrillion team colors are supported, just the basis 6.

![Screen Shot 2020-01-05 at 15 09 49](https://user-images.githubusercontent.com/3179271/71781335-d6fe1b80-2fcd-11ea-8d12-71ac1ed82274.png)
![Screen Shot 2020-01-05 at 15 11 44](https://user-images.githubusercontent.com/3179271/71781336-d8c7df00-2fcd-11ea-955f-b7c0c21c09f5.png)

> the player option greys out if admin below it is selected* 🥔 