### PR TITLE
fix for js print() function printing null

### DIFF
--- a/core/assets/scripts/base.js
+++ b/core/assets/scripts/base.js
@@ -1,5 +1,5 @@
 const log = function(context, obj){
-    Vars.mods.getScripts().log(context, obj ? String(obj) : "null")
+    Vars.mods.getScripts().log(context, obj !== null ? String(obj) : "null")
 }
 
 var scriptName = "base.js"


### PR DESCRIPTION
js print() function prints null, if zero or false is passed to it as an argument.