### PR TITLE
add 'use strict' to mod scripts

### DIFF
--- a/core/src/mindustry/mod/Scripts.java
+++ b/core/src/mindustry/mod/Scripts.java
@@ -93,7 +93,7 @@ public class Scripts implements Disposable{
                 context.evaluateString(scope, "modName = \"" + currentMod.name + "\"\nscriptName = \"" + file + "\"", "initscript.js", 1, null);
             }
             context.evaluateString(scope,
-            wrap ? "(function(){\n" + script + "\n})();" : script,
+            wrap ? "(function(){'use strict'\n" + script + "\n})();" : script,
             file, 0, null);
             return true;
         }catch(Throwable t){

--- a/core/src/mindustry/mod/Scripts.java
+++ b/core/src/mindustry/mod/Scripts.java
@@ -93,7 +93,7 @@ public class Scripts implements Disposable{
                 context.evaluateString(scope, "modName = \"" + currentMod.name + "\"\nscriptName = \"" + file + "\"", "initscript.js", 1, null);
             }
             context.evaluateString(scope,
-            wrap ? "(function(){'use strict'\n" + script + "\n})();" : script,
+            wrap ? "(function(){'use strict';\n" + script + "\n})();" : script,
             file, 0, null);
             return true;
         }catch(Throwable t){


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode

tl;dr;
`const x = 0; x = 1; print(x);`
will throw an error instead of silently ignoring it and printing 0