### PR TITLE
remove abandoned.io (mindustry.io)

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -27,18 +27,6 @@
     "address": "mindustry.ru:7000"
   },
   {
-    "address": "mindustry.io"
-  },
-  {
-    "address": "mindustry.io:1000"
-  },
-  {
-    "address": "mindustry.io:2000"
-  },
-  {
-    "address": "mindustry.io:3000"
-  },
-  {
     "address": "aamindustry.play.ai"
   },
   {


### PR DESCRIPTION
Aze/fuzzbuck has been missing ever since he started that rent a server thing.
About a week ago mindustry.io died.
It should be removed, hes not coming back