### PR TITLE
[doodle] terrain schematics

### DIFF
--- a/core/src/mindustry/Vars.java
+++ b/core/src/mindustry/Vars.java
@@ -125,6 +125,8 @@ public class Vars implements Loadable{
     public static boolean steam;
     /** whether typing into the console is enabled - developers only */
     public static boolean enableConsole = false;
+    /** whether schematics can be used as blueprints - developers only */
+    public static boolean enableBlueprint = true;
     /** application data directory, equivalent to {@link Settings#getDataDirectory()} */
     public static Fi dataDirectory;
     /** data subdirectory used for screenshots */

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -9,6 +9,7 @@ import mindustry.*;
 import mindustry.ctype.*;
 import mindustry.entities.*;
 import mindustry.entities.bullet.*;
+import mindustry.entities.units.*;
 import mindustry.gen.*;
 import mindustry.graphics.*;
 import mindustry.type.*;
@@ -107,6 +108,11 @@ public class Blocks implements ContentList{
                     variantRegions = new TextureRegion[]{Core.atlas.find("clear")};
                 }
                 return variantRegions;
+            }
+            
+            @Override
+            public TextureRegion getRequestRegion(BuildRequest req, Eachable<BuildRequest> list){
+                return Core.atlas.find("cross");
             }
         };
 

--- a/core/src/mindustry/game/Schematics.java
+++ b/core/src/mindustry/game/Schematics.java
@@ -271,8 +271,12 @@ public class Schematics implements Loadable{
 
     /** Creates an array of build requests from a schematic's data, centered on the provided x+y coordinates. */
     public Array<BuildRequest> toRequests(Schematic schem, int x, int y){
-        return schem.tiles.map(t -> new BuildRequest(t.x + x - schem.width/2, t.y + y - schem.height/2, t.rotation, t.block).original(t.x, t.y, schem.width, schem.height).configure(t.config))
+        if(enableBlueprint){
+            return schem.tiles.map(t -> new BuildRequest(t.x + x - schem.width/2, t.y + y - schem.height/2, t.rotation, t.block).original(t.x, t.y, schem.width, schem.height).configure(t.config));
+        }else{
+            return schem.tiles.map(t -> new BuildRequest(t.x + x - schem.width/2, t.y + y - schem.height/2, t.rotation, t.block).original(t.x, t.y, schem.width, schem.height).configure(t.config))
             .removeAll(s -> !s.block.isVisible() || !s.block.unlockedCur());
+        }
     }
 
     public void placeLoadout(Schematic schem, int x, int y){
@@ -369,11 +373,17 @@ public class Schematics implements Loadable{
                 Tilec tile = world.ent(cx, cy);
 
                 if(tile != null && !counted.contains(tile.pos()) && !(tile.block() instanceof BuildBlock)
-                    && (tile.block().isVisible() || (tile.block() instanceof CoreBlock && Core.settings.getBool("coreselect")))){
+                    && (tile.block().isVisible() || enableBlueprint || (tile.block() instanceof CoreBlock && Core.settings.getBool("coreselect")))){
                     Object config = tile.config();
 
                     tiles.add(new Stile(tile.block(), tile.tileX() + offsetX, tile.tileY() + offsetY, config, (byte)tile.rotation()));
                     counted.add(tile.pos());
+                }
+
+                Tile under = world.tile(cx, cy);
+                if(under != null && enableBlueprint){
+                    tiles.add(new Stile(under.floor(), under.x + offsetX, under.y + offsetY, null, (byte)0));
+                    tiles.add(new Stile(under.overlay(), under.x + offsetX, under.y + offsetY, null, (byte)0));
                 }
             }
         }

--- a/core/src/mindustry/graphics/Pal.java
+++ b/core/src/mindustry/graphics/Pal.java
@@ -81,5 +81,8 @@ public class Pal{
     redDust = Color.valueOf("ffa480"),
     redderDust = Color.valueOf("ff7b69"),
 
-    plasticSmoke = Color.valueOf("f1e479");
+    plasticSmoke = Color.valueOf("f1e479"),
+
+    blueprint = Color.valueOf("#549de5"),
+    blueprintBack = Color.valueOf("#3e73a7");
 }

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -24,6 +24,7 @@ import mindustry.gen.*;
 import mindustry.graphics.*;
 import mindustry.ui.*;
 import mindustry.world.*;
+import mindustry.world.blocks.environment.*;
 
 import static arc.Core.scene;
 import static mindustry.Vars.*;
@@ -129,6 +130,18 @@ public class DesktopInput extends InputHandler{
 
         for(BuildRequest request : selectRequests){
             drawOverRequest(request);
+        }
+
+        if(enableBlueprint && !selectRequests.isEmpty()){
+            BuildRequest min = selectRequests.first();
+            BuildRequest max = selectRequests.first();
+
+            for(BuildRequest request : selectRequests){
+                if(request.x < min.x || request.y < min.y) min = request;
+                if(request.x > max.x || request.y > max.y) max = request;
+            }
+
+            drawSelection(min.x, min.y, max.x, max.y, maxSchematicSize, Pal.blueprint, Pal.blueprintBack);
         }
 
         //draw things that may be placed soon

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -438,13 +438,17 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
     }
 
     protected void drawSelection(int x1, int y1, int x2, int y2, int maxLength){
+        drawSelection(x1, y1, x2, y2, maxLength, Pal.accent, Pal.accentBack);
+    }
+
+    protected void drawSelection(int x1, int y1, int x2, int y2, int maxLength, Color front, Color back){
         NormalizeDrawResult result = Placement.normalizeDrawArea(Blocks.air, x1, y1, x2, y2, false, maxLength, 1f);
 
         Lines.stroke(2f);
 
-        Draw.color(Pal.accentBack);
+        Draw.color(back);
         Lines.rect(result.x, result.y - 1, result.x2 - result.x, result.y2 - result.y);
-        Draw.color(Pal.accent);
+        Draw.color(front);
         Lines.rect(result.x, result.y, result.x2 - result.x, result.y2 - result.y);
     }
 

--- a/core/src/mindustry/world/blocks/environment/Floor.java
+++ b/core/src/mindustry/world/blocks/environment/Floor.java
@@ -7,9 +7,11 @@ import arc.graphics.g2d.TextureAtlas.*;
 import arc.math.*;
 import arc.math.geom.*;
 import arc.struct.*;
+import arc.util.*;
 import arc.util.ArcAnnotate.*;
 import mindustry.content.*;
 import mindustry.entities.*;
+import mindustry.entities.units.*;
 import mindustry.graphics.*;
 import mindustry.graphics.MultiPacker.*;
 import mindustry.type.*;
@@ -238,4 +240,10 @@ public class Floor extends Block{
         return block.edges()[x][2 - y];
     }
 
+    public void drawRequest(BuildRequest req, Eachable<BuildRequest> list, boolean valid){
+        Draw.reset();
+        Draw.alpha(0.5f);
+        drawRequestRegion(req, list);
+        Draw.reset();
+    }
 }


