### PR TITLE
Overdrive projector visualization on plastanium conveyors

### DIFF
--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -277,6 +277,10 @@ public class Block extends UnlockableContent{
         return rotate;
     }
 
+    public boolean shouldOverdrive(Tile tile){
+        return canOverdrive;
+    }
+
     /** Adds a region by name to be loaded, with the final name "{name}-suffix". Returns an ID to looks this region up by in {@link #reg(int)}. */
     protected int reg(String suffix){
         cacheRegionStrings.add(name + suffix);

--- a/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
+++ b/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
@@ -99,7 +99,7 @@ public class OverdriveProjector extends Block{
         public void drawSelect(){
             float realRange = range + phaseHeat * phaseRangeBoost;
 
-            indexer.eachBlock(this, realRange, other -> other.block().canOverdrive, other -> Drawf.selected(other, Tmp.c1.set(baseColor).a(Mathf.absin(4f, 1f))));
+            indexer.eachBlock(this, realRange, other -> other.block().canOverdrive && other.block().shouldOverdrive(other.tile()), other -> Drawf.selected(other, Tmp.c1.set(baseColor).a(Mathf.absin(4f, 1f))));
 
             Drawf.dashCircle(x, y, realRange, baseColor);
         }

--- a/core/src/mindustry/world/blocks/distribution/StackConveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/StackConveyor.java
@@ -102,6 +102,11 @@ public class StackConveyor extends Block implements Autotiler{
         return super.rotatedOutput(x, y);
     }
 
+    @Override
+    public boolean shouldOverdrive(Tile tile){
+        return tile.<StackConveyorEntity>ent().state == stateLoad;
+    }
+
     public class StackConveyorEntity extends TileEntity{
         public int state, blendprox;
 


### PR DESCRIPTION
> only shows the overdrive indicators for the loading dock

![Screen Shot 2020-04-30 at 16 01 11](https://user-images.githubusercontent.com/3179271/80719590-fc261500-8afb-11ea-8482-34e5c45ae1c7.png)

> personally not so happy with the way this now does a double check though