### PR TITLE
add a sorter item filter timeout setting

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -668,6 +668,7 @@ setting.sensitivity.name = Controller Sensitivity
 setting.saveinterval.name = Save Interval
 setting.seconds = {0} seconds
 setting.blockselecttimeout.name = Block Select Timeout
+setting.filtertimeout.name = Sorter Filter Timeout
 setting.milliseconds = {0} milliseconds
 setting.fullscreen.name = Fullscreen
 setting.borderlesswindow.name = Borderless Window[lightgray] (may require restart)

--- a/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
+++ b/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
@@ -231,6 +231,8 @@ public class SettingsMenuDialog extends SettingsDialog{
             game.checkPref("crashreport", true);
         }
 
+        game.sliderPref("filtertimeout", 0, 0, 60 * 60 * 24, 10, i -> Core.bundle.format("setting.seconds", i));
+
         game.checkPref("savecreate", true);
         game.checkPref("blockreplace", true);
         game.checkPref("conveyorpathfinding", true);

--- a/core/src/mindustry/world/blocks/distribution/Sorter.java
+++ b/core/src/mindustry/world/blocks/distribution/Sorter.java
@@ -1,5 +1,6 @@
 package mindustry.world.blocks.distribution;
 
+import arc.*;
 import arc.graphics.g2d.*;
 import arc.math.*;
 import arc.scene.ui.layout.*;
@@ -17,6 +18,7 @@ import static mindustry.Vars.*;
 
 public class Sorter extends Block{
     private static Item lastItem;
+    private static float lastTime;
     public boolean invert;
 
     public Sorter(String name){
@@ -52,6 +54,11 @@ public class Sorter extends Block{
         @Override
         public void playerPlaced(){
             if(lastItem != null){
+                float timeout = Core.settings.getFloat("filtertimeout", 0f);
+                if(timeout > 0f && Time.time() - lastTime > timeout){
+                    lastItem = null;
+                    return;
+                }
                 tile.configure(lastItem);
             }
         }
@@ -60,6 +67,7 @@ public class Sorter extends Block{
         public void configured(Playerc player, Object value){
             super.configured(player, value);
 
+            lastTime = Time.time();
             if(!headless){
                 renderer.minimap.update(tile);
             }
@@ -76,8 +84,6 @@ public class Sorter extends Block{
                 Draw.rect("center", x, y);
                 Draw.color();
             }
-
-
         }
 
         @Override


### PR DESCRIPTION
Adds slider, that when not zero, will make sorters forget their last filtered item after some time.

Prevents setting a large amount of sorters to an unwanted item when you forget about it.
Timeout can be between a second and a day.