### PR TITLE
Prevent construction/deconstruction of blocks on other teams

### DIFF
--- a/core/src/mindustry/entities/traits/BuilderTrait.java
+++ b/core/src/mindustry/entities/traits/BuilderTrait.java
@@ -81,6 +81,10 @@ public interface BuilderTrait extends Entity, TeamTrait{
         }
 
         if(tile.entity instanceof BuildEntity && !current.initialized){
+            if(getTeam() != tile.getTeam()){
+                buildQueue().removeFirst();
+                return;
+            }
             Core.app.post(() -> Events.fire(new BuildSelectEvent(tile, unit.getTeam(), this, current.breaking)));
             current.initialized = true;
         }


### PR DESCRIPTION
If blocks on other teams are manually added to the build queue, it is possible to construct/deconstruct them. This is abusable to steal resources from the enemy team during construction of blocks.