### PR TITLE
Double Click to Disconnect Mass Driver

### DIFF
--- a/core/src/mindustry/world/blocks/distribution/MassDriver.java
+++ b/core/src/mindustry/world/blocks/distribution/MassDriver.java
@@ -212,7 +212,10 @@ public class MassDriver extends Block{
 
         @Override
         public boolean onConfigureTileTapped(Tilec other){
-            if(this == other) return false;
+            if(this == other){
+                tile.configure(-1);
+                return false;
+            }
 
             if(link == other.pos()){
                 tile.configure(-1);


### PR DESCRIPTION
![Peek 2020-05-03 17-17](https://user-images.githubusercontent.com/16971676/80910471-3ee92680-8d62-11ea-8399-fcc4b4eb7b39.gif)
To inline the feature of double clicking with other connectable blocks such as Power Nodes, Item Bridges and Sorters.