### PR TITLE
Reset local player name on disconnect

### DIFF
--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -102,6 +102,7 @@ public class NetClient implements ApplicationListener{
             state.set(State.menu);
             logic.reset();
             platform.updateRPC();
+            player.name = Core.settings.getString("name");
 
             if(quiet) return;
 


### PR DESCRIPTION
Some servers may change the player name in game. This is incorrectly persisted after disconnecting from the server, causing it to carry over to other servers.

This is especially problematic when Mindustry is launched from steam, as player names cannot be easily changed there.