### PR TITLE
Add TWS (Hong Kong server) to server.json

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -52,5 +52,8 @@
   },
   {
     "address": "mindustry.kbni.net.au:6568"
+  },
+  {
+    "address": "twsmindustry.24x7.hk"
   }
 ]


### PR DESCRIPTION
Based in Hong Kong, the Co-op server has been stable and regularly maintained since 4 Feb. 

The server is also known as "ggg.sytes.net", used a different domain in this commit for easier identification.

We have moderators across different timezone, a map pool focused on the uniqueness and own plugin and server control.

If the full name of TWS doesn't look good in the public server list, please let me know. I can just leave the short form TWS as the display server name.