### PR TITLE
Material refund when deconstructing is now a map rule

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -777,6 +777,7 @@ rules.respawntime = Respawn Time:[lightgray] (sec)
 rules.wavespacing = Wave Spacing:[lightgray] (sec)
 rules.buildcostmultiplier = Build Cost Multiplier
 rules.buildspeedmultiplier = Build Speed Multiplier
+rules.deconstructrefundmultiplier = Deconstruct Refund Multiplier
 rules.waitForWaveToEnd = Waves Wait for Enemies
 rules.dropzoneradius = Drop Zone Radius:[lightgray] (tiles)
 rules.respawns = Max respawns per wave

--- a/core/src/mindustry/game/Rules.java
+++ b/core/src/mindustry/game/Rules.java
@@ -44,6 +44,8 @@ public class Rules{
     public float buildCostMultiplier = 1f;
     /** Multiplier for building speed. */
     public float buildSpeedMultiplier = 1f;
+    /** Multiplier for percentage of materials refunded when deconstructing */
+    public float deconstructRefundMultiplier = 0.5f;
     /** No-build zone around enemy core radius. */
     public float enemyCoreBuildRadius = 400f;
     /** Radius around enemy wave drop zones.*/

--- a/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
+++ b/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
@@ -142,6 +142,7 @@ public class CustomRulesDialog extends FloatingDialog{
         check("$rules.reactorexplosions", b -> rules.reactorExplosions = b, () -> rules.reactorExplosions);
         number("$rules.buildcostmultiplier", false, f -> rules.buildCostMultiplier = f, () -> rules.buildCostMultiplier, () -> !rules.infiniteResources);
         number("$rules.buildspeedmultiplier", f -> rules.buildSpeedMultiplier = f, () -> rules.buildSpeedMultiplier);
+        number("$rules.deconstructrefundmultiplier", false, f -> rules.deconstructRefundMultiplier = f, () -> rules.deconstructRefundMultiplier, () -> !rules.infiniteResources);
         number("$rules.blockhealthmultiplier", f -> rules.blockHealthMultiplier = f, () -> rules.blockHealthMultiplier);
 
         main.addButton("$configure",

--- a/core/src/mindustry/world/blocks/BuildBlock.java
+++ b/core/src/mindustry/world/blocks/BuildBlock.java
@@ -252,7 +252,7 @@ public class BuildBlock extends Block{
         }
 
         public void deconstruct(Unit builder, @Nullable TileEntity core, float amount){
-            float deconstructMultiplier = 0.5f;
+            float deconstructMultiplier = state.rules.deconstructRefundMultiplier;
 
             if(cblock != null){
                 ItemStack[] requirements = cblock.requirements;


### PR DESCRIPTION
Primary reason is to make PvE/PvP multiplayer servers to increase this to 100% refund to further mitigate griefer/bad building placements but otherwise can be used to make a map harder. 