### PR TITLE
Gitignore update: mods/ and .bat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,5 @@ gradle-app.setting
 .DS_Store
 Thumbs.db
 android/libs/
+mods/
+*.bat

--- a/core/assets/bundles/bundle_cs.properties
+++ b/core/assets/bundles/bundle_cs.properties
@@ -104,6 +104,7 @@ mods.none = [lightgray]Modifikace nebyly nalezeny.[]
 mods.guide = Průvodce modifikacemi
 mods.report = Nahlásit závadu
 mods.openfolder = Otevřít složku s modifikacemi
+mod.display = [gray]Modifikace:[][orange] {0}[]
 mod.enabled = [lightgray]Povoleno[]
 mod.disabled = [scarlet]Zakázáno[]
 mod.disable = Zakázat

--- a/fastlane/metadata/android/cs-CZ/changelogs/103.1.txt
+++ b/fastlane/metadata/android/cs-CZ/changelogs/103.1.txt
@@ -1,0 +1,9 @@
+- Přidány nové ikony s hladkým škálováním
+- Přidána černá díra na kapaliny (přispěno uživatelem @GioIacca9)
+- Přidáno nastavení průsvitnosti přemostění přepravníku (přispěno uživatelem @Quezler)
+- Přidána brána s podtokem (protikus k bráně s přetečením)
+- Přidány emotikony do kanálu zpráv, pro většinu bloků a předmětů
+- Přidán nový strom technologií, s lepší podporou pro modifikace
+- Přidán soubor s logem hry, uložený v adresáři s daty
+- Přidán nová oddělovat pro sprity a animace (ocená modéři)
+- Přidán seznam synergetických dlaždic do statistik některých bloků (viz například vrt na vodu)

--- a/fastlane/metadata/android/cs-CZ/changelogs/103.1.txt
+++ b/fastlane/metadata/android/cs-CZ/changelogs/103.1.txt
@@ -5,5 +5,5 @@
 - Přidány emotikony do kanálu zpráv, pro většinu bloků a předmětů
 - Přidán nový strom technologií, s lepší podporou pro modifikace
 - Přidán soubor s logem hry, uložený v adresáři s daty
-- Přidán nová oddělovat pro sprity a animace (ocená modéři)
+- Přidán nový oddělovač pro sprity a animace (ocení modéři)
 - Přidán seznam synergetických dlaždic do statistik některých bloků (viz například vrt na vodu)

--- a/fastlane/metadata/android/cs-CZ/changelogs/103.2.txt
+++ b/fastlane/metadata/android/cs-CZ/changelogs/103.2.txt
@@ -1,0 +1,9 @@
+- Přidány nové ikony s hladkým škálováním
+- Přidána černá díra na kapaliny (přispěno uživatelem @GioIacca9)
+- Přidáno nastavení průsvitnosti přemostění přepravníku (přispěno uživatelem @Quezler)
+- Přidána brána s podtokem (protikus k bráně s přetečením)
+- Přidány emotikony do kanálu zpráv, pro většinu bloků a předmětů
+- Přidán nový strom technologií, s lepší podporou pro modifikace
+- Přidán soubor s logem hry, uložený v adresáři s daty
+- Přidán nová oddělovat pro sprity a animace (ocená modéři)
+- Přidán seznam synergetických dlaždic do statistik některých bloků (viz například vrt na vodu)

--- a/fastlane/metadata/android/cs-CZ/changelogs/103.2.txt
+++ b/fastlane/metadata/android/cs-CZ/changelogs/103.2.txt
@@ -5,5 +5,5 @@
 - Přidány emotikony do kanálu zpráv, pro většinu bloků a předmětů
 - Přidán nový strom technologií, s lepší podporou pro modifikace
 - Přidán soubor s logem hry, uložený v adresáři s daty
-- Přidán nová oddělovat pro sprity a animace (ocená modéři)
+- Přidán nový oddělovač pro sprity a animace (ocení modéři)
 - Přidán seznam synergetických dlaždic do statistik některých bloků (viz například vrt na vodu)

