### PR TITLE
Scale stack conveyor edge regions for requests

### DIFF
--- a/core/src/mindustry/world/blocks/distribution/StackConveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/StackConveyor.java
@@ -78,7 +78,7 @@ public class StackConveyor extends Block implements Autotiler{
 
         for(int i = 0; i < 4; i++){
             if((bits[3] & (1 << i)) == 0){
-                Draw.rect(edgeRegion, req.drawx(), req.drawy(), (req.rotation - i) * 90);
+                Draw.rect(edgeRegion, req.drawx(), req.drawy(), region.getWidth() * Draw.scl * req.animScale, region.getHeight() * Draw.scl * req.animScale, (req.rotation - i) * 90);
             }
         }
     }


### PR DESCRIPTION
> also found by `@FlipFlop#8988`, stack conveyor edges didn't scale for mobile build requests:

![May-04-2020 15-49-49](https://user-images.githubusercontent.com/3179271/80972907-fba0bd80-8e1e-11ea-8516-a48b66d2f2ae.gif)

![May-04-2020 15-49-41](https://user-images.githubusercontent.com/3179271/80972903-fb082700-8e1e-11ea-978e-e770cac42fcf.gif)
