### PR TITLE
Make snek great again

### DIFF
--- a/core/src/mindustry/world/blocks/distribution/Sorter.java
+++ b/core/src/mindustry/world/blocks/distribution/Sorter.java
@@ -88,7 +88,7 @@ public class Sorter extends Block{
 
         boolean isSame(Building other){
             //uncomment code below to prevent sorter/gate chaining
-            return other != null && (other.block() instanceof Sorter || other.block() instanceof OverflowGate);
+            return other != null && (other.block() instanceof Sorter/* || other.block() instanceof OverflowGate */);
         }
 
         Building getTileTarget(Item item, Building source, boolean flip){


### PR DESCRIPTION
This commit reverts pull request #2271 

Majority of the people voted **for** keeping the sortersnek in the Mindustry discord server.
(https://discordapp.com/channels/391020510269669376/513178557653188609/695649084895133766)

By removing the sortersnek, a lot of efficient and compact schematics would be broken, so that's why I reverted it.