### PR TITLE
[quality of life] hide drop zone warning when you're immune

### DIFF
--- a/core/src/mindustry/ai/WaveSpawner.java
+++ b/core/src/mindustry/ai/WaveSpawner.java
@@ -39,7 +39,7 @@ public class WaveSpawner{
 
     /** @return true if the player is near a ground spawn point. */
     public boolean playerNear(){
-        return groundSpawns.contains(g -> Mathf.dst(g.x * tilesize, g.y * tilesize, player.x, player.y) < state.rules.dropZoneRadius);
+        return groundSpawns.contains(g -> Mathf.dst(g.x * tilesize, g.y * tilesize, player.x, player.y) < state.rules.dropZoneRadius && player.getTeam() != state.rules.waveTeam);
     }
 
     public void spawnEnemies(){


### PR DESCRIPTION
The drop zone does not explode/bounce units/blocks/players that belong to the wave team, normally this would not occur, but when you somehow are (e.g. messing with a plugin/javascript/minigame/etc it would make sense to hide the warning that obstructs your view)

![Screen Shot 2020-02-02 at 14 58 44](https://user-images.githubusercontent.com/3179271/73609299-87ab0b00-45cc-11ea-8e13-821de07a8aca.png)
