### PR TITLE
Add Mo Town servers to community servers

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -41,4 +41,10 @@
   {
     "address": "aamindustry.play.ai"
   }
+  {
+    "address": "motownmindustry.duckdns.org"
+  }
+  {
+    "address": "motownmindustry.duckdns.org:6577"
+  }
 ]


### PR DESCRIPTION
I have two dedicated servers running and I would like them to be visible in community servers. One is for maps that I make, another is a hexed pvp with no unit factories.