### PR TITLE
Separate ambient light and solar panel efficiency

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -789,6 +789,7 @@ rules.title.unit = Units
 rules.title.experimental = Experimental
 rules.lighting = Lighting
 rules.ambientlight = Ambient Light
+rules.solarpowermultiplier = Solar Power Multiplier
 
 content.item.name = Items
 content.liquid.name = Liquids

--- a/core/src/mindustry/game/Rules.java
+++ b/core/src/mindustry/game/Rules.java
@@ -82,6 +82,8 @@ public class Rules{
     public boolean lighting = false;
     /** Ambient light color, used when lighting is enabled. */
     public Color ambientLight = new Color(0.01f, 0.01f, 0.04f, 0.99f);
+    /** Solar panel power output is multiplied by this. */
+    public float solarEfficiency = 1f;
     /** team of the player by default */
     public Team defaultTeam = Team.sharded;
     /** team of the enemy in waves/sectors */

--- a/core/src/mindustry/game/Rules.java
+++ b/core/src/mindustry/game/Rules.java
@@ -82,8 +82,9 @@ public class Rules{
     public boolean lighting = false;
     /** Ambient light color, used when lighting is enabled. */
     public Color ambientLight = new Color(0.01f, 0.01f, 0.04f, 0.99f);
-    /** Multiplier for solar panel power output. */
-	public float solarPowerMultiplier = 1f;
+    /** Multiplier for solar panel power output.
+    negative = use ambient light if lighting is enabled. */
+    public float solarPowerMultiplier = -1f;
     /** team of the player by default */
     public Team defaultTeam = Team.sharded;
     /** team of the enemy in waves/sectors */

--- a/core/src/mindustry/game/Rules.java
+++ b/core/src/mindustry/game/Rules.java
@@ -82,8 +82,8 @@ public class Rules{
     public boolean lighting = false;
     /** Ambient light color, used when lighting is enabled. */
     public Color ambientLight = new Color(0.01f, 0.01f, 0.04f, 0.99f);
-    /** Solar panel power output is multiplied by this. */
-    public float solarEfficiency = 1f;
+    /** Multiplier for solar panel power output. */
+	public float solarPowerMultiplier = 1f;
     /** team of the player by default */
     public Team defaultTeam = Team.sharded;
     /** team of the enemy in waves/sectors */

--- a/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
+++ b/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
@@ -172,6 +172,7 @@ public class CustomRulesDialog extends FloatingDialog{
         number("$rules.enemycorebuildradius", f -> rules.enemyCoreBuildRadius = f * tilesize, () -> Math.min(rules.enemyCoreBuildRadius / tilesize, 200));
 
         title("$rules.title.experimental");
+        number("$rules.solarpowermultiplier", f -> rules.solarPowerMultiplier = f, () -> rules.solarPowerMultiplier);
         check("$rules.lighting", b -> rules.lighting = b, () -> rules.lighting);
 
         main.addButton(b -> {

--- a/core/src/mindustry/world/blocks/power/SolarGenerator.java
+++ b/core/src/mindustry/world/blocks/power/SolarGenerator.java
@@ -17,7 +17,7 @@ public class SolarGenerator extends PowerGenerator{
 
     @Override
     public void update(Tile tile){
-        tile.<GeneratorEntity>ent().productionEfficiency = state.rules.lighting ? 1f - state.rules.ambientLight.a : 1f;
+        tile.<GeneratorEntity>ent().productionEfficiency = state.rules.solarPowerMultiplier;
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/power/SolarGenerator.java
+++ b/core/src/mindustry/world/blocks/power/SolarGenerator.java
@@ -17,7 +17,7 @@ public class SolarGenerator extends PowerGenerator{
 
     @Override
     public void update(Tile tile){
-        tile.<GeneratorEntity>ent().productionEfficiency = state.rules.solarPowerMultiplier;
+        tile.<GeneratorEntity>ent().productionEfficiency = state.rules.solarPowerMultiplier < 0 ? (state.rules.lighting ? 1f - state.rules.ambientLight.a : 1f) : state.rules.solarPowerMultiplier;
     }
 
     @Override


### PR DESCRIPTION
Before, solar panel multiplier was 1 - ambient light opacity
Now, solar panel multiplier can be set in game rules.
Requested by at least two people that have no affiliation with me!