### PR TITLE
Remove "sortersnek"

### DIFF
--- a/core/src/mindustry/world/blocks/distribution/Sorter.java
+++ b/core/src/mindustry/world/blocks/distribution/Sorter.java
@@ -88,7 +88,7 @@ public class Sorter extends Block{
 
         boolean isSame(Building other){
             //uncomment code below to prevent sorter/gate chaining
-            return other != null && (other.block() instanceof Sorter/* || other.block() instanceof OverflowGate */);
+            return other != null && (other.block() instanceof Sorter || other.block() instanceof OverflowGate);
         }
 
         Building getTileTarget(Item item, Building source, boolean flip){


### PR DESCRIPTION
There is many reasons behind it, but most important (that let to removing other "sneks") is infinite throughput/teleporter like mechanic.
I know that most of players like it and they will never change their mind, so this might be better solution.