### PR TITLE
Shift Click to Same Tile Configure

### DIFF
--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -610,6 +610,11 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         }
         boolean consumed = false, showedInventory = false;
 
+        if(tile.block().configurable && tile.interactable(player.team())){
+            consumed = true;
+            tile.onConfigureTileTapped(tile);
+        }
+
         //check if tapped block is configurable
         if(tile.block().configurable && tile.interactable(player.team())){
             consumed = true;

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -610,15 +610,13 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         }
         boolean consumed = false, showedInventory = false;
 
-        if(tile.block().configurable && tile.interactable(player.team())){
-            consumed = true;
-            tile.onConfigureTileTapped(tile);
-        }
-
         //check if tapped block is configurable
         if(tile.block().configurable && tile.interactable(player.team())){
             consumed = true;
-            if(((!frag.config.isShown() && tile.shouldShowConfigure(player)) //if the config fragment is hidden, show
+            if(Core.input.keyDown(Binding.dash)){
+                tile.onConfigureTileTapped(tile);
+            }
+            else if(((!frag.config.isShown() && tile.shouldShowConfigure(player)) //if the config fragment is hidden, show
             //alternatively, the current selected block can 'agree' to switch config tiles
             || (frag.config.isShown() && frag.config.getSelectedTile().onConfigureTileTapped(tile)))){
                 Sounds.click.at(tile);


### PR DESCRIPTION
![Peek 2020-05-10 18-08](https://user-images.githubusercontent.com/16971676/81496531-dadadb00-92ea-11ea-90bf-9adc979b94af.gif)
In the GIF above, I am Shift-Clicking the power nodes to configure the power nodes itself. It's the same as clicking the power node twice or double-click. This too works with all other double-click configurable blocks such as bridges and sorters.