### PR TITLE
Change wave targeting

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -1411,7 +1411,6 @@ public class Blocks implements ContentList{
             Liquids.cryofluid, Bullets.cryoShot,
             Liquids.oil, Bullets.oilShot
             );
-            targetAir = false;
             size = 2;
             recoilAmount = 0f;
             reloadTime = 2f;

--- a/core/src/mindustry/world/blocks/defense/turrets/LiquidTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/LiquidTurret.java
@@ -72,6 +72,14 @@ public class LiquidTurret extends Turret{
             return target != null && hasAmmo();
         }
 
+        protected void findTargetWithoutStatus(){
+            if(targetAir && !targetGround){
+                target = Units.closestEnemy(team, x, y, range, e -> !e.dead() && !e.isGrounded() &&!e.hasEffect(liquids.current().effect));
+            }else{
+                target = Units.closestTarget(team, x, y, range, e -> !e.dead() && (e.isGrounded() || targetAir) && (!e.isGrounded() || targetGround) &&!e.hasEffect(liquids.current().effect));
+            }
+        }
+
         @Override
         protected void findTarget(){
             if(liquids.current().canExtinguish()){
@@ -85,8 +93,10 @@ public class LiquidTurret extends Turret{
                     }
                 }
             }
-
-            super.findTarget();
+            findTargetWithoutStatus();
+            if(target == null) {
+                super.findTarget();
+            }
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/defense/turrets/LiquidTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/LiquidTurret.java
@@ -74,9 +74,9 @@ public class LiquidTurret extends Turret{
 
         protected void findTargetWithoutStatus(){
             if(targetAir && !targetGround){
-                target = Units.closestEnemy(team, x, y, range, e -> !e.dead() && !e.isGrounded() &&!e.hasEffect(liquids.current().effect));
+                target = Units.closestEnemy(team, x, y, range, e -> !e.dead() && !e.isGrounded() && !e.hasEffect(liquids.current().effect));
             }else{
-                target = Units.closestTarget(team, x, y, range, e -> !e.dead() && (e.isGrounded() || targetAir) && (!e.isGrounded() || targetGround) &&!e.hasEffect(liquids.current().effect));
+                target = Units.closestTarget(team, x, y, range, e -> !e.dead() && (e.isGrounded() || targetAir) && (!e.isGrounded() || targetGround) && !e.hasEffect(liquids.current().effect));
             }
         }
 


### PR DESCRIPTION
The main purpose of waves are to apply status effects to all units around them, so shouldn't they prioritize units without the status effect they apply? Also I don't see why waves shouldn't be able to target air, so I changed that too. 