### PR TITLE
Unify tower terminology in german translation of tutorial

### DIFF
--- a/core/assets/bundles/bundle_de.properties
+++ b/core/assets/bundles/bundle_de.properties
@@ -1076,8 +1076,8 @@ tutorial.breaking = Oft kommt es vor, dass Blöcke zerstört werden müssen.\n[a
 tutorial.breaking.mobile = Oft kommt es vor, dass Blöcke zerstört werden müssen.\n[accent]Wähle den Abbau-Modus[], dann wähle einen Block um ihn zu zerstören.\nZerstöre eine Fläche, indem du deinen Finger einige Sekunden gedrückt hältst[] und in eine beliebige Richtung ziehst.\nTippe auf das Häkchen um den Rückbau zu bestätigen.\n\n[accent]Zerstöre all Schrott-Blöcke links des Kerns mithilfe der Flächenauswahl.
 tutorial.withdraw = Einige Situationen erfordern, dass Materialien direkt aus den Blöcken aufgenommen werden.\nUm dies zu tun, [accent]tippe auf einen Block[] mit Materialien dann [accent]tippe auf das Material[] in diesem Block.\nUm mehrere Materialien zu entnehmen [accent]tippe darauf und halte die Maustaste gedrückt[].\n\n[accent]Entnimm etwas Kupfer vom Kern.[]
 tutorial.deposit = Materialien können in Blöcke abgelegt werden, indem du  die linke Maustaste drückst und von deinem Schiff dorthin ziehst.\n\n[accent]Lege das Kupfer zurück in den Kern.[]
-tutorial.waves = Der [lightgray]Gegner[] greift an.\n\nVerteidige deinen Kern 2 Wellen lang. Baue mehr Türme.
-tutorial.waves.mobile = Der[lightgray] Gegner[] greift an.\n\nVerteidige deinen Kern 2 Wellen lang. Dein Schiff feuert automatisch auf Gegner.\nBaue mehr Geschütztürme und Bohrer. Baue mehr Kupfer ab.
+tutorial.waves = Der [lightgray]Gegner[] greift an.\n\nVerteidige deinen Kern 2 Wellen lang. Baue mehr Geschütze.
+tutorial.waves.mobile = Der[lightgray] Gegner[] greift an.\n\nVerteidige deinen Kern 2 Wellen lang. Dein Schiff feuert automatisch auf Gegner.\nBaue mehr Geschütze und Bohrer. Baue mehr Kupfer ab.
 tutorial.launch = Sobald du eine bestimmte Welle erreicht hast, kannst du die [accent]Mission abschließen[]. Dadurch lässt du deine Basis zurück[accent] und überträgst alle Ressourcen in deinen Kern.[]\nDiese Ressourcen können zur Erforschung neuer Technologien eingesetzt werden.\n\n[accent]Drücke nun den Abschluss-Button.
 
 item.copper.description = Ein nützliches Material. Wird in allen Arten von Blöcken verwendet.


### PR DESCRIPTION
A friend of mine was playing through the tutorial and was confused by the term "Turm", since the duo is translated as "Geschütz", so he didn't quite know what the tutorial wanted. This unifies the terminology, since in the beginning you only have one "Geschütz" choice anyways.