### PR TITLE
[quality of life] mass driver place range assist

### DIFF
--- a/core/src/mindustry/world/blocks/distribution/MassDriver.java
+++ b/core/src/mindustry/world/blocks/distribution/MassDriver.java
@@ -162,6 +162,16 @@ public class MassDriver extends Block{
     @Override
     public void drawPlace(int x, int y, int rotation, boolean valid){
         Drawf.dashCircle(x * tilesize, y*tilesize, range, Pal.accent);
+
+        // check if a mass driver is selected while placing this driver
+        if(!control.input.frag.config.isShown()) return;
+        Tile selected = control.input.frag.config.getSelectedTile();
+        if(!(selected.block() instanceof MassDriver) || !(selected.dst(x * tilesize, y * tilesize) <= range)) return;
+
+        // if so, draw a dotted line towards it while it is in range
+        Lines.stroke(2f, Pal.placing);
+        Lines.dashLine(x * tilesize, y * tilesize, selected.drawx(), selected.drawy(), (int)range / tilesize / 4);
+        Draw.reset();
     }
 
     @Override


### PR DESCRIPTION
> line size/color/divisions/etc will probably need tweaking

Just a small quality of life thing, the ability to see if the driver you're trying to place is actually in range of the one you have selected, especially when you try to place one right on the edge 🤔 

![Jan-06-2020 17-07-49](https://user-images.githubusercontent.com/3179271/71830479-1ba9b580-30a7-11ea-86bc-a53fa7ef6428.gif)
