### PR TITLE
Water extractor now requires 25 metaglass rather than 25 graphite to construct

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -1223,7 +1223,7 @@ public class Blocks implements ContentList{
         }};
 
         waterExtractor = new SolidPump("water-extractor"){{
-            requirements(Category.production, ItemStack.with(Items.copper, 25, Items.graphite, 25, Items.lead, 20));
+            requirements(Category.production, ItemStack.with(Items.copper, 25, Items.metaglass, 25, Items.lead, 20));
             result = Liquids.water;
             pumpAmount = 0.13f;
             size = 2;


### PR DESCRIPTION
Despite being a building for extracting liquids, it required graphite rather than metaglass; this change is mainly to just make it require metaglass rather than graphite to construct. 

With the recent PR of nerfing water extractors, this comes with the added bonus of already needing metaglass income beforehand so you can actually do piping rather than wonder why you spent 25 graphite on some building