### PR TITLE
add Chaotic-Neutral to Community Server List

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -58,5 +58,8 @@
   },
   {
     "address": "twsmindustry.24x7.hk"
+  },
+  {
+    "address": "Chaotic-Neutral.ddns.net:1111"
   }
 ]


### PR DESCRIPTION
Chaotic-Neutral. A US based Mindustry server with the goal of giving the best griefer-free experience.
We have na awesome discord with channels for almost any topic as well as useful information.