### PR TITLE
[QOL] Center Map to Player Implementation

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -639,6 +639,7 @@ setting.linear.name = Linear Filtering
 setting.hints.name = Hints
 setting.flow.name = Display Resource Flow Rate
 setting.buildautopause.name = Auto-Pause Building
+setting.mapcenter.name = Auto Center Map To Player
 setting.animatedwater.name = Animated Fluids
 setting.animatedshields.name = Animated Shields
 setting.antialias.name = Antialias[lightgray] (requires restart)[]

--- a/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
+++ b/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
@@ -238,6 +238,7 @@ public class SettingsMenuDialog extends SettingsDialog{
         if(!mobile){
             game.checkPref("buildautopause", false);
         }
+        game.checkPref("mapcenter", true);
 
         if(steam){
             game.sliderPref("playerlimit", 16, 2, 32, i -> {

--- a/core/src/mindustry/ui/fragments/MinimapFragment.java
+++ b/core/src/mindustry/ui/fragments/MinimapFragment.java
@@ -111,10 +111,12 @@ public class MinimapFragment extends Fragment{
     }
 
     public void toggle(){
-        float size = baseSize * zoom * world.width();
-        float ratio = (float)renderer.minimap.getTexture().getHeight() / renderer.minimap.getTexture().getWidth();
-        panx = size/2f - player.x() / (world.width() * tilesize) * size;
-        pany = size*ratio/2f - player.y() / (world.height() * tilesize) * size*ratio;
+        if(Core.settings.getBool("mapcenter")){
+            float size = baseSize * zoom * world.width();
+            float ratio = (float)renderer.minimap.getTexture().getHeight() / renderer.minimap.getTexture().getWidth();
+            panx = (size/2f - player.x() / (world.width() * tilesize) * size) / zoom;
+            pany = (size*ratio/2f - player.y() / (world.height() * tilesize) * size*ratio) / zoom;
+        }
         shown = !shown;
     }
 }

--- a/core/src/mindustry/ui/fragments/MinimapFragment.java
+++ b/core/src/mindustry/ui/fragments/MinimapFragment.java
@@ -8,7 +8,6 @@ import arc.math.*;
 import arc.scene.*;
 import arc.scene.event.*;
 import arc.scene.ui.layout.*;
-import arc.util.*;
 import mindustry.gen.*;
 import mindustry.input.*;
 import mindustry.ui.*;

--- a/core/src/mindustry/ui/fragments/MinimapFragment.java
+++ b/core/src/mindustry/ui/fragments/MinimapFragment.java
@@ -8,6 +8,7 @@ import arc.math.*;
 import arc.scene.*;
 import arc.scene.event.*;
 import arc.scene.ui.layout.*;
+import arc.util.*;
 import mindustry.gen.*;
 import mindustry.input.*;
 import mindustry.ui.*;
@@ -111,6 +112,10 @@ public class MinimapFragment extends Fragment{
     }
 
     public void toggle(){
+        float size = baseSize * zoom * world.width();
+        float ratio = (float)renderer.minimap.getTexture().getHeight() / renderer.minimap.getTexture().getWidth();
+        panx = size/2f - player.x() / (world.width() * tilesize) * size;
+        pany = size*ratio/2f - player.y() / (world.height() * tilesize) * size*ratio;
         shown = !shown;
     }
 }


### PR DESCRIPTION
Opening the map will center the map to you. So you have a better time navigating yourself instead of searching for yourself in a cluster of blocks with the same colour or searching for yourself in a very huge map.

TODO:
- [X] Make it not ignore zoom