### PR TITLE
[Small Fix] Cursor On Enemy Block.

### DIFF
--- a/core/src/mindustry/entities/comp/TileComp.java
+++ b/core/src/mindustry/entities/comp/TileComp.java
@@ -995,7 +995,7 @@ abstract class TileComp implements Posc, Teamc, Healthc, Tilec, Timerc, QuadTree
 
     /** Returns whether or not a hand cursor should be shown over this block. */
     public Cursor getCursor(){
-        return block.configurable ? && tile.team() == player.team() SystemCursor.hand : SystemCursor.arrow;
+        return block.configurable && tile.team() == player.team() ? SystemCursor.hand : SystemCursor.arrow;
     }
 
     /**

--- a/core/src/mindustry/entities/comp/TileComp.java
+++ b/core/src/mindustry/entities/comp/TileComp.java
@@ -995,7 +995,7 @@ abstract class TileComp implements Posc, Teamc, Healthc, Tilec, Timerc, QuadTree
 
     /** Returns whether or not a hand cursor should be shown over this block. */
     public Cursor getCursor(){
-        return block.configurable ? SystemCursor.hand : SystemCursor.arrow;
+        return block.configurable ? && tile.team() == player.team() SystemCursor.hand : SystemCursor.arrow;
     }
 
     /**


### PR DESCRIPTION
If a player hovers over an enemy block, although it may be configurable, the cursor should not become a hand because you can't configure it.