### PR TITLE
controlled script loading

### DIFF
--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -317,7 +317,7 @@ public class Mods implements Loadable{
         return result;
     }
 
-    private LoadedMod locateMod(String name){
+    public LoadedMod locateMod(String name){
         return mods.find(mod -> mod.enabled() && mod.name.equals(name));
     }
 

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -795,7 +795,7 @@ public class Mods implements Loadable{
 
     /** Plugin metadata information.*/
     public static class ModMeta{
-        public String name, displayName, author, description, version, main, minGameVersion, mainScript;
+        public String name, displayName, author, description, version, main, minGameVersion;
         public Array<String> dependencies = Array.with();
         /** Hidden mods are only server-side or client-side, and do not support adding new content. */
         public boolean hidden;

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -475,7 +475,7 @@ public class Mods implements Loadable{
 						}
 					}else{
 						Core.app.post(() -> {
-							Log.err("No main.js found for mod {1}.", mod.meta.name);
+							Log.err("No main.js found for mod {0}.", mod.meta.name);
 						});
 					}
                 }

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -479,7 +479,7 @@ public class Mods implements Loadable{
                             }
                         }
                     }else{
-                        Fi file = new Fi(mod.meta.mainScript + ".js");
+                        Fi file = mod.root.child("scripts").child(mod.meta.mainScript + ".js");
                         try{
                             if(scripts == null){
                                 scripts = platform.createScripts();

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -479,7 +479,7 @@ public class Mods implements Loadable{
                             }
                         }
                     }else{
-                        Fi file = new Fi(mod.meta.mainscript + ".js");
+                        Fi file = new Fi(mod.meta.mainScript + ".js");
                         try{
                             if(scripts == null){
                                 scripts = platform.createScripts();
@@ -488,7 +488,7 @@ public class Mods implements Loadable{
                         }catch(Throwable e){
                             Core.app.post(() -> {
                                 Log.err("Error loading main script {0} for mod {1}.", file.name(), mod.meta.name);
-                                e.printStacktrace();
+                                e.printStackTrace();
                             });
                         }
                     }

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -460,24 +460,24 @@ public class Mods implements Loadable{
             eachEnabled(mod -> {
                 if(mod.root.child("scripts").exists()){
                     content.setCurrentMod(mod);
-					Fi main = mod.root.child("scripts").child("main.js");
-					if(main.exists() && !main.isDirectory()){
-						try{
-							if(scripts == null){
-								scripts = platform.createScripts();
-							}
-							scripts.run(mod, main);
-						}catch(Throwable e){
-							Core.app.post(() -> {
-								Log.err("Error loading main script {0} for mod {1}.", main.name(), mod.meta.name);
-								e.printStackTrace();
-							});
-						}
-					}else{
-						Core.app.post(() -> {
-							Log.err("No main.js found for mod {0}.", mod.meta.name);
-						});
-					}
+                    Fi main = mod.root.child("scripts").child("main.js");
+                    if(main.exists() && !main.isDirectory()){
+                        try{
+                            if(scripts == null){
+                                scripts = platform.createScripts();
+                            }
+                            scripts.run(mod, main);
+                        }catch(Throwable e){
+                            Core.app.post(() -> {
+                                Log.err("Error loading main script {0} for mod {1}.", main.name(), mod.meta.name);
+                                e.printStackTrace();
+                            });
+                        }
+                    }else{
+                        Core.app.post(() -> {
+                            Log.err("No main.js found for mod {0}.", mod.meta.name);
+                        });
+                    }
                 }
             });
         }finally{

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -460,38 +460,24 @@ public class Mods implements Loadable{
             eachEnabled(mod -> {
                 if(mod.root.child("scripts").exists()){
                     content.setCurrentMod(mod);
-                    if(mod.meta.mainScript == null){
-                        mod.scripts = mod.root.child("scripts").findAll(f -> f.extension().equals("js"));
-                        Log.debug("[{0}] Found {1} scripts.", mod.meta.name, mod.scripts.size);
-
-                        for(Fi file : mod.scripts){
-                            try{
-                                if(scripts == null){
-                                    scripts = platform.createScripts();
-                                }
-                                scripts.run(mod, file);
-                            }catch(Throwable e){
-                                Core.app.post(() -> {
-                                    Log.err("Error loading script {0} for mod {1}.", file.name(), mod.meta.name);
-                                    e.printStackTrace();
-                                });
-                                break;
-                            }
-                        }
-                    }else{
-                        Fi file = mod.root.child("scripts").child(mod.meta.mainScript + ".js");
-                        try{
-                            if(scripts == null){
-                                scripts = platform.createScripts();
-                            }
-                            scripts.run(mod, file);
-                        }catch(Throwable e){
-                            Core.app.post(() -> {
-                                Log.err("Error loading main script {0} for mod {1}.", file.name(), mod.meta.name);
-                                e.printStackTrace();
-                            });
-                        }
-                    }
+					Fi main = mod.root.child("scripts").child("main.js");
+					if(main.exists() && !main.isDirectory()){
+						try{
+							if(scripts == null){
+								scripts = platform.createScripts();
+							}
+							scripts.run(mod, main);
+						}catch(Throwable e){
+							Core.app.post(() -> {
+								Log.err("Error loading main script {0} for mod {1}.", main.name(), mod.meta.name);
+								e.printStackTrace();
+							});
+						}
+					}else{
+						Core.app.post(() -> {
+							Log.err("No main.js found for mod {1}.", mod.meta.name);
+						});
+					}
                 }
             });
         }finally{

--- a/core/src/mindustry/mod/Scripts.java
+++ b/core/src/mindustry/mod/Scripts.java
@@ -107,7 +107,7 @@ public class Scripts implements Disposable{
     }
 
     private class ScriptModuleProvider extends UrlModuleSourceProvider{
-		private Pattern directory = Pattern.compile("^(.+?)/(.+)");
+        private Pattern directory = Pattern.compile("^(.+?)/(.+)");
         public ScriptModuleProvider(){
             super(null, null);
         }
@@ -119,19 +119,19 @@ public class Scripts implements Disposable{
         }
 
         private ModuleSource loadSource(LoadedMod mod, String moduleId, Fi root, Object validator) throws IOException, URISyntaxException{
-			Matcher matched = directory.matcher(moduleId);
-			if(matched.find()){
-				LoadedMod required = Vars.mods.locateMod(matched.group(1));
-				String script = matched.group(2);
-				if(required == null || root == required.root.child("scripts")){ // Mod not found, or already using a mod
-					Fi dir = root.child(matched.group(1));
-					if(dir == null) return null; // Mod and folder not found
-					return loadSource(mod, script, dir, validator);
-				}
-				return loadSource(required, script, required.root.child("scripts"), validator);
-			}
+            Matcher matched = directory.matcher(moduleId);
+            if(matched.find()){
+                LoadedMod required = Vars.mods.locateMod(matched.group(1));
+                String script = matched.group(2);
+                if(required == null || root == required.root.child("scripts")){ // Mod not found, or already using a mod
+                    Fi dir = root.child(matched.group(1));
+                    if(dir == null) return null; // Mod and folder not found
+                    return loadSource(mod, script, dir, validator);
+                }
+                return loadSource(required, script, required.root.child("scripts"), validator);
+            }
 
-			Fi module = root.child(moduleId + ".js");
+            Fi module = root.child(moduleId + ".js");
             if(!module.exists() || module.isDirectory()) return null;
             return new ModuleSource(
                 new InputStreamReader(new ByteArrayInputStream((fillWrapper(module)).getBytes())),

--- a/core/src/mindustry/mod/Scripts.java
+++ b/core/src/mindustry/mod/Scripts.java
@@ -131,7 +131,7 @@ public class Scripts implements Disposable{
 				return loadSource(required, script, required.root.child("scripts"), validator);
 			}
 
-            Fi module = root.child(moduleId + ".js");
+			Fi module = root.child(moduleId + ".js");
             if(!module.exists() || module.isDirectory()) return null;
             return new ModuleSource(
                 new InputStreamReader(new ByteArrayInputStream((fillWrapper(module)).getBytes())),

--- a/core/src/mindustry/mod/Scripts.java
+++ b/core/src/mindustry/mod/Scripts.java
@@ -117,7 +117,7 @@ public class Scripts implements Disposable{
             if(!module.exists() || module.isDirectory()) return null;
             return new ModuleSource(
                 new InputStreamReader(new ByteArrayInputStream((fillWrapper(module)).getBytes())),
-                null, module.file().toURI(), null, validator);
+                null, new URI(moduleId), module.parent().file().toURI(), validator);
         }
     }
 }

--- a/core/src/mindustry/mod/Scripts.java
+++ b/core/src/mindustry/mod/Scripts.java
@@ -68,6 +68,10 @@ public class Scripts implements Disposable{
     }
 
     public void run(LoadedMod mod, Fi file){
+        new RequireBuilder()
+            .setModuleScriptProvider(new SoftCachingModuleScriptProvider(
+                new UrlModuleSourceProvider(Arrays.asList(new URI[] {file.child("scripts").file().toURI()}), null)))
+            .setSandboxed(true).createRequire(context, scope).install(scope);
         run(wrapper.replace("$SCRIPT_NAME$", mod.name + "/" + file.nameWithoutExtension()).replace("$CODE$", file.readString()).replace("$MOD_NAME$", mod.name), file.name());
     }
 

--- a/core/src/mindustry/mod/Scripts.java
+++ b/core/src/mindustry/mod/Scripts.java
@@ -81,6 +81,7 @@ public class Scripts implements Disposable{
     public void run(LoadedMod mod, Fi file){
         loadedMod = mod;
         run(fillWrapper(file), file.name());
+        loadedMod = null;
     }
 
     private boolean run(String script, String file){

--- a/core/src/mindustry/mod/Scripts.java
+++ b/core/src/mindustry/mod/Scripts.java
@@ -9,6 +9,7 @@ import arc.util.Log.*;
 import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.regex.*;
 import mindustry.*;
 import mindustry.mod.Mods.*;
 import org.mozilla.javascript.*;
@@ -106,6 +107,7 @@ public class Scripts implements Disposable{
     }
 
     private class ScriptModuleProvider extends UrlModuleSourceProvider{
+		private Pattern directory = Pattern.compile("^(.+?)/(.+)");
         public ScriptModuleProvider(){
             super(null, null);
         }
@@ -113,11 +115,27 @@ public class Scripts implements Disposable{
         @Override
         public ModuleSource loadSource(String moduleId, Scriptable paths, Object validator) throws IOException, URISyntaxException{
             if(loadedMod == null) return null;
-            Fi module = loadedMod.root.child("scripts").child(moduleId + ".js");
+            return loadSource(loadedMod, moduleId, loadedMod.root.child("scripts"), validator);
+        }
+
+        private ModuleSource loadSource(LoadedMod mod, String moduleId, Fi root, Object validator) throws IOException, URISyntaxException{
+			Matcher matched = directory.matcher(moduleId);
+			if(matched.find()){
+				LoadedMod required = Vars.mods.locateMod(matched.group(1));
+				String script = matched.group(2);
+				if(required == null || root == required.root.child("scripts")){ // Mod not found, or already using a mod
+					Fi dir = root.child(matched.group(1));
+					if(dir == null) return null; // Mod and folder not found
+					return loadSource(mod, script, dir, validator);
+				}
+				return loadSource(required, script, required.root.child("scripts"), validator);
+			}
+
+            Fi module = root.child(moduleId + ".js");
             if(!module.exists() || module.isDirectory()) return null;
             return new ModuleSource(
                 new InputStreamReader(new ByteArrayInputStream((fillWrapper(module)).getBytes())),
-                null, new URI(moduleId), module.parent().file().toURI(), validator);
+                null, new URI(moduleId), root.file().toURI(), validator);
         }
     }
 }

--- a/core/src/mindustry/mod/Scripts.java
+++ b/core/src/mindustry/mod/Scripts.java
@@ -5,9 +5,13 @@ import arc.files.*;
 import arc.struct.*;
 import arc.util.*;
 import arc.util.Log.*;
+import java.net.URI;
+import java.util.Arrays;
 import mindustry.*;
 import mindustry.mod.Mods.*;
 import org.mozilla.javascript.*;
+import org.mozilla.javascript.commonjs.module.*;
+import org.mozilla.javascript.commonjs.module.provider.*;
 
 public class Scripts implements Disposable{
     private final Array<String> blacklist = Array.with("net", "files", "reflect", "javax", "rhino", "file", "channels", "jdk",

--- a/core/src/mindustry/mod/Scripts.java
+++ b/core/src/mindustry/mod/Scripts.java
@@ -108,6 +108,7 @@ public class Scripts implements Disposable{
 
     private class ScriptModuleProvider extends UrlModuleSourceProvider{
         private Pattern directory = Pattern.compile("^(.+?)/(.+)");
+
         public ScriptModuleProvider(){
             super(null, null);
         }
@@ -125,7 +126,7 @@ public class Scripts implements Disposable{
                 String script = matched.group(2);
                 if(required == null || root == required.root.child("scripts")){ // Mod not found, or already using a mod
                     Fi dir = root.child(matched.group(1));
-                    if(dir == null) return null; // Mod and folder not found
+                    if(!dir.exists()) return null; // Mod and folder not found
                     return loadSource(mod, script, dir, validator);
                 }
                 return loadSource(required, script, required.root.child("scripts"), validator);


### PR DESCRIPTION
If `mainScript` is defined, it will just load the scripts/<mainScript>.js file instead of all files in scripts/
Also lets mods use `require("script");` to load files under scripts, at their discretion.

CURRENTLY NO SECURITY AT ALL //todo //pls check maybe arc does a thing

-------
scripts/main.js is now required. it will be loaded first, after that you can use `require("script")` for scripts/script.js, `require("folder/script")` for scripts/folder/script.js, `require("mod/script")`, etc.
please do not do `require("main")` it will stack overflow