### PR TITLE
Add "pardon" command for votekicks

### DIFF
--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -661,7 +661,8 @@ public class ServerControl implements ApplicationListener{
         });
         
         handler.register("pardon", "<ID>", "Pardons a votekicked player by ID and allows them to join again.", arg -> {
-            PlayerInfo info = netServer.admins.getInfo(arg[0]);
+            PlayerInfo info = netServer.admins.getInfoOptional(arg[0]);
+            
             if(info != null){
                 info.lastKicked = 0;
                 info("Pardoned player: {0}", info.lastName);

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -667,7 +667,7 @@ public class ServerControl implements ApplicationListener{
                 info.lastKicked = 0;
                 info("Pardoned player: {0}", info.lastName);
             }else{
-                err("That ID hasn't been votekicked!");
+                err("That ID can't be found.");
             }
         });
 

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -666,7 +666,7 @@ public class ServerControl implements ApplicationListener{
                 info.lastKicked = 0;
                 info("Pardoned player: {0}", info.lastName);
             } else{
-                err("That ID isn't hasn't been votekicked!");
+                err("That ID hasn't been votekicked!");
             }
         });
 

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -659,6 +659,16 @@ public class ServerControl implements ApplicationListener{
                 err("That IP/ID is not banned!");
             }
         });
+        
+        handler.register("pardon", "<ID>", "Pardons a votekicked player by ID and allows them to join again.", arg -> {
+            PlayerInfo info = netServer.admins.getInfo(arg[0]);
+            if(info != null){
+                info.lastKicked = 0;
+                info("Pardoned player: {0}", info.lastName);
+            } else{
+                err("That ID isn't hasn't been votekicked!");
+            }
+        });
 
         handler.register("admin", "<add/remove> <username/ID...>", "Make an online user admin", arg -> {
             if(!state.is(State.playing)){

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -666,7 +666,7 @@ public class ServerControl implements ApplicationListener{
             if(info != null){
                 info.lastKicked = 0;
                 info("Pardoned player: {0}", info.lastName);
-            } else{
+            }else{
                 err("That ID hasn't been votekicked!");
             }
         });


### PR DESCRIPTION
Allows admins to "pardon" a votekick ban, useful for when a player gets unfairly votekicked and has to wait **60 minutes**, but he can instead be pardoned and join right away.