### PR TITLE
Improved ItemModule::take() behavior

### DIFF
--- a/core/src/mindustry/world/modules/ItemModule.java
+++ b/core/src/mindustry/world/modules/ItemModule.java
@@ -86,7 +86,7 @@ public class ItemModule extends BlockModule{
             if(items[i] > 0){
                 items[i]--;
                 total--;
-    			// save the next position so the next call to take() can resume from there.
+    		// save the next position so the next call to take() can resume from there.
                 takeRotation = (i + 1) % items.length;
                 return content.item(i);
             }

--- a/core/src/mindustry/world/modules/ItemModule.java
+++ b/core/src/mindustry/world/modules/ItemModule.java
@@ -12,6 +12,9 @@ public class ItemModule extends BlockModule{
     private int[] items = new int[content.items().size];
     private int total;
 
+    // Make the take() loop persistent so it does not return the same item twice in a row unless there is nothing else to return.
+    protected int takeRotation;
+
     public void forEach(ItemConsumer cons){
         for(int i = 0; i < items.length; i++){
             if(items[i] > 0){
@@ -65,9 +68,6 @@ public class ItemModule extends BlockModule{
     public int total(){
         return total;
     }
-
-    // Making the take() loop persistent so it does not return the same item twice in a row unless there is nothing else to return.
-    protected int takeRotation;
 
     public Item take(){
     	// 0-to-length loop broken in two parts. First resume the loop where it previously left off.

--- a/core/src/mindustry/world/modules/ItemModule.java
+++ b/core/src/mindustry/world/modules/ItemModule.java
@@ -75,7 +75,7 @@ public class ItemModule extends BlockModule{
             if(items[i] > 0){
                 items[i]--;
                 total--;
-    			// save the next position so the next call to take() can resume from there.
+    		// save the next position so the next call to take() can resume from there.
                 takeRotation = (i + 1) % items.length;
                 return content.item(i);
             }

--- a/core/src/mindustry/world/modules/ItemModule.java
+++ b/core/src/mindustry/world/modules/ItemModule.java
@@ -70,25 +70,14 @@ public class ItemModule extends BlockModule{
     }
 
     public Item take(){
-    	// 0-to-length loop broken in two parts. First resume the loop where it previously left off.
-        for(int i = takeRotation; i < items.length; i++){
-            if(items[i] > 0){
-                items[i]--;
-                total--;
-    		// save the next position so the next call to take() can resume from there.
-                takeRotation = (i + 1) % items.length;
-                return content.item(i);
-            }
-        }
-
-        // Then start a new lap which ends where the call started from if empty.
-        for(int i = 0; i < takeRotation; i++){
-            if(items[i] > 0){
-                items[i]--;
-                total--;
-    		// save the next position so the next call to take() can resume from there.
-                takeRotation = (i + 1) % items.length;
-                return content.item(i);
+        for(int i = 0; i < items.length; i++){
+            int index = (i + takeRotation);
+            if(index >= items.length) index -= items.length; //conditional instead of mod
+            if(items[index] > 0){
+                items[index] --;
+                total --;
+                takeRotation = index + 1;
+                return content.item(index % items.length);
             }
         }
         return null;

--- a/core/src/mindustry/world/modules/ItemModule.java
+++ b/core/src/mindustry/world/modules/ItemModule.java
@@ -66,11 +66,28 @@ public class ItemModule extends BlockModule{
         return total;
     }
 
+    // Making the take() loop persistent so it does not return the same item twice in a row unless there is nothing else to return.
+    protected int takeRotation;
+
     public Item take(){
-        for(int i = 0; i < items.length; i++){
+    	// 0-to-length loop broken in two parts. First resume the loop where it previously left off.
+        for(int i = takeRotation; i < items.length; i++){
             if(items[i] > 0){
                 items[i]--;
                 total--;
+    			// save the next position so the next call to take() can resume from there.
+                takeRotation = (i + 1) % items.length;
+                return content.item(i);
+            }
+        }
+
+        // Then start a new lap which ends where the call started from if empty.
+        for(int i = 0; i < takeRotation; i++){
+            if(items[i] > 0){
+                items[i]--;
+                total--;
+    			// save the next position so the next call to take() can resume from there.
+                takeRotation = (i + 1) % items.length;
                 return content.item(i);
             }
         }


### PR DESCRIPTION
The original take() behavior spams items in whatever order they appear in the items list until each index is depleted, which is problematic when non-specific unloaders are competing against dedicated unloaders for a low-index resources.

My modification makes the take() loop persistent so take() will do complete laps around the item list starting from wherever the previous call returned from, never repeating the same item twice in a row unless there is nothing else to return. A significant improvement IMO.

How is this an improvement? With the original behavior, if you converge a bunch of belts on a storage block or launcher, want to unload a few belts of specific resources (ex.: copper, lead, silicon and titanium for surge alloy) and pass everything else including overflows along using non-specific unloaders, you are out of luck when the resources you want are at the top of the list since most of those will get swept away by non-specific unloaders. With the rotating take(), non-specific unloaders are equal-opportunity across all available resources, which gives single-resource unloaders that many more chances to unload more of their resources before non-specific unloaders get to them. It also reduces the rate at which items further down the list that may hardly ever get touched by the existing implementation will race toward the storage block's cap. The even drain across all items will help prevent things like mass driver stalls due to receivers filling up with an excess resource that isn't getting cleared.

It would be even nicer if dedicated unloaders had priority over non-specific ones (non-specific unloaders don't touch resources with dedicated unloaders unless the dedicated unloaders are overflowing), though that would require a rework beyond my current "getting the stupid IDE and tool chains to work" level of familiarity with Java development.

To sum it up: trivial change, big impact for people who like mixing belts and sorting them out with unloaders.