### PR TITLE
Reduce the camera shake generated by salvos

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -1546,7 +1546,7 @@ public class Blocks implements ContentList{
             ammoEjectBack = 3f;
             cooldown = 0.03f;
             recoilAmount = 3f;
-            shootShake = 2f;
+            shootShake = 1f;
             burstSpacing = 3f;
             shots = 4;
             ammoUseEffect = Fx.shellEjectBig;


### PR DESCRIPTION
It becomes very difficult to try and build things precisely around salvos, specifically in attack maps, because they shoot very fast and cause a lot of camera shake, which makes very difficult to place conveyors or turrets around them.