### PR TITLE
Add phased range when selecting menders or overdrivers

### DIFF
--- a/core/src/mindustry/world/blocks/defense/MendProjector.java
+++ b/core/src/mindustry/world/blocks/defense/MendProjector.java
@@ -86,10 +86,15 @@ public class MendProjector extends Block{
         @Override
         public void drawSelect(){
             float realRange = range + phaseHeat * phaseRangeBoost;
+            if(!cons().optionalValid()) {
+                indexer.eachBlock(this, realRange, other -> true, other -> Drawf.selected(other, Tmp.c1.set(baseColor).a(Mathf.absin(4f, 1f))));
 
-            indexer.eachBlock(this, realRange, other -> true, other -> Drawf.selected(other, Tmp.c1.set(baseColor).a(Mathf.absin(4f, 1f))));
+                Drawf.dashCircle(x, y, realRange, baseColor);
+            } else {
+                indexer.eachBlock(this, realRange, other -> true, other -> Drawf.selected(other, Tmp.c1.set(phaseColor).a(Mathf.absin(4f, 1f))));
 
-            Drawf.dashCircle(x, y, realRange, baseColor);
+                Drawf.dashCircle(x, y, realRange, phaseColor);
+            }
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/defense/MendProjector.java
+++ b/core/src/mindustry/world/blocks/defense/MendProjector.java
@@ -52,7 +52,8 @@ public class MendProjector extends Block{
 
     @Override
     public void drawPlace(int x, int y, int rotation, boolean valid){
-        Drawf.dashCircle(x * tilesize + offset, y * tilesize + offset, range, Pal.accent);
+        Drawf.dashCircle(x * tilesize + offset, y * tilesize + offset, range + phaseRangeBoost, phaseColor);
+        Drawf.dashCircle(x * tilesize + offset, y * tilesize + offset, range, baseColor);
     }
 
     public class MendEntity extends Building{

--- a/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
+++ b/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
@@ -43,7 +43,10 @@ public class OverdriveProjector extends Block{
 
     @Override
     public void drawPlace(int x, int y, int rotation, boolean valid){
-        Drawf.dashCircle(x * tilesize + offset, y * tilesize + offset, range, Pal.accent);
+        if(hasBoost) {
+            Drawf.dashCircle(x * tilesize + offset, y * tilesize + offset, range + phaseRangeBoost, phaseColor);
+        }
+        Drawf.dashCircle(x * tilesize + offset, y * tilesize + offset, range, baseColor);
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
+++ b/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
@@ -99,7 +99,7 @@ public class OverdriveProjector extends Block{
         public void drawSelect(){
             float realRange = range + phaseHeat * phaseRangeBoost;
 
-            if(!cons().optionalValid()) {
+            if(!cons().optionalValid() || !hasBoost) {
                 indexer.eachBlock(this, realRange, other -> other.block().canOverdrive, other -> Drawf.selected(other, Tmp.c1.set(baseColor).a(Mathf.absin(4f, 1f))));
 
                 Drawf.dashCircle(x, y, realRange, baseColor);

--- a/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
+++ b/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
@@ -102,6 +102,15 @@ public class OverdriveProjector extends Block{
             indexer.eachBlock(this, realRange, other -> other.block().canOverdrive, other -> Drawf.selected(other, Tmp.c1.set(baseColor).a(Mathf.absin(4f, 1f))));
 
             Drawf.dashCircle(x, y, realRange, baseColor);
+            if(!cons().optionalValid()) {
+                indexer.eachBlock(this, realRange, other -> other.block().canOverdrive, other -> Drawf.selected(other, Tmp.c1.set(baseColor).a(Mathf.absin(4f, 1f))));
+
+                Drawf.dashCircle(x, y, realRange, baseColor);
+            } else {
+                indexer.eachBlock(this, realRange, other -> other.block().canOverdrive, other -> Drawf.selected(other, Tmp.c1.set(phaseColor).a(Mathf.absin(4f, 1f))));
+
+                Drawf.dashCircle(x, y, realRange, phaseColor);
+            }
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
+++ b/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
@@ -99,9 +99,6 @@ public class OverdriveProjector extends Block{
         public void drawSelect(){
             float realRange = range + phaseHeat * phaseRangeBoost;
 
-            indexer.eachBlock(this, realRange, other -> other.block().canOverdrive, other -> Drawf.selected(other, Tmp.c1.set(baseColor).a(Mathf.absin(4f, 1f))));
-
-            Drawf.dashCircle(x, y, realRange, baseColor);
             if(!cons().optionalValid()) {
                 indexer.eachBlock(this, realRange, other -> other.block().canOverdrive, other -> Drawf.selected(other, Tmp.c1.set(baseColor).a(Mathf.absin(4f, 1f))));
 


### PR DESCRIPTION
Based on https://github.com/Anuken/Mindustry-Suggestions/issues/309

Queued menders/overdrivers show phased and regular range: 
![Mindustry 7_20_2020 6_12_44 PM (2)](https://user-images.githubusercontent.com/68400583/88001398-ed288080-cab4-11ea-9ee0-929aa0432bca.png)
Selecting placed menders/overdrivers have green range indicator and green icons on affected blocks: 
![Mindustry 7_20_2020 9_58_38 PM (2)](https://user-images.githubusercontent.com/68400583/88014691-6388ab00-cad4-11ea-996d-adbece1dbf29.png)
But when phased, are yellowish-orange
![Mindustry 7_20_2020 9_57_23 PM (2)](https://user-images.githubusercontent.com/68400583/88014715-756a4e00-cad4-11ea-99b6-d204aab0a728.png)
A very simple change, not sure if it deserves a pull request
