### PR TITLE
Trim schematic string before calling Base64Decoder

### DIFF
--- a/core/src/mindustry/game/Schematics.java
+++ b/core/src/mindustry/game/Schematics.java
@@ -375,7 +375,7 @@ public class Schematics implements Loadable{
     /** Loads a schematic from base64. May throw an exception. */
     public static Schematic readBase64(String schematic){
         try{
-            return read(new ByteArrayInputStream(Base64Coder.decode(schematic)));
+            return read(new ByteArrayInputStream(Base64Coder.decode(schematic.trim())));
         }catch(IOException e){
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This fixes getting the "Length of Base64 encoded input string is not a multiple of 4." error when importing schematics that have whitespace at the start/end of them, which is easy to accidentally have without knowing by when copying the schematic codes from random different web pages.