### PR TITLE
Remove power usage from phase bridge endpoints

### DIFF
--- a/core/src/mindustry/world/blocks/distribution/ItemBridge.java
+++ b/core/src/mindustry/world/blocks/distribution/ItemBridge.java
@@ -357,6 +357,11 @@ public class ItemBridge extends Block{
         }
 
         @Override
+        public boolean shouldConsume(){
+            return linkValid(tile, world.tile(link));
+        }
+
+        @Override
         public Point2 config(){
             return Point2.unpack(link).sub(tile.x, tile.y);
         }


### PR DESCRIPTION
> sets power usage to `0f` when they aren't validly linked (cursor is on the bottom left one)

![Screen Shot 2020-04-25 at 13 25 15](https://user-images.githubusercontent.com/3179271/80278648-6c95f600-86f8-11ea-8b8b-7d24da2b0f36.png)

> falls in the same category a #998, makes it so you don't have to babysit accidental connections (like when trying to perfectly balance them with solar panels and such) 🌻 