### PR TITLE
gitignore - adding mods/ and *.bat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,5 @@ gradle-app.setting
 .DS_Store
 Thumbs.db
 android/libs/
+mods/
+*.bat


### PR DESCRIPTION
Hi,
please accept this update, which adds to .gitignore following
`mods/` - obvious reasons, there will be no mods in Mindustry and github 
`*.bat` - that's what I use for effective contributing (remote pull etc), I believe there will be no *.bat file in future

This change should make no harm to anyone and it will help me a lot :)