--- a/fastlane/metadata/android/cs-CZ/changelogs/103.3.txt
+++ b/fastlane/metadata/android/cs-CZ/changelogs/103.3.txt
@@ -1,0 +1,9 @@
+- Přidány nové ikony s hladkým škálováním
+- Přidána černá díra na kapaliny (přispěno uživatelem @GioIacca9)
+- Přidáno nastavení průsvitnosti přemostění přepravníku (přispěno uživatelem @Quezler)
+- Přidána brána s podtokem (protikus k bráně s přetečením)
+- Přidány emotikony do kanálu zpráv, pro většinu bloků a předmětů
+- Přidán nový strom technologií, s lepší podporou pro modifikace
+- Přidán soubor s logem hry, uložený v adresáři s daty
+- Přidán nová oddělovat pro sprity a animace (ocená modéři)
+- Přidán seznam synergetických dlaždic do statistik některých bloků (viz například vrt na vodu)

--- a/fastlane/metadata/android/cs-CZ/changelogs/103.3.txt
+++ b/fastlane/metadata/android/cs-CZ/changelogs/103.3.txt
@@ -5,5 +5,5 @@
 - Přidány emotikony do kanálu zpráv, pro většinu bloků a předmětů
 - Přidán nový strom technologií, s lepší podporou pro modifikace
 - Přidán soubor s logem hry, uložený v adresáři s daty
-- Přidán nová oddělovat pro sprity a animace (ocená modéři)
+- Přidán nový oddělovač pro sprity a animace (ocení modéři)
 - Přidán seznam synergetických dlaždic do statistik některých bloků (viz například vrt na vodu)

--- a/fastlane/metadata/android/cs-CZ/changelogs/103.txt
+++ b/fastlane/metadata/android/cs-CZ/changelogs/103.txt
@@ -1,0 +1,9 @@
+- Přidány nové ikony s hladkým škálováním
+- Přidána černá díra na kapaliny (přispěno uživatelem @GioIacca9)
+- Přidáno nastavení průsvitnosti přemostění přepravníku (přispěno uživatelem @Quezler)
+- Přidána brána s podtokem (protikus k bráně s přetečením)
+- Přidány emotikony do kanálu zpráv, pro většinu bloků a předmětů
+- Přidán nový strom technologií, s lepší podporou pro modifikace
+- Přidán soubor s logem hry, uložený v adresáři s daty
+- Přidán nová oddělovat pro sprity a animace (ocená modéři)
+- Přidán seznam synergetických dlaždic do statistik některých bloků (viz například vrt na vodu)

--- a/fastlane/metadata/android/cs-CZ/changelogs/103.txt
+++ b/fastlane/metadata/android/cs-CZ/changelogs/103.txt
@@ -5,5 +5,5 @@
 - Přidány emotikony do kanálu zpráv, pro většinu bloků a předmětů
 - Přidán nový strom technologií, s lepší podporou pro modifikace
 - Přidán soubor s logem hry, uložený v adresáři s daty
-- Přidán nová oddělovat pro sprity a animace (ocená modéři)
+- Přidán nový oddělovač pro sprity a animace (ocení modéři)
 - Přidán seznam synergetických dlaždic do statistik některých bloků (viz například vrt na vodu)

--- a/fastlane/metadata/android/cs-CZ/changelogs/29591.txt
+++ b/fastlane/metadata/android/cs-CZ/changelogs/29591.txt
@@ -1,0 +1,9 @@
+- Přidány nové ikony s hladkým škálováním
+- Přidána černá díra na kapaliny (přispěno uživatelem @GioIacca9)
+- Přidáno nastavení průsvitnosti přemostění přepravníku (přispěno uživatelem @Quezler)
+- Přidána brána s podtokem (protikus k bráně s přetečením)
+- Přidány emotikony do kanálu zpráv, pro většinu bloků a předmětů
+- Přidán nový strom technologií, s lepší podporou pro modifikace
+- Přidán soubor s logem hry, uložený v adresáři s daty
+- Přidán nová oddělovat pro sprity a animace (ocená modéři)
+- Přidán seznam synergetických dlaždic do statistik některých bloků (viz například vrt na vodu)

