### PR TITLE
Add throughput module to sandbox blocks

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -598,6 +598,7 @@ bar.progress = Build Progress
 bar.spawned = Units: {0}/{1}
 bar.input = Input
 bar.output = Output
+bar.throughput = Throughput: {0}/s
 
 bullet.damage = [stat]{0}[lightgray] damage
 bullet.splashdamage = [stat]{0}[lightgray] area dmg ~[stat] {1}[lightgray] tiles

--- a/core/src/mindustry/entities/def/TileComp.java
+++ b/core/src/mindustry/entities/def/TileComp.java
@@ -55,6 +55,7 @@ abstract class TileComp implements Posc, Teamc, Healthc, Tilec, Timerc, QuadTree
     PowerModule power;
     ItemModule items;
     LiquidModule liquids;
+    ThroughputModule throughput;
     ConsumeModule cons;
 
     private transient float timeScale = 1f, timeScaleDuration;
@@ -1054,6 +1055,10 @@ abstract class TileComp implements Posc, Teamc, Healthc, Tilec, Timerc, QuadTree
 
         if(power != null){
             power.graph.update();
+        }
+
+        if(throughput != null){
+            throughput.update();
         }
 
         updateFlow = false;

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -39,6 +39,7 @@ public class Block extends UnlockableContent{
     public boolean hasItems;
     public boolean hasLiquids;
     public boolean hasPower;
+    public boolean hasThroughput;
 
     public boolean outputsLiquid = false;
     public boolean consumesPower = true;
@@ -335,6 +336,14 @@ public class Block extends UnlockableContent{
 
         if(hasItems && configurable){
             bars.add("items", entity -> new Bar(() -> Core.bundle.format("bar.items", entity.items().total()), () -> Pal.items, () -> (float)entity.items().total() / itemCapacity));
+        }
+
+        if(hasThroughput){
+            bars.add("throughput", entity -> new Bar(() ->
+            Core.bundle.format("bar.throughput",
+            Strings.fixed(entity.throughput().window.getMean() * 60, 2)),
+            () -> Pal.items,
+            () -> (float)entity.throughput().window.getValueCount() / (float)entity.throughput().window.getWindowSize()));
         }
     }
 

--- a/core/src/mindustry/world/Tile.java
+++ b/core/src/mindustry/world/Tile.java
@@ -560,6 +560,7 @@ public class Tile implements Position, QuadTreeObject{
                 entity.power(new PowerModule());
                 entity.power().graph.add(entity);
             }
+            if(block.hasThroughput) entity.throughput(new ThroughputModule());
         }
     }
 

--- a/core/src/mindustry/world/blocks/distribution/StackConveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/StackConveyor.java
@@ -139,7 +139,6 @@ public class StackConveyor extends Block implements Autotiler{
 
             //item
             float size = itemSize * Mathf.lerp(Math.min((float)items.total() / itemCapacity, 1), 1f, 0.4f);
-            Drawf.shadow(Tmp.v1.x, Tmp.v1.y, size * 1.2f);
             Draw.rect(items.first().icon(Cicon.medium), Tmp.v1.x, Tmp.v1.y, size, size, 0);
         }
 

--- a/core/src/mindustry/world/blocks/sandbox/ItemSource.java
+++ b/core/src/mindustry/world/blocks/sandbox/ItemSource.java
@@ -24,6 +24,7 @@ public class ItemSource extends Block{
         solid = true;
         group = BlockGroup.transportation;
         configurable = true;
+        hasThroughput = true;
         config(Item.class, (tile, item) -> ((ItemSourceEntity)tile).outputItem = item);
         configClear(tile -> ((ItemSourceEntity)tile).outputItem = null);
     }
@@ -70,7 +71,7 @@ public class ItemSource extends Block{
             if(outputItem == null) return;
 
             items.set(outputItem, 1);
-            dump(outputItem);
+            if(dump(outputItem)) throughput.i++;
             items.set(outputItem, 0);
         }
 

