### PR TITLE
[mapping] show name of conflicting map when importing

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -380,7 +380,7 @@ editor.unsaved = [scarlet]You have unsaved changes![]\nAre you sure you want to 
 editor.resizemap = Resize Map
 editor.mapname = Map Name:
 editor.overwrite = [accent]Warning!\nThis overwrites an existing map.
-editor.overwrite.confirm = [scarlet]Warning![] A map with this name already exists. Are you sure you want to overwrite it?
+editor.overwrite.confirm = [scarlet]Warning![] A map with this name already exists. Are you sure you want to overwrite it?\n"[accent]{0}[]"
 editor.exists = A map with this name already exists.
 editor.selectmap = Select a map to load:
 

--- a/core/src/mindustry/ui/dialogs/MapsDialog.java
+++ b/core/src/mindustry/ui/dialogs/MapsDialog.java
@@ -98,7 +98,7 @@ public class MapsDialog extends FloatingDialog{
                         if(conflict != null && !conflict.custom){
                             ui.showInfo(Core.bundle.format("editor.import.exists", name));
                         }else if(conflict != null){
-                            ui.showConfirm("$confirm", "$editor.overwrite.confirm", () -> {
+                            ui.showConfirm("$confirm", Core.bundle.format("editor.overwrite.confirm", map.name()), () -> {
                                 maps.tryCatchMapError(() -> {
                                     maps.removeMap(conflict);
                                     maps.importMap(map.file);


### PR DESCRIPTION
Currently when you download/import a map there is no guarantee the filename is even remotely similar to the name it receives in game, so when you add it to the editor list you need to search around till you find it.

This is also troubling when you import a map again (or one that happens to have the same name), you simply don't know how the already present map is called.

For a solution i propose to show the name of the two conflicting maps to allow for easier finding:
![Screen Shot 2020-04-12 at 11 49 57](https://user-images.githubusercontent.com/3179271/79065911-1e263780-7cb4-11ea-852b-194cba7cbcc9.png)
