### PR TITLE
Bind plasma sprite's size to reactor's size

### DIFF
--- a/core/src/mindustry/world/blocks/power/ImpactReactor.java
+++ b/core/src/mindustry/world/blocks/power/ImpactReactor.java
@@ -100,7 +100,7 @@ public class ImpactReactor extends PowerGenerator{
         Draw.rect(reg(bottomRegion), tile.drawx(), tile.drawy());
 
         for(int i = 0; i < plasmas; i++){
-            float r = 29f + Mathf.absin(Time.time(), 2f + i * 1f, 5f - i * 0.5f);
+            float r = size * tilesize - 3f + Mathf.absin(Time.time(), 2f + i * 1f, 5f - i * 0.5f);
 
             Draw.color(plasma1, plasma2, (float)i / plasmas);
             Draw.alpha((0.3f + Mathf.absin(Time.time(), 2f + i * 2f, 0.3f + i * 0.05f)) * entity.warmup);


### PR DESCRIPTION
This will be useful for modded ImpactReactors that have different sizes. (Please correct my code if it is wrong).