### PR TITLE
[quality of life] resuming construction in bulk

### DIFF
--- a/core/src/mindustry/world/Build.java
+++ b/core/src/mindustry/world/Build.java
@@ -87,7 +87,7 @@ public class Build{
         if(tile == null) return false;
 
         if(type.isMultiblock()){
-            if(type.canReplace(tile.block()) && tile.block().size == type.size && type.canPlaceOn(tile) && tile.interactable(team)){
+            if((type.canReplace(tile.block()) || (tile.block instanceof BuildBlock && tile.<BuildEntity>ent().cblock == type)) && tile.block().size == type.size && type.canPlaceOn(tile) && tile.interactable(team)){
                 return true;
             }
 
@@ -117,7 +117,7 @@ public class Build{
             && contactsGround(tile.x, tile.y, type)
             && (!tile.floor().isDeep() || type.floating)
             && tile.floor().placeableOn
-            && ((type.canReplace(tile.block())
+            && (((type.canReplace(tile.block()) || (tile.block instanceof BuildBlock && tile.<BuildEntity>ent().cblock == type))
             && !(type == tile.block() && rotation == tile.rotation() && type.rotate)) || tile.block().alwaysReplace || tile.block() == Blocks.air)
             && tile.block().isMultiblock() == type.isMultiblock() && type.canPlaceOn(tile);
         }


### PR DESCRIPTION
Currently when you run out of building resources (or when you die) half way through construction you're left with one or more build blocks with barely any progress, and the only way to complete what was intended is to either click all of them by hand, or delete them in order to replace them.

This draft allows people to resume the build by allowing it to be added to the build queue if the block being constructed matches the current type.

Some things that are up for debate:
- it only allows the original block to be constructed, no wall/conveyor/drill hotswap upgrading.
- it keeps the rotation the original block was in, could either be annoying or fairly useful.
- and of course the code, no idea if i thought of everything, haven't tested it a lot yet. 

![Apr-03-2020 16-03-46](https://user-images.githubusercontent.com/3179271/78368965-c48f8000-75c4-11ea-9ba6-bdfc560e73d8.gif)
> gif shows me running out, then scavenging copper to resume via dragging a new line 🥔 