### PR TITLE
let scripts require from the same mod

### DIFF
--- a/core/src/mindustry/mod/Scripts.java
+++ b/core/src/mindustry/mod/Scripts.java
@@ -122,7 +122,7 @@ public class Scripts implements Disposable{
             if(matched.find()){
                 LoadedMod required = Vars.mods.locateMod(matched.group(1));
                 String script = matched.group(2);
-                if(required == null || root.equals(required.root.child("scripts"))){ // Mod not found, or already using a mod
+                if(required == null){ // Mod not found, treat it as a folder
                     Fi dir = root.child(matched.group(1));
                     if(!dir.exists()) return null; // Mod and folder not found
                     return loadSource(script, dir, validator);


### PR DESCRIPTION
it seems fine to have
`require("mymod/script")`
e.g. if mods require a lot of scripts and want to organise it
works nicely so far in my 2 real library mods and one broken one (it loads the files but they have too many errors lol)