### PR TITLE
Prevent colored map author name from tainting gameover

### DIFF
--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -140,7 +140,7 @@ public class ServerControl implements ApplicationListener{
                 Call.onInfoMessage((state.rules.pvp
                 ? "[YELLOW]The " + event.winner.name + " team is victorious![]" : "[SCARLET]Game over![]")
                 + "\nNext selected map:[accent] " + map.name() + "[]"
-                + (map.tags.containsKey("author") && !map.tags.get("author").trim().isEmpty() ? " by[accent] " + map.author() + "[]" : "") + "." +
+                + (map.tags.containsKey("author") && !map.tags.get("author").trim().isEmpty() ? " by[accent] " + map.author() + "[white]" : "") + "." +
                 "\nNew game begins in " + roundExtraTime + "[] seconds.");
 
                 info("Selected next map to be {0}.", map.name());


### PR DESCRIPTION
> been bothering me for a while now, this should fix the below issue from occurring:

![Screen Shot 2020-04-26 at 13 08 20](https://user-images.githubusercontent.com/3179271/80305741-045e1780-87bf-11ea-8583-7616bae5ab58.png)

> putting it into draft since i'm not sure if i got that number correct yet 😗 