### PR TITLE
Remove kr server

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -42,9 +42,6 @@
     "address": "aamindustry.play.ai"
   },
   {
-    "address": "mindustry.kr"
-  },
-  {
     "address": "mindustry.atannergaming.com"
   },
   {


### PR DESCRIPTION
# Too many griefers
Players didn't want to grief on their main server, so the users seemed to be doing it on my server.

# Admins are volunteers.
The plugin solves most of the problems, but on average 7 hours a day, about 13 people come to griefing the server __every day__.

Yeah. Mindustry is Sandbox defence game.
So there's a limit to plugins. (Unless I make AI)
Admins have been busy and tired of catching griefers every day, not playing games.

# Not many multiplayer-only maps
There are more cases of building a meltdown or wave skip in just 15 waves.
Most discord/steam map isn't designed for multiplayer.

The solution is to create a map, but unlike other servers, my server is a solo development, so I don't have enough time to do plugin and server monitoring and map production at the same time.

# When will this server come back?
After making new server contents
ex) Bullet hell (like a anuke's other games)