### PR TITLE
For consistency

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -59,7 +59,7 @@ public class Blocks implements ContentList{
     //transport
     conveyor, titaniumConveyor, armoredConveyor, distributor, junction, itemBridge, phaseConveyor, sorter, invertedSorter, router, overflowGate, underflowGate, massDriver,
 
-    //liquids
+    //liquid
     mechanicalPump, rotaryPump, thermalPump, conduit, pulseConduit, platedConduit, liquidRouter, liquidTank, liquidJunction, bridgeConduit, phaseConduit,
 
     //power


### PR DESCRIPTION
Swap "liquids" with "liquid." Also proposing because the category for liquid blocks is "liquid" and not "liquids" when modding.