### PR TITLE
[quality of life] impact reactor startup sequence

### DIFF
--- a/core/src/mindustry/world/blocks/power/ImpactReactor.java
+++ b/core/src/mindustry/world/blocks/power/ImpactReactor.java
@@ -71,7 +71,7 @@ public class ImpactReactor extends PowerGenerator{
     public void update(Tile tile){
         FusionReactorEntity entity = tile.ent();
 
-        if(entity.cons.valid() && entity.power.status >= 0.99f){
+        if(entity.cons.valid() && entity.power.status >= 0.99f && (entity.warmup >= warmupSpeed * 0.9f || entity.items.total() >= itemCapacity)){
             boolean prevOut = getPowerProduction(tile) <= consumes.getPower().requestedPower(entity);
 
             entity.warmup = Mathf.lerpDelta(entity.warmup, 1f, warmupSpeed);


### PR DESCRIPTION
https://feathub.com/Anuken/Mindustry/+626

changes it so the impact reactor needs to be full of blast compound in order to begin starting up.
(once its startup animation has started it will continue spinning with any amount of blast*)

this should help greatly since impact reactors tend to omnomnom away if there's only 1 in them.
and it might also make it a bit easier to spot (potential) throughput issues, among other things.

![block-impact-reactor-full](https://user-images.githubusercontent.com/3179271/73294190-9d53b580-4205-11ea-832a-70b7715a2b83.png)

> picture is just here to make the pull request look a little less boring (^-^)