### PR TITLE
Make coreblocks have their team represented on sprite

### DIFF
--- a/core/src/mindustry/world/blocks/storage/CoreBlock.java
+++ b/core/src/mindustry/world/blocks/storage/CoreBlock.java
@@ -100,7 +100,18 @@ public class CoreBlock extends StorageBlock{
         public void requestSpawn(Playerc player){
             Call.onPlayerSpawn(tile, player);
         }
-
+        @Override
+        public void draw(Tile tile){
+            Draw.rect(Core.atlas.find(name + "-base"), tile.drawx(), tile.drawy());
+            if(tile.getTeam() == Team.sharded){
+                Draw.rect(Core.atlas.find(name), tile.drawx(), tile.drawy());
+            } else {
+                Draw.color(tile.getTeam().color);
+                Draw.rect(Core.atlas.find(name + "-top"), tile.drawx(), tile.drawy());
+            }
+            Draw.color();
+            Draw.reset();
+        }
         @Override
         public void drawLight(){
             Drawf.light(x, y, 30f * size, Pal.accent, 0.5f + Mathf.absin(20f, 0.1f));


### PR DESCRIPTION
I made this on my custom build, and it turned out very well. As I can't upload files, I can't upload the sprites required, but look in my build's sprites: [block sprites](https://github.com/ThePythonGuy3/Mindblowstry/tree/master/core/assets-raw/sprites/blocks/storage)

If you don't like mine, you'll need: name (sharded team block), name-top (The part that changes depending on team) and name-base (The base of the core).

Here's how it turns out:
![image](https://cdn.discordapp.com/attachments/656612099128164362/722114648077500476/unknown.png)