### PR TITLE
Add Atanner Gaming Hub to Serverlist

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -56,6 +56,9 @@
   {
     "address": "mindustry.atannergaming.com:6800"
   },
+   {
+    "address": "mindustry.atannergaming.com:7500"
+  },
   {
     "address": "mindustry.kbni.net.au:6567"
   },


### PR DESCRIPTION
The hub has all of our main servers listed as well as a few that are for verified members. We are working on a few more gamemodes and servers to be added to the hub.