### PR TITLE
[drones] miner drone dropoff

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -1627,7 +1627,7 @@ public class Blocks implements ContentList{
         //endregion
         //region units
 
-        draugFactory = new UnitFactory("draug-factory"){{
+        draugFactory = new MinerFactory("draug-factory"){{
             requirements(Category.units, ItemStack.with(Items.copper, 30, Items.lead, 70));
             unitType = UnitTypes.draug;
             produceTime = 2500;

--- a/core/src/mindustry/entities/type/base/MinerDrone.java
+++ b/core/src/mindustry/entities/type/base/MinerDrone.java
@@ -176,4 +176,9 @@ public class MinerDrone extends BaseDrone implements MinerTrait{
         }
         targetItem = Structs.findMin(type.toMine, indexer::hasOre, (a, b) -> -Integer.compare(entity.items.get(a), entity.items.get(b)));
     }
+
+    @Override
+    public TileEntity getClosestCore(){
+        return getSpawner().entity;
+    }
 }

--- a/core/src/mindustry/world/blocks/units/MinerFactory.java
+++ b/core/src/mindustry/world/blocks/units/MinerFactory.java
@@ -1,0 +1,31 @@
+package mindustry.world.blocks.units;
+
+import mindustry.type.*;
+import mindustry.world.*;
+
+public class MinerFactory extends UnitFactory{
+    public MinerFactory(String name){
+        super(name);
+    }
+
+    @Override
+    public boolean acceptItem(Item item, Tile tile, Tile source){
+        if(tile != source) return false;
+        if(!unitType.toMine.contains(item)) return false;
+
+        return tile.entity.items.get(item) < getMaximumAccepted(tile, item);
+    }
+
+    @Override
+    public int getMaximumAccepted(Tile tile, Item item){
+        if(!unitType.toMine.contains(item)) return 0;
+        return 50;
+    }
+
+    @Override
+    public void update(Tile tile){
+        super.update(tile);
+
+        tryDump(tile);
+    }
+}


### PR DESCRIPTION
> proof of concept, code is not all that serious, this is to kickstart the topic :)

instead of placing the miner drones in the far edges of the map to get free minerals until the end of time, changes them so you actually have to take the items out of them one way or another.

its been discussed a few times to have a dedicated drop off point, but it would probably make most sense to make them drop off at their spawnpoint or cointainers right next to it.

this probably won't go well for drones that require items to spawn since it will unload.

but this would allow for some more precise mining drone usage, since you can get the right amount of copper/lead from anywhere in the map, instead of finding a patch or unloading it from the core 10 miles away.

![Screen Shot 2020-01-06 at 12 33 12](https://user-images.githubusercontent.com/3179271/71815795-e7230300-3080-11ea-9b0b-32e997421d2a.png)

🥔 