### PR TITLE
Add filter reset keybind [J]

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -757,6 +757,7 @@ keybind.chat_history_next.name = Chat History Next
 keybind.chat_scroll.name = Chat Scroll
 keybind.drop_unit.name = Drop Unit
 keybind.zoom_minimap.name = Zoom Minimap
+keybind.reset_filters.name = Reset Filters
 mode.help.title = Description of modes
 mode.survival.name = Survival
 mode.survival.description = The normal mode. Limited resources and automatic incoming waves.\n[gray]Requires enemy spawns in the map to play.

--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -261,6 +261,7 @@ cancel = Cancel
 openlink = Open Link
 copylink = Copy Link
 back = Back
+resetfilters = Block filters reset!
 data.export = Export Data
 data.import = Import Data
 data.openfolder = Open Data Folder

--- a/core/src/mindustry/game/EventType.java
+++ b/core/src/mindustry/game/EventType.java
@@ -29,7 +29,8 @@ public class EventType{
         openWiki,
         teamCoreDamage,
         socketConfigChanged,
-        update
+        update,
+        resetFilters
     }
 
     public static class WinEvent{}

--- a/core/src/mindustry/input/Binding.java
+++ b/core/src/mindustry/input/Binding.java
@@ -56,6 +56,7 @@ public enum Binding implements KeyBind{
     chat_history_next(KeyCode.down),
     chat_scroll(new Axis(KeyCode.scroll)),
     console(KeyCode.f8),
+    reset_filters(KeyCode.j),
     ;
 
     private final KeybindValue defaultValue;

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -515,6 +515,10 @@ public class DesktopInput extends InputHandler{
                 Core.settings.put("lasersopacity", 0);
             }
         }
