### PR TITLE
Plastanium conveyors are worse than titaniums in every condition.

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -911,7 +911,7 @@ public class Blocks implements ContentList{
         plastaniumConveyor = new StackConveyor("plastanium-conveyor"){{
             requirements(Category.distribution, with(Items.plastanium, 1, Items.silicon, 1, Items.graphite, 1));
             health = 75;
-            speed = 2.5f / 60f;
+            speed = 3.125f / 75f;
             recharge = 2f;
         }};
 


### PR DESCRIPTION
Plastanium conveyor is only good when compared to titanium one with unlimited item source because it instantly fills plastanium conveyors but in reality its worse because nothing can instantly fill plastanium conveyors and in a condition which we use boosted airblast its a bit worse than titanium conveyor. I didn't test the other drills/production outputs but i guess it gets worse. Increasing the speed of it, the items get to where they should earlier and maybe makes it better than titanium conveyors because they almost have same speed but plastanium conveyors also have to fill up thats why currently if you have high throughput use plastanium, if you have low throughput use titanium because with low throughput it takes so long for 10 items to fill and go to somewhere but maybe increasing the speed makes it similar to titanium with low throughput. The distance between the two points are also very important because of the high speed it goes to somewhere so fast even if it takes so long to fill.

Current situation:
Plastanium: Has to fill (Bad) + low speed (Bad) (Requires very high throughput that is only done with unlimited item source to be better than titanium conveyors)
Titanium: Doesn't has to fill (Good) + low speed (Bad) (Speed is a bit worse than plastanium but that doesnt matter so much)

PR situation:
Plastanium: Has to fill (Bad) + high speed (Good) (Requires good throughput to be better than titanium and its actually easy to do it)
Titanium: Doesn't has to fill (Good) + low speed (Bad) (Compared to Plastanium)

If you implement this PR both conveyors will be good in certain situations (Plastanium at higher throughputs and Titanium at lower throughputs)

Notes:
• I increased plast conveyor speed by %25 but i didnt test it so it could be OP or maybe still similar to titanium.
• Maybe instead of increasing the speed you can lower the item capacity from 10 to 5 or something.
