### PR TITLE
format sprite packing command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ First, make sure you have [JDK 8](https://adoptopenjdk.net/) installed. Open a t
 
 #### Windows
 
-_Running:_ `gradlew desktop:run`  
-_Building:_ `gradlew desktop:dist`
+_Running:_ `gradlew desktop:run` 
+_Building:_ `gradlew desktop:dist`  
 _Sprite Packing:_ `gradlew tools:pack`
 
 #### Linux/Mac OS
 
-_Running:_ `./gradlew desktop:run`  
-_Building:_ `./gradlew desktop:dist`
+_Running:_ `./gradlew desktop:run` 
+_Building:_ `./gradlew desktop:dist`  
 _Sprite Packing:_ `./gradlew tools:pack`
 
 #### Server


### PR DESCRIPTION
> fixes newline formatting introduced by [`aaaa`](https://github.com/Anuken/Mindustry/pull/1502)

![Screen Shot 2020-02-03 at 20 52 27](https://user-images.githubusercontent.com/3179271/73686075-9b876780-46c7-11ea-8478-082431279be4.png)
> for some bizarre reason leading spaces cause the new line to neatly fall into place

![Screen Shot 2020-02-03 at 20 55 21](https://user-images.githubusercontent.com/3179271/73686077-9b876780-46c7-11ea-9891-d31ec44627d4.png)
> 🥔 