### PR TITLE
[QOL] Show Overdrive Range when Building Overdrive

### DIFF
--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -148,10 +148,10 @@ public class DesktopInput extends InputHandler{
             }
             Draw.color();
             drawRequest(cursorX, cursorY, block, rotation);
-			if(!(block instanceof OverdriveProjector))
-            	block.drawPlace(cursorX, cursorY, rotation, validPlace(cursorX, cursorY, block, rotation));
-			else
-            	block.drawPlace(cursorX, cursorY, rotation, validPlace(cursorX, cursorY, block, rotation), player.team());
+            if(!(block instanceof OverdriveProjector))
+                block.drawPlace(cursorX, cursorY, rotation, validPlace(cursorX, cursorY, block, rotation));
+            else
+                block.drawPlace(cursorX, cursorY, rotation, validPlace(cursorX, cursorY, block, rotation), player.team());
 
             if(block.saveConfig && block.lastConfig != null){
                 brequest.set(cursorX, cursorY, rotation, block);

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -25,6 +25,7 @@ import mindustry.gen.*;
 import mindustry.graphics.*;
 import mindustry.ui.*;
 import mindustry.world.*;
+import mindustry.world.blocks.defense.*;
 
 import static arc.Core.scene;
 import static mindustry.Vars.*;
@@ -147,7 +148,10 @@ public class DesktopInput extends InputHandler{
             }
             Draw.color();
             drawRequest(cursorX, cursorY, block, rotation);
-            block.drawPlace(cursorX, cursorY, rotation, validPlace(cursorX, cursorY, block, rotation));
+			if(!(block instanceof OverdriveProjector))
+            	block.drawPlace(cursorX, cursorY, rotation, validPlace(cursorX, cursorY, block, rotation));
+			else
+            	block.drawPlace(cursorX, cursorY, rotation, validPlace(cursorX, cursorY, block, rotation), player.team());
 
             if(block.saveConfig && block.lastConfig != null){
                 brequest.set(cursorX, cursorY, rotation, block);

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -19,6 +19,7 @@ import mindustry.annotations.Annotations.*;
 import mindustry.ctype.*;
 import mindustry.entities.*;
 import mindustry.entities.units.*;
+import mindustry.game.*;
 import mindustry.gen.*;
 import mindustry.graphics.*;
 import mindustry.graphics.MultiPacker.*;
@@ -213,6 +214,9 @@ public class Block extends UnlockableContent{
 
     /** Drawn when you are placing a block. */
     public void drawPlace(int x, int y, int rotation, boolean valid){
+    }
+
+    public void drawPlace(int x, int y, int rotation, boolean valid, Team team){
     }
 
     public float drawPlaceText(String text, int x, int y, boolean valid){

--- a/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
+++ b/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
@@ -45,11 +45,10 @@ public class OverdriveProjector extends Block{
 
     @Override
     public void drawPlace(int x, int y, int rotation, boolean valid, Team team){
-        float showRange = Interpolation.linear.apply(range, range + phaseRangeBoost, Mathf.absin(Time.time(), 10f, 1f));
-        Drawf.dashCircle(x * tilesize + offset(), y * tilesize + offset(), showRange, Pal.accent);
+        Drawf.dashCircle(x * tilesize + offset(), y * tilesize + offset(), range, Pal.accent);
 
         for(Tile overdrive : indexer.getAllied(team, BlockFlag.overdrive))
-            Drawf.dashCircle(overdrive.ent().x(), overdrive.ent().y(), range, Pal.accent);
+            Drawf.dashCircle(overdrive.ent().x(), overdrive.ent().y(), range + overdrive.<OverdriveEntity>ent().phaseHeat * phaseRangeBoost, Pal.accent);
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
+++ b/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
@@ -47,8 +47,9 @@ public class OverdriveProjector extends Block{
     public void drawPlace(int x, int y, int rotation, boolean valid, Team team){
         float showRange = Interpolation.linear.apply(range, range + phaseRangeBoost, Mathf.absin(Time.time(), 10f, 1f));
         Drawf.dashCircle(x * tilesize + offset(), y * tilesize + offset(), showRange, Pal.accent);
-        //for(Tile other : indexer.getAllied(team, BlockFlag.overdrive))
-        //	Drawf.dashCircle(other.x * tilesize + offset(), other.y * tilesize + offset(), range, Pal.accent);
+
+        for(Tile overdrive : indexer.getAllied(team, BlockFlag.overdrive))
+            Drawf.dashCircle(overdrive.ent().x(), overdrive.ent().y(), range, Pal.accent);
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
+++ b/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
@@ -3,9 +3,11 @@ package mindustry.world.blocks.defense;
 import arc.graphics.*;
 import arc.graphics.g2d.*;
 import arc.math.*;
+import arc.struct.*;
 import arc.util.*;
 import arc.util.io.*;
 import mindustry.annotations.Annotations.*;
+import mindustry.game.*;
 import mindustry.gen.*;
 import mindustry.graphics.*;
 import mindustry.world.*;
@@ -29,6 +31,7 @@ public class OverdriveProjector extends Block{
     public OverdriveProjector(String name){
         super(name);
         solid = true;
+		flags = EnumSet.of(BlockFlag.overdrive);
         update = true;
         hasPower = true;
         hasItems = true;
@@ -41,8 +44,11 @@ public class OverdriveProjector extends Block{
     }
 
     @Override
-    public void drawPlace(int x, int y, int rotation, boolean valid){
+    public void drawPlace(int x, int y, int rotation, boolean valid, Team team){
         Drawf.dashCircle(x * tilesize + offset(), y * tilesize + offset(), range, Pal.accent);
+        Drawf.dashCircle(x * tilesize + offset(), y * tilesize + offset(), range + phaseRangeBoost, phaseColor);
+		for(Tile other : indexer.getAllied(team, BlockFlag.overdrive))
+        	Drawf.dashCircle(other.x * tilesize + offset(), other.y * tilesize + offset(), range, Pal.accent);
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
+++ b/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
@@ -31,7 +31,7 @@ public class OverdriveProjector extends Block{
     public OverdriveProjector(String name){
         super(name);
         solid = true;
-		flags = EnumSet.of(BlockFlag.overdrive);
+        flags = EnumSet.of(BlockFlag.overdrive);
         update = true;
         hasPower = true;
         hasItems = true;
@@ -45,10 +45,10 @@ public class OverdriveProjector extends Block{
 
     @Override
     public void drawPlace(int x, int y, int rotation, boolean valid, Team team){
-        Drawf.dashCircle(x * tilesize + offset(), y * tilesize + offset(), range, Pal.accent);
-        Drawf.dashCircle(x * tilesize + offset(), y * tilesize + offset(), range + phaseRangeBoost, phaseColor);
-		for(Tile other : indexer.getAllied(team, BlockFlag.overdrive))
-        	Drawf.dashCircle(other.x * tilesize + offset(), other.y * tilesize + offset(), range, Pal.accent);
+        float showRange = Interpolation.linear.apply(range, range + phaseRangeBoost, Mathf.absin(Time.time(), 10f, 1f));
+        Drawf.dashCircle(x * tilesize + offset(), y * tilesize + offset(), showRange, Pal.accent);
+        //for(Tile other : indexer.getAllied(team, BlockFlag.overdrive))
+        //	Drawf.dashCircle(other.x * tilesize + offset(), other.y * tilesize + offset(), range, Pal.accent);
     }
 
     @Override

--- a/core/src/mindustry/world/meta/BlockFlag.java
+++ b/core/src/mindustry/world/meta/BlockFlag.java
@@ -14,6 +14,8 @@ public enum BlockFlag{
     comandCenter,
     /** Repair point. */
     repair,
+	/** Overdrive. */
+	overdrive,
     /** Upgrade pad. */
     mechPad;
 

--- a/core/src/mindustry/world/meta/BlockFlag.java
+++ b/core/src/mindustry/world/meta/BlockFlag.java
@@ -14,8 +14,8 @@ public enum BlockFlag{
     comandCenter,
     /** Repair point. */
     repair,
-	/** Overdrive. */
-	overdrive,
+    /** Overdrive. */
+    overdrive,
     /** Upgrade pad. */
     mechPad;
 


### PR DESCRIPTION
![Screenshot_20200506_124151](https://user-images.githubusercontent.com/16971676/81139087-14cc7a00-8f97-11ea-96b2-774b05993bfd.png)
Currently you need to either guess or memorize the size of the overdrive range when you want to place down an overdrive with minimal overlap. This pull will show all of the overdrive range when OverdriveProjector is selected.

Update: Maybe won't be updated for a month or two. Feel free to do a PR on this

TODO:
- [ ] Show overdrive range around the mouse only
- [ ] Toggleable shaders to show area coverage like shield projectors
