### PR TITLE
[Added] Dedicated Players command

### DIFF
--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -715,6 +715,18 @@ public class ServerControl implements ApplicationListener{
             }
         });
 
+        handler.register("players", "List all players currently in game.", arg -> {
+            if(playerGroup.size() == 0){
+                info("No players are currently in the server.");
+            }else{
+                info("&lyPlayers: {0}", playerGroup.size());
+                for(Player user : playerGroup){
+                    PlayerInfo userInfo = user.getInfo();
+                    info(" &lm {0} /  ID: '{1}' / IP: '{2}' / Admin: '{3}'", userInfo.lastName, userInfo.id, userInfo.lastIP, userInfo.admin);
+                }
+            }
+        });
+
         handler.register("runwave", "Trigger the next wave.", arg -> {
             if(!state.is(State.playing)){
                 err("Not hosting. Host a game first.");


### PR DESCRIPTION
**What does it add**
Add's a 'players' command for servers to use. Lists info such as username, id, ip and if they are an admin.

**Why add it?**
Currently you can view the current players with 'status', but it only display's a minimal amount of info. Along with that it's not clear that there is a player command, even if status does it. A command dedicated to listing players is always useful.

**Does it compile and work?**
Tested local host (server build)
No players joined, 0 users
Player joined, 1 users
Player left, 0 users