### PR TITLE
[quality of life] console-style chat scrolling

### DIFF
--- a/core/src/mindustry/ui/fragments/ChatFragment.java
+++ b/core/src/mindustry/ui/fragments/ChatFragment.java
@@ -231,6 +231,8 @@ public class ChatFragment extends Table{
 
         fadetime += 1f;
         fadetime = Math.min(fadetime, messagesShown) + 1f;
+        
+        if(scrollPos > 0) scrollPos++;
     }
 
     private static class ChatMessage{


### PR DESCRIPTION
Currently when you're scrolled back in chat it moves when a new message gets added,
this piece of code makes sure that what you're looking at stays in place. 🔖
(like most consoles/terminals handle scrolling with new output)