### PR DESCRIPTION
> this is just me playing around with the code to get closer to the below explained goal

![Screen Shot 2020-04-26 at 12 38 12](https://user-images.githubusercontent.com/3179271/80305091-f8705680-87ba-11ea-8b17-42c0ea5cc450.png)

_basically, allowing any block, floor & overlay in a schematic:_

Currently we have `Loadouts.java`, which contains as you know the starting core layouts, but that only consists of normal blocks, and its hardcoded to place ores under drills.

I propose embedding support into schematics for floor & overlay layers as well.

The reason i'm diving into this now is since i'm planning to explore the 6.0 `tile.setFloor` calls, and it would be nice to have some predefined "ruins" or "decorated ore patches" that are placable on the map (by the server) in realtime.

And to do that i'll either have to modify the schematic format / come up with some sort of editor generation setting for predefined embeds / create like a secondary map to be loaded in that functions like a spritemap of some sort that i'll have to map out / etc, basically the schematic approach sounded most logical.

I don't really intend for players to be able to use it in single player or multiplayer, but while developing this it does have some promising usages for the ingame editor.

The reason i'm leaving this draft here is for discussion on what would be a nice approach, since i'd rather not bodge in my own hacky solution that lack official support, i'm willing to bet that more people find this idea interesting, and thus a more official implementation would be required.

Thanks for reading, please leave a reaction (either emoji or text)

**tldr** easily defining structures that use all 3 layers that the server can paste into the world 🥔 

> needless to say this code currently only sorta does the graphical part, not much else (yet)