### PR TITLE
[quality of life] visualize solar panel efficiency

### DIFF
--- a/core/src/mindustry/world/blocks/power/SolarGenerator.java
+++ b/core/src/mindustry/world/blocks/power/SolarGenerator.java
@@ -1,7 +1,10 @@
 package mindustry.world.blocks.power;
 
+import arc.*;
 import arc.struct.*;
+import mindustry.ui.*;
 import mindustry.world.*;
+import mindustry.graphics.*;
 import mindustry.world.meta.*;
 
 import static mindustry.Vars.state;
@@ -26,5 +29,20 @@ public class SolarGenerator extends PowerGenerator{
         // Solar Generators don't really have an efficiency (yet), so for them 100% = 1.0f
         stats.remove(generationType);
         stats.add(generationType, powerProduction * 60.0f, StatUnit.powerSecond);
+    }
+
+    @Override
+    public void drawPlace(int x, int y, int rotation, boolean valid){
+        drawPlaceText(Core.bundle.formatFloat("bar.efficiency", (state.rules.lighting ? 1f - state.rules.ambientLight.a : 1f) * 100, 0), x, y, valid);
+    }
+
+    @Override
+    public void setBars(){
+        super.setBars();
+
+        bars.add("efficiency", entity -> new Bar(
+        () -> Core.bundle.formatFloat("bar.efficiency", ((GeneratorEntity)entity).productionEfficiency * 100f, 0),
+        () -> Pal.ammo,
+        () -> ((GeneratorEntity)entity).productionEfficiency));
     }
 }


### PR DESCRIPTION
> makes it (more) clear that on darker maps solar panels produce less power.

<img width="560" alt="Screen Shot 2020-01-10 at 18 16 17" src="https://user-images.githubusercontent.com/3179271/72173510-077ff400-33d8-11ea-8c1b-01f94e6d8e77.png">

![Screen Shot 2020-01-10 at 18 35 06](https://user-images.githubusercontent.com/3179271/72173525-0ea70200-33d8-11ea-8d6e-af68105ea8c3.png)

![Screen Shot 2020-01-10 at 18 35 12](https://user-images.githubusercontent.com/3179271/72173536-14044c80-33d8-11ea-9fb6-5171e206c2ef.png)

> not sure if this "should" be merged, since lighting is still listed as experimental.