--- a/fastlane/metadata/android/cs-CZ/changelogs/29591.txt
+++ b/fastlane/metadata/android/cs-CZ/changelogs/29591.txt
@@ -5,5 +5,5 @@
 - Přidány emotikony do kanálu zpráv, pro většinu bloků a předmětů
 - Přidán nový strom technologií, s lepší podporou pro modifikace
 - Přidán soubor s logem hry, uložený v adresáři s daty
-- Přidán nová oddělovat pro sprity a animace (ocená modéři)
+- Přidán nový oddělovač pro sprity a animace (ocení modéři)
 - Přidán seznam synergetických dlaždic do statistik některých bloků (viz například vrt na vodu)

--- a/fastlane/metadata/android/cs-CZ/changelogs/29594.txt
+++ b/fastlane/metadata/android/cs-CZ/changelogs/29594.txt
@@ -1,0 +1,9 @@
+- Přidány nové ikony s hladkým škálováním
+- Přidána černá díra na kapaliny (přispěno uživatelem @GioIacca9)
+- Přidáno nastavení průsvitnosti přemostění přepravníku (přispěno uživatelem @Quezler)
+- Přidána brána s podtokem (protikus k bráně s přetečením)
+- Přidány emotikony do kanálu zpráv, pro většinu bloků a předmětů
+- Přidán nový strom technologií, s lepší podporou pro modifikace
+- Přidán soubor s logem hry, uložený v adresáři s daty
+- Přidán nová oddělovat pro sprity a animace (ocená modéři)
+- Přidán seznam synergetických dlaždic do statistik některých bloků (viz například vrt na vodu)

--- a/fastlane/metadata/android/cs-CZ/changelogs/29594.txt
+++ b/fastlane/metadata/android/cs-CZ/changelogs/29594.txt
@@ -5,5 +5,5 @@
 - Přidány emotikony do kanálu zpráv, pro většinu bloků a předmětů
 - Přidán nový strom technologií, s lepší podporou pro modifikace
 - Přidán soubor s logem hry, uložený v adresáři s daty
-- Přidán nová oddělovat pro sprity a animace (ocená modéři)
+- Přidán nový oddělovač pro sprity a animace (ocení modéři)
 - Přidán seznam synergetických dlaždic do statistik některých bloků (viz například vrt na vodu)

--- a/fastlane/metadata/android/cs-CZ/changelogs/29597.txt
+++ b/fastlane/metadata/android/cs-CZ/changelogs/29597.txt
@@ -1,0 +1,9 @@
+- Přidány nové ikony s hladkým škálováním
+- Přidána černá díra na kapaliny (přispěno uživatelem @GioIacca9)
+- Přidáno nastavení průsvitnosti přemostění přepravníku (přispěno uživatelem @Quezler)
+- Přidána brána s podtokem (protikus k bráně s přetečením)
+- Přidány emotikony do kanálu zpráv, pro většinu bloků a předmětů
+- Přidán nový strom technologií, s lepší podporou pro modifikace
+- Přidán soubor s logem hry, uložený v adresáři s daty
+- Přidán nová oddělovat pro sprity a animace (ocená modéři)
+- Přidán seznam synergetických dlaždic do statistik některých bloků (viz například vrt na vodu)

--- a/fastlane/metadata/android/cs-CZ/changelogs/29597.txt
+++ b/fastlane/metadata/android/cs-CZ/changelogs/29597.txt
@@ -5,5 +5,5 @@
 - Přidány emotikony do kanálu zpráv, pro většinu bloků a předmětů
 - Přidán nový strom technologií, s lepší podporou pro modifikace
 - Přidán soubor s logem hry, uložený v adresáři s daty
-- Přidán nová oddělovat pro sprity a animace (ocená modéři)
+- Přidán nový oddělovač pro sprity a animace (ocení modéři)
 - Přidán seznam synergetických dlaždic do statistik některých bloků (viz například vrt na vodu)


### PR DESCRIPTION
Hi,
please accept this update, which adds to .gitignore following
`mods/` - obvious reasons, there will be no mods in Mindustry and github 
`*.bat` - that's what I use for effective contributing (remote pull etc), I believe there will be no *.bat file in future

This change should make no harm to anyone and it will help me a lot :)