--- a/core/src/mindustry/world/blocks/sandbox/ItemVoid.java
+++ b/core/src/mindustry/world/blocks/sandbox/ItemVoid.java
@@ -8,12 +8,15 @@ public class ItemVoid extends Block{
 
     public ItemVoid(String name){
         super(name);
-        update = solid = acceptsItems = true;
+        update = solid = acceptsItems = hasThroughput = true;
     }
 
     public class ItemVoidEntity extends TileEntity{
+
         @Override
-        public void handleItem(Tilec source, Item item){}
+        public void handleItem(Tilec source, Item item){
+            throughput.i++;
+        }
 
         @Override
         public boolean acceptItem(Tilec source, Item item){

--- a/core/src/mindustry/world/blocks/sandbox/LiquidSource.java
+++ b/core/src/mindustry/world/blocks/sandbox/LiquidSource.java
@@ -26,6 +26,7 @@ public class LiquidSource extends Block{
         liquidCapacity = 100f;
         configurable = true;
         outputsLiquid = true;
+        hasThroughput = true;
         config(Liquid.class, (tile, l) -> ((LiquidSourceEntity)tile).source = l);
         configClear(tile -> ((LiquidSourceEntity)tile).source = null);
     }
@@ -51,7 +52,9 @@ public class LiquidSource extends Block{
                 liquids.clear();
             }else{
                 liquids.add(source, liquidCapacity);
+                throughput.i += liquids().currentAmount();
                 dumpLiquid(source);
+                throughput.i -= liquids().currentAmount();
             }
         }
 

--- a/core/src/mindustry/world/blocks/sandbox/LiquidVoid.java
+++ b/core/src/mindustry/world/blocks/sandbox/LiquidVoid.java
@@ -11,6 +11,7 @@ public class LiquidVoid extends Block{
         hasLiquids = true;
         solid = true;
         update = true;
+        hasThroughput = true;
     }
 
     @Override
@@ -27,6 +28,7 @@ public class LiquidVoid extends Block{
 
         @Override
         public void handleLiquid(Tilec source, Liquid liquid, float amount){
+            throughput.i += amount;
         }
     }
 

--- a/core/src/mindustry/world/modules/ThroughputModule.java
+++ b/core/src/mindustry/world/modules/ThroughputModule.java
@@ -1,19 +1,8 @@
 package mindustry.world.modules;
 
 import arc.math.*;
-import arc.util.io.*;
 
-public class ThroughputModule extends BlockModule{
-
-    @Override
-    public void write(Writes write){
-
-    }
-
-    @Override
-    public void read(Reads read){
-
-    }
+public class ThroughputModule{
 
     public WindowedMean window = new WindowedMean(60 * 10);
     public float i;

--- a/core/src/mindustry/world/modules/ThroughputModule.java
+++ b/core/src/mindustry/world/modules/ThroughputModule.java
@@ -1,0 +1,25 @@
+package mindustry.world.modules;
+
+import arc.math.*;
+import arc.util.io.*;
+
+public class ThroughputModule extends BlockModule{
+
+    @Override
+    public void write(Writes write){
+
+    }
+
+    @Override
+    public void read(Reads read){
+
+    }
+
+    public WindowedMean window = new WindowedMean(60 * 10);
+    public float i;
+
+    public void update(){
+        window.addValue(i);
+        i = 0;
+    }
+}


### PR DESCRIPTION
> when playing around with #1954 i needed more-accurate-then-eyesight measurements.

so i started working on idea's for a measurement block sprite, and how it should function (sorters are instant / needs to support liquids / maybe like a junction / etc), but then it just dawned on me i could just add it to the `item` & `liquid` `sources` & `voids`:

basically those `4` blocks now measure their throughput over a period of `10 seconds`.
(during the **initial 10 seconds** the bar will slowly fill up, indicating it is measuring/loading)

> cursor is over the liquid void next to the cryofluid mixer (shown below)
![Screen Shot 2020-05-01 at 11 18 52](https://user-images.githubusercontent.com/3179271/80795713-95f1ce80-8b9d-11ea-9626-4e1153daaef7.png)

during my limited amount of testing it does appear to flicker a bit.
(like between `4.2` and `4.3` for normal conveyors, but that [somewhat makes sense](https://github.com/Anuken/Mindustry/blob/master/core/src/mindustry/world/blocks/distribution/Conveyor.java#L53))

![Screen Shot 2020-05-01 at 11 10 35](https://user-images.githubusercontent.com/3179271/80795543-1106b500-8b9d-11ea-90e9-d824a49eb5d6.png)

i am not sure how large of a performance impact this would have, nor if the measurement frame is of the right size, it takes a while to load but it seams nice to measure over a longer period of time, but its entirely up for debate.

> i'll probably post a video of this in action in `#pull-requests` later today 🥔 