### PR TITLE
Fixed BlockBuildEndEvent sometimes not firing in multiplayer

### DIFF
--- a/core/src/mindustry/world/blocks/BuildBlock.java
+++ b/core/src/mindustry/world/blocks/BuildBlock.java
@@ -65,6 +65,8 @@ public class BuildBlock extends Block{
     @Remote(called = Loc.server)
     public static void onConstructFinish(Tile tile, Block block, int builderID, byte rotation, Team team, boolean skipConfig){
         if(tile == null) return;
+        
+        Events.fire(new BlockBuildEndEvent(tile, playerGroup.getByID(builderID), team, false));
         float healthf = tile.entity == null ? 1f : tile.entity.healthf();
         tile.set(block, team, rotation);
         if(tile.entity != null){
@@ -107,7 +109,6 @@ public class BuildBlock extends Block{
         Call.onConstructFinish(tile, block, builderID, rotation, team, skipConfig);
         tile.block().placed(tile);
 
-        Events.fire(new BlockBuildEndEvent(tile, playerGroup.getByID(builderID), team, false));
         if(shouldPlay()) Sounds.place.at(tile, calcPitch(true));
     }
 


### PR DESCRIPTION
BlockBuildEndEvent really seemed unpredictabe when building in multiplayer, sometimes firing, sometimes not. After i moved it to onConstructFinish() method, it seems like it works every time. Not sure exactly how, because onConstructFinish() was only ever called in constructed(), but it fixed it