+
+        if(Core.input.keyTap(Binding.reset_filters)){
+            Events.fire(Trigger.resetFilters);
+        }
     }
 
     @Override

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -518,6 +518,8 @@ public class DesktopInput extends InputHandler{
 
         if(Core.input.keyTap(Binding.reset_filters)){
             Events.fire(Trigger.resetFilters);
+            ui.showInfoToast(Core.bundle.get("resetfilters"), 5);
+            Sounds.click.play();
         }
     }
 

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -898,7 +898,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
 
         if(block instanceof PowerNode){
             Array<Point2> skip = new Array<>();
-            
+
             for(int i = 1; i < points.size; i++){
                 int overlaps = 0;
                 Point2 point = points.get(i);

--- a/core/src/mindustry/world/blocks/distribution/Sorter.java
+++ b/core/src/mindustry/world/blocks/distribution/Sorter.java
@@ -1,5 +1,6 @@
 package mindustry.world.blocks.distribution;
 
+import arc.*;
 import arc.graphics.g2d.*;
 import arc.math.*;
 import arc.scene.ui.layout.*;
@@ -7,6 +8,7 @@ import arc.util.ArcAnnotate.*;
 import arc.util.*;
 import arc.util.io.*;
 import mindustry.entities.units.*;
+import mindustry.game.EventType.*;
 import mindustry.gen.*;
 import mindustry.type.*;
 import mindustry.world.*;
@@ -16,7 +18,8 @@ import mindustry.world.meta.*;
 import static mindustry.Vars.*;
 
 public class Sorter extends Block{
-    private static Item lastItem;
+    protected static Item lastItem;
+
     public boolean invert;
 
     public Sorter(String name){
@@ -25,10 +28,15 @@ public class Sorter extends Block{
         solid = true;
         instantTransfer = true;
         group = BlockGroup.transportation;
-        configurable = true;
         unloadable = false;
+
+        configurable = true;
         config(Item.class, (tile, item) -> ((SorterEntity)tile).sortItem = item);
         configClear(tile -> ((SorterEntity)tile).sortItem = null);
+
+        Events.on(Trigger.resetFilters, () -> {
+            lastItem = null;
+        });
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/sandbox/ItemSource.java
+++ b/core/src/mindustry/world/blocks/sandbox/ItemSource.java
@@ -6,6 +6,7 @@ import arc.scene.ui.layout.*;
 import arc.util.*;
 import arc.util.io.*;
 import mindustry.entities.units.*;
+import mindustry.game.EventType.*;
 import mindustry.gen.*;
 import mindustry.type.*;
 import mindustry.world.*;
@@ -15,7 +16,7 @@ import mindustry.world.meta.*;
 import static mindustry.Vars.*;
 
 public class ItemSource extends Block{
-    private static Item lastItem;
+    protected static Item lastItem;
 
     public ItemSource(String name){
         super(name);
@@ -23,9 +24,14 @@ public class ItemSource extends Block{
         update = true;
         solid = true;
         group = BlockGroup.transportation;
+
         configurable = true;
         config(Item.class, (tile, item) -> ((ItemSourceEntity)tile).outputItem = item);
         configClear(tile -> ((ItemSourceEntity)tile).outputItem = null);
+
+        Events.on(Trigger.resetFilters, () -> {
+            lastItem = null;
+        });
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/sandbox/LiquidSource.java
+++ b/core/src/mindustry/world/blocks/sandbox/LiquidSource.java
@@ -8,6 +8,7 @@ import arc.util.*;
 import arc.util.io.*;
 import mindustry.ctype.*;
 import mindustry.entities.units.*;
+import mindustry.game.EventType.*;
 import mindustry.gen.*;
 import mindustry.type.*;
 import mindustry.world.*;
@@ -16,7 +17,7 @@ import mindustry.world.blocks.*;
 import static mindustry.Vars.*;
 
 public class LiquidSource extends Block{
-    public static Liquid lastLiquid;
+    protected static Liquid lastLiquid;
 
     public LiquidSource(String name){
         super(name);
@@ -24,10 +25,15 @@ public class LiquidSource extends Block{
         solid = true;
         hasLiquids = true;
         liquidCapacity = 100f;
-        configurable = true;
         outputsLiquid = true;
+
+        configurable = true;
         config(Liquid.class, (tile, l) -> ((LiquidSourceEntity)tile).source = l);
         configClear(tile -> ((LiquidSourceEntity)tile).source = null);
+
+        Events.on(Trigger.resetFilters, () -> {
+            lastLiquid = null;
+        });
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/storage/Unloader.java
+++ b/core/src/mindustry/world/blocks/storage/Unloader.java
@@ -1,11 +1,13 @@
 package mindustry.world.blocks.storage;
 
+import arc.*;
 import arc.graphics.*;
 import arc.graphics.g2d.*;
 import arc.scene.ui.layout.*;
 import arc.util.*;
 import arc.util.io.*;
 import mindustry.entities.units.*;
+import mindustry.game.EventType.*;
 import mindustry.gen.*;
 import mindustry.type.*;
 import mindustry.world.*;
@@ -14,10 +16,10 @@ import mindustry.world.blocks.*;
 import static mindustry.Vars.*;
 
 public class Unloader extends Block{
+    protected static Item lastItem;
+
     public float speed = 1f;
     public final int timerUnload = timers++;
-
-    private static Item lastItem;
 
     public Unloader(String name){
         super(name);
@@ -25,13 +27,17 @@ public class Unloader extends Block{
         solid = true;
         health = 70;
         hasItems = true;
+
         configurable = true;
         config(Item.class, (tile, item) -> {
             tile.items().clear();
             ((UnloaderEntity)tile).sortItem = item;
         });
-
         configClear(tile -> ((UnloaderEntity)tile).sortItem = null);
+
+        Events.on(Trigger.resetFilters, () -> {
+            lastItem = null;
+        });
     }
 
     @Override


### PR DESCRIPTION
A simple way to reset filters on sorters, unloaders and item/liquid sources.
Adds Trigger.resetFilters event that is fired when J (no thought it's just unused) is pressed.
Mods can use this in custom filterable blocks if they want.

TODO:
- Mobile button?

Replaces #1957