### PR TITLE
[quality of life] don't rebuild shock mines

### DIFF
--- a/core/src/mindustry/core/Logic.java
+++ b/core/src/mindustry/core/Logic.java
@@ -47,8 +47,8 @@ public class Logic implements ApplicationListener{
             //blocks that get broken are appended to the team's broken block queue
             Tile tile = event.tile;
             Block block = tile.block();
-            //skip null entities or nukes, for obvious reasons; also skip client since they can't modify these requests
-            if(tile.entity == null || tile.block() instanceof NuclearReactor || net.client()) return;
+            //skip null entities or un-rebuildables, for obvious reasons; also skip client since they can't modify these requests
+            if(tile.entity == null || !tile.block().rebuildable || net.client()) return;
 
             if(block instanceof BuildBlock){
 

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -55,6 +55,8 @@ public class Block extends BlockStorage{
     public boolean rotate;
     /** whether you can break this with rightclick */
     public boolean breakable;
+    /** whether to add this block to brokenblocks */
+    public boolean rebuildable = true;
     /** whether this floor can be placed on. */
     public boolean placeableOn = true;
     /** whether this block has insulating properties. */

--- a/core/src/mindustry/world/blocks/defense/ShockMine.java
+++ b/core/src/mindustry/world/blocks/defense/ShockMine.java
@@ -26,6 +26,7 @@ public class ShockMine extends Block{
         solid = false;
         targetable = false;
         layer = Layer.overlay;
+        rebuildable = false;
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/power/NuclearReactor.java
+++ b/core/src/mindustry/world/blocks/power/NuclearReactor.java
@@ -46,6 +46,7 @@ public class NuclearReactor extends PowerGenerator{
         hasItems = true;
         hasLiquids = true;
         entityType = NuclearReactorEntity::new;
+        rebuildable = false;
     }
 
     @Override


### PR DESCRIPTION
When playing on a server, its almost impossible to stop phantom drones from rebuilding shock mines near a defensive line that has fallen (since client doesn't sync brokenblocks with the server), this pull changes the rebuildable check from hardcoded to the reactor to being a block property, as well as adding the shock mine to the ignore list.

<img width="456" alt="Screen Shot 2020-01-08 at 16 22 21" src="https://user-images.githubusercontent.com/3179271/71990089-12e5ea80-3233-11ea-8efb-e3af16645e9d.png">
