### PR TITLE
Finetune itemsmoved stat on stack conveyors

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -913,7 +913,7 @@ public class Blocks implements ContentList{
         plastaniumConveyor = new StackConveyor("plastanium-conveyor"){{
             requirements(Category.distribution, ItemStack.with(Items.plastanium, 1, Items.silicon, 1, Items.graphite, 1));
             health = 75;
-            speed = 0.04f;
+            speed = 2.5f / 60f;
             recharge = 2f;
         }};
 

--- a/core/src/mindustry/world/blocks/distribution/StackConveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/StackConveyor.java
@@ -57,7 +57,7 @@ public class StackConveyor extends Block implements Autotiler{
     public void setStats(){
         super.setStats();
 
-        stats.add(BlockStat.itemsMoved, speed * 60, StatUnit.perSecond);
+        stats.add(BlockStat.itemsMoved, Mathf.round(itemCapacity * speed * 60), StatUnit.itemsSecond);
     }
 
     @Override


### PR DESCRIPTION
> currently it shows like this, which is a bit vague and confusing:

![Screen Shot 2020-05-01 at 09 59 28](https://user-images.githubusercontent.com/3179271/80791641-96389c80-8b92-11ea-9230-f46958781634.png)

> this changes it to look like normal conveyors:

![Screen Shot 2020-05-01 at 09 58 46](https://user-images.githubusercontent.com/3179271/80791677-abadc680-8b92-11ea-87fd-3a657e7ed364.png)

> (& a slight boost from `24` to `25` items since that rounds nicely with its item capacity of `10`)
