### PR TITLE
Steady block inventory.

### DIFF
--- a/core/src/mindustry/ui/fragments/BlockInventoryFragment.java
+++ b/core/src/mindustry/ui/fragments/BlockInventoryFragment.java
@@ -29,11 +29,13 @@ import static mindustry.Vars.*;
 
 public class BlockInventoryFragment extends Fragment{
     private final static float holdWithdraw = 20f;
+    private final static float holdShrink = 120f;
 
     private Table table = new Table();
     private Tile tile;
     private float holdTime = 0f;
     private boolean holding;
+    private float[] shrinkHoldTimes = new float[content.items().size];
     private Item lastItem;
 
     @Remote(called = Loc.server, targets = Loc.both, forward = true)
@@ -116,12 +118,19 @@ public class BlockInventoryFragment extends Fragment{
 
                 updateTablePosition();
                 if(tile.block().hasItems){
+                    boolean dirty = false;
                     for(int i = 0; i < content.items().size; i++){
                         boolean has = tile.entity.items.has(content.item(i));
-                        if(has != container.contains(i)){
-                            rebuild(false);
+                        boolean had = container.contains(i);
+                        if(has){
+                            shrinkHoldTimes[i] = 0f;
+                            dirty |= !had;
+                        }else if(had && !has){
+                            shrinkHoldTimes[i] += Time.delta();
+                            dirty |= shrinkHoldTimes[i] >= holdShrink;
                         }
                     }
+                    if(dirty) rebuild(false);
                 }
             }
         });


### PR DESCRIPTION
Added a delay before the disappearence of an item from a block's
inventory causes the BlockInventoryFragment to rebuild its table.

This is mainly for the case where resources are moving directly through a container, in and immediately out.  Before this patch it would be hard to read the constantly rebuilding table or select resources to withdraw.

This patch causes one more allocation (one use of "new") per instance of BlockInventoryFragment.  As far as I can see you only get one of these objects when someone clicks a block and it persists until something else is selected, so I though the allocation was probably acceptable.

Ran ./gradelw desktop:test and it didn't complain. ./gradlew desktop:run does what I described if you play around with containers in sandbox mode.