### PR TITLE
Server locale support and filtering

### DIFF
--- a/SERVERLIST.md
+++ b/SERVERLIST.md
@@ -17,10 +17,12 @@ You'll need to either hire some moderators, or make use of (currently non-existe
 4. **Check your server configuration.** *(optional)* I would recommend adding a message rate limit of 1 second (`config messageRateLimit 1`), and disabling connect/disconnect messages to reduce spam (`config showConnectMessages false`).
 5. Finally, **submit a pull request** to add your server's IP to the list. 
 This should be fairly straightforward: Press the edit button on the [server file](https://github.com/Anuken/Mindustry/blob/master/servers.json), then add a JSON object with a single key, indicating your server address.
-For example, if your server address is `google.com`, you would add a comma after the last entry and insert:
+For example, if your server address is `google.ru`, you would add a comma after the last entry and insert:
 ```json
   {
-    "address": "google.com"
+    "address": "google.ru",
+	"locale": "ru"
   }
 ```
+("locale" is the language code that your server uses, default is "en" for English.)
 Then, press the *'submit pull request'* button and I'll take a look at your server. If I have any issues with it, I'll let you know in the PR comments.

--- a/core/src/mindustry/ui/dialogs/JoinDialog.java
+++ b/core/src/mindustry/ui/dialogs/JoinDialog.java
@@ -424,6 +424,7 @@ public class JoinDialog extends FloatingDialog{
     @SuppressWarnings("unchecked")
     private void loadServers(){
         servers = Core.settings.getObject("server-list", Array.class, Array::new);
+        final String locale = ui.language.getLocale().getCountry().toLowerCase();
 
         //get servers
         Core.net.httpGet(becontrol.active() ? serverJsonBeURL : serverJsonURL, result -> {
@@ -432,7 +433,11 @@ public class JoinDialog extends FloatingDialog{
                 Core.app.post(() -> {
                     try{
                         defaultServers.clear();
-                        val.asArray().each(child -> defaultServers.add(child.getString("address", "<invalid>")));
+                        val.asArray().each(child -> {
+                            if (child.getString("locale", "en") == locale) {
+                                defaultServers.add(child.getString("address", "<invalid>"));
+                            }
+                        });
                         Log.info("Fetched {0} global servers.", defaultServers.size);
                     }catch(Throwable ignored){}
                 });

--- a/core/src/mindustry/ui/dialogs/JoinDialog.java
+++ b/core/src/mindustry/ui/dialogs/JoinDialog.java
@@ -434,7 +434,7 @@ public class JoinDialog extends FloatingDialog{
                     try{
                         defaultServers.clear();
                         val.asArray().each(child -> {
-                            if (child.getString("locale", "en") == locale) {
+                            if(child.getString("locale", "en") == locale){
                                 defaultServers.add(child.getString("address", "<invalid>"));
                             }
                         });

--- a/servers.json
+++ b/servers.json
@@ -21,10 +21,12 @@
     "address": "mindustry.ecansol.com:6599"
   },
   {
-    "address": "mindustry.ru"
+    "address": "mindustry.ru",
+	"locale": "ru"
   },
   {
-    "address": "mindustry.ru:7000"
+    "address": "mindustry.ru:7000",
+	"locale": "ru"
   },
   {
     "address": "mindustry.io"


### PR DESCRIPTION
This pr adds a `locale` field to the server list which specifies what language it uses, if not English.
Clients check this against their current language to filter out servers.
Currently there is no way to disable it, but I wouldn't mind adding a setting for it.