### PR TITLE
[quality of life] better visiualize sorters with no filter

### DIFF
--- a/core/src/mindustry/world/blocks/distribution/Sorter.java
+++ b/core/src/mindustry/world/blocks/distribution/Sorter.java
@@ -66,12 +66,10 @@ public class Sorter extends Block{
         if(entity.sortItem == null){
             Draw.color(Pal.remove);
             Draw.rect(Icon.cancelSmall.getRegion(), tile.drawx(), tile.drawy());
-            Draw.color();
-            return;
+        }else{ // ▲ unfiltered | filtered ▼
+            Draw.color(entity.sortItem.color);
+            Draw.rect("center", tile.worldx(), tile.worldy());
         }
-
-        Draw.color(entity.sortItem.color);
-        Draw.rect("center", tile.worldx(), tile.worldy());
         Draw.color();
     }
 

--- a/core/src/mindustry/world/blocks/distribution/Sorter.java
+++ b/core/src/mindustry/world/blocks/distribution/Sorter.java
@@ -7,6 +7,8 @@ import arc.util.ArcAnnotate.*;
 import arc.util.*;
 import mindustry.entities.traits.BuilderTrait.*;
 import mindustry.entities.type.*;
+import mindustry.gen.*;
+import mindustry.graphics.*;
 import mindustry.type.*;
 import mindustry.world.*;
 import mindustry.world.blocks.*;
@@ -61,7 +63,12 @@ public class Sorter extends Block{
         super.draw(tile);
 
         SorterEntity entity = tile.ent();
-        if(entity.sortItem == null) return;
+        if(entity.sortItem == null){
+            Draw.color(Pal.remove);
+            Draw.rect(Icon.cancelSmall.getRegion(), tile.drawx(), tile.drawy());
+            Draw.color();
+            return;
+        }
 
         Draw.color(entity.sortItem.color);
         Draw.rect("center", tile.worldx(), tile.worldy());


### PR DESCRIPTION
> a possible solution, there are more, feel free to suggest the latter.

Currently some filter types (cough: silicon) look way to much like an unfiltered sorter.
This pull steals the red cross from the byte-logic branch to more clearly mark them:
![Screen Shot 2020-02-12 at 19 36 09](https://user-images.githubusercontent.com/3179271/74365885-391d1e00-4dcf-11ea-91b9-335355f08ee9.png)
> yes, the 2 center ones are set to silicon, same color, just a different size, pretty hard right?