### PR TITLE
Reduce voteCooldown

### DIFF
--- a/core/src/mindustry/core/NetServer.java
+++ b/core/src/mindustry/core/NetServer.java
@@ -305,7 +305,7 @@ public class NetServer implements ApplicationListener{
         //voting round duration in seconds
         float voteDuration = 0.5f * 60;
         //cooldown between votes in seconds
-        int voteCooldown = 60 * 5;
+        int voteCooldown = 10;
 
         class VoteSession{
             Playerc target;


### PR DESCRIPTION
### Reason
If the vote fails to expel the griefer, during the cool time, the griefers can destroy everything.
It's really enough time.

The best solution is a remove voteCooldown or 5~10 second cooldown.