### PR TITLE
make health and efficiency correlated

### DIFF
--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -294,7 +294,9 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
 
     /** Base efficiency. If this entity has non-buffered power, returns the power %, otherwise returns 1. */
     public float efficiency(){
-        return power != null && (block.consumes.has(ConsumeType.power) && !block.consumes.getPower().buffered) ? power.status : 1f;
+        float powerefficiency = power != null && (block.consumes.has(ConsumeType.power) && !block.consumes.getPower().buffered) ? power.status : 1f;
+        float healthefficiency = health / block.health;
+        return powerefficiency * healthefficiency;
     }
 
     /** Call when nothing is happening to the entity. This increments the internal sleep timer. */

--- a/core/src/mindustry/world/blocks/defense/turrets/PowerTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/PowerTurret.java
@@ -47,7 +47,7 @@ public class PowerTurret extends Turret{
 
         @Override
         protected float baseReloadSpeed(){
-            return cheating() ? 1f : power.status;
+            return cheating() ? 1f : super.baseReloadSpeed();
         }
     }
 }

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -382,7 +382,7 @@ public abstract class Turret extends Block{
         }
 
         protected float baseReloadSpeed(){
-            return 1f;
+            return efficiency();
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/distribution/BufferedItemBridge.java
+++ b/core/src/mindustry/world/blocks/distribution/BufferedItemBridge.java
@@ -29,7 +29,7 @@ public class BufferedItemBridge extends ExtendingItemBridge{
             }
 
             Item item = buffer.poll(speed / timeScale);
-            if(timer(timerAccept, 4) && item != null && other.acceptItem(this, item)){
+            if(uptime >= 0.5f && timer(timerAccept, 4) && item != null && other.acceptItem(this, item)){
                 cycleSpeed = Mathf.lerpDelta(cycleSpeed, 4f, 0.05f);
                 other.handleItem(this, item);
                 buffer.remove();

--- a/core/src/mindustry/world/blocks/distribution/BufferedItemBridge.java
+++ b/core/src/mindustry/world/blocks/distribution/BufferedItemBridge.java
@@ -28,8 +28,8 @@ public class BufferedItemBridge extends ExtendingItemBridge{
                 buffer.accept(items.take());
             }
 
-            Item item = buffer.poll(speed / timeScale);
-            if(uptime >= 0.5f && timer(timerAccept, 4) && item != null && other.acceptItem(this, item)){
+            Item item = buffer.poll(speed / efficiency() / timeScale);
+            if(timer(timerAccept, 4) && item != null && other.acceptItem(this, item)){
                 cycleSpeed = Mathf.lerpDelta(cycleSpeed, 4f, 0.05f);
                 other.handleItem(this, item);
                 buffer.remove();

--- a/core/src/mindustry/world/blocks/distribution/Conveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/Conveyor.java
@@ -114,7 +114,7 @@ public class Conveyor extends Block implements Autotiler{
 
         @Override
         public void draw(){
-            int frame = clogHeat <= 0.5f ? (int)(((Time.time() * speed * 8f * timeScale())) % 4) : 0;
+            int frame = clogHeat <= 0.5f ? (int)(((Time.time() * speed * efficiency() * 8f * timeScale())) % 4) : 0;
 
             //draw extra conveyors facing this one for non-square tiling purposes
             Draw.z(Layer.blockUnder);
@@ -175,7 +175,7 @@ public class Conveyor extends Block implements Autotiler{
 
             noSleep();
 
-            float mspeed = speed * tilesize / 2.4f;
+            float mspeed = speed * tilesize * efficiency() / 2.4f;
             float centerSpeed = 0.1f;
             float centerDstScl = 3f;
             float tx = Geometry.d4[rotation].x, ty = Geometry.d4[rotation].y;
@@ -211,13 +211,13 @@ public class Conveyor extends Block implements Autotiler{
 
             for(int i = len - 1; i >= 0; i--){
                 float nextpos = (i == len - 1 ? 100f : ys[i + 1]) - itemSpace;
-                float maxmove = Mathf.clamp(nextpos - ys[i], 0, speed * delta());
+                float maxmove = Mathf.clamp(nextpos - ys[i], 0, speed * efficiency() * delta());
 
                 ys[i] += maxmove;
 
                 if(ys[i] > nextMax) ys[i] = nextMax;
                 if(ys[i] > 0.5 && i > 0) mid = i - 1;
-                xs[i] = Mathf.approachDelta(xs[i], 0, speed*2);
+                xs[i] = Mathf.approachDelta(xs[i], 0, speed*2*efficiency());
 
                 if(ys[i] >= 1f && moveForward(ids[i])){
                     //align X position if passing forwards

--- a/core/src/mindustry/world/blocks/distribution/ExtendingItemBridge.java
+++ b/core/src/mindustry/world/blocks/distribution/ExtendingItemBridge.java
@@ -32,7 +32,7 @@ public class ExtendingItemBridge extends ItemBridge{
                 ey = other.worldy() - y - Geometry.d4[i].y * tilesize / 2f;
 
             float uptime = state.isEditor() ? 1f : this.uptime;
-
+            uptime = efficiency() < 1f ? 1f : uptime;
             ex *= uptime;
             ey *= uptime;
 

--- a/core/src/mindustry/world/blocks/distribution/PayloadConveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/PayloadConveyor.java
@@ -95,7 +95,7 @@ public class PayloadConveyor extends Block{
 
         @Override
         public void updateTile(){
-            progress = Time.time() % moveTime;
+            progress = Time.time() % moveTime * efficiency();
 
             updatePayload();
 
@@ -274,11 +274,11 @@ public class PayloadConveyor extends Block{
         }
 
         int curStep(){
-            return (int)((Time.time()) / moveTime);
+            return (int)((Time.time()) / moveTime * efficiency());
         }
 
         float fract(){
-            return interp.apply(progress / moveTime);
+            return interp.apply(progress / moveTime * efficiency());
         }
     }
 

--- a/core/src/mindustry/world/blocks/liquid/Conduit.java
+++ b/core/src/mindustry/world/blocks/liquid/Conduit.java
@@ -132,7 +132,7 @@ public class Conduit extends LiquidBlock implements Autotiler{
         public void updateTile(){
             smoothLiquid = Mathf.lerpDelta(smoothLiquid, liquids.currentAmount() / liquidCapacity, 0.05f);
 
-            if(liquids.total() > 0.001f && timer(timerFlow, 1)){
+            if(liquids.total() > 0.001f && timer(timerFlow, 1 / efficiency())){
                 moveLiquidForward(leakResistance, liquids.current());
                 noSleep();
             }else{

--- a/core/src/mindustry/world/blocks/liquid/LiquidExtendingBridge.java
+++ b/core/src/mindustry/world/blocks/liquid/LiquidExtendingBridge.java
@@ -9,6 +9,7 @@ import mindustry.world.meta.*;
 import static mindustry.Vars.world;
 
 public class LiquidExtendingBridge extends ExtendingItemBridge{
+    public final int timerFlow = timers++;
 
     public LiquidExtendingBridge(String name){
         super(name);
@@ -38,7 +39,7 @@ public class LiquidExtendingBridge extends ExtendingItemBridge{
                     uptime = Mathf.lerpDelta(uptime, 0f, 0.02f);
                 }
 
-                if(uptime * efficiency() == 1f){
+                if(uptime >= 0.5f && timer(timerFlow, 1 / efficiency())){
                     if(moveLiquid(other, liquids.current()) > 0.1f){
                         cycleSpeed = Mathf.lerpDelta(cycleSpeed, 4f, 0.05f);
                     }else{

--- a/core/src/mindustry/world/blocks/liquid/LiquidExtendingBridge.java
+++ b/core/src/mindustry/world/blocks/liquid/LiquidExtendingBridge.java
@@ -38,7 +38,7 @@ public class LiquidExtendingBridge extends ExtendingItemBridge{
                     uptime = Mathf.lerpDelta(uptime, 0f, 0.02f);
                 }
 
-                if(uptime >= 0.5f){
+                if(uptime * efficiency() == 1f){
                     if(moveLiquid(other, liquids.current()) > 0.1f){
                         cycleSpeed = Mathf.lerpDelta(cycleSpeed, 4f, 0.05f);
                     }else{

--- a/core/src/mindustry/world/blocks/power/PowerGenerator.java
+++ b/core/src/mindustry/world/blocks/power/PowerGenerator.java
@@ -36,7 +36,7 @@ public class PowerGenerator extends PowerDistributor{
             Core.bundle.format("bar.poweroutput",
             Strings.fixed(entity.getPowerProduction() * 60 * entity.timeScale(), 1)),
             () -> Pal.powerBar,
-            () -> entity.productionEfficiency));
+            () -> entity.productionEfficiency * entity.efficiency()));
         }
     }
 
@@ -52,7 +52,7 @@ public class PowerGenerator extends PowerDistributor{
 
         @Override
         public float getPowerProduction(){
-            return powerProduction * productionEfficiency;
+            return powerProduction * productionEfficiency * efficiency();
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/production/Cultivator.java
+++ b/core/src/mindustry/world/blocks/production/Cultivator.java
@@ -33,7 +33,7 @@ public class Cultivator extends GenericCrafter{
         super.setBars();
         bars.add("multiplier", (CultivatorEntity entity) -> new Bar(() ->
         Core.bundle.formatFloat("bar.efficiency",
-        ((entity.boost + 1f + attribute.env()) * entity.warmup) * 100f, 1),
+        ((entity.boost + 1f + attribute.env()) * entity.warmup * entity.efficiency()) * 100f, 1),
         () -> Pal.ammo,
         () -> entity.warmup));
     }

--- a/core/src/mindustry/world/blocks/production/Drill.java
+++ b/core/src/mindustry/world/blocks/production/Drill.java
@@ -87,7 +87,7 @@ public class Drill extends Block{
         super.setBars();
 
         bars.add("drillspeed", (DrillEntity e) ->
-             new Bar(() -> Core.bundle.format("bar.drillspeed", Strings.fixed(e.lastDrillSpeed * 60 * e.timeScale(), 2)), () -> Pal.ammo, () -> e.warmup));
+             new Bar(() -> Core.bundle.format("bar.drillspeed", Strings.fixed(e.lastDrillSpeed * e.efficiency() * 60 * e.timeScale(), 2)), () -> Pal.ammo, () -> e.warmup));
     }
 
     public Item getDrop(Tile tile){

--- a/core/src/mindustry/world/blocks/storage/Unloader.java
+++ b/core/src/mindustry/world/blocks/storage/Unloader.java
@@ -48,7 +48,7 @@ public class Unloader extends Block{
 
         @Override
         public void updateTile(){
-            if(timer(timerUnload, speed / timeScale())){
+            if(timer(timerUnload, speed / efficiency() / timeScale())){
                 for(Building other : proximity){
                     if(other.interactable(team) && other.block().unloadable && other.block().hasItems
                         && ((sortItem == null && other.items.total() > 0) || (sortItem != null && other.items.has(sortItem)))){

--- a/core/src/mindustry/world/blocks/units/ResupplyPoint.java
+++ b/core/src/mindustry/world/blocks/units/ResupplyPoint.java
@@ -42,7 +42,7 @@ public class ResupplyPoint extends Block{
 
         @Override
          public void updateTile(){
-             if(consValid() && timer(timerResupply, resupplyRate / timeScale) && resupply(this, range, ammoAmount, ammoColor)){
+             if(consValid() && timer(timerResupply, resupplyRate * efficiency() / timeScale) && resupply(this, range, ammoAmount, ammoColor)){
                  consume();
              }
          }


### PR DESCRIPTION
Based on https://github.com/Anuken/Mindustry-Suggestions/issues/347

The efficiency of a block is now 100% multiplied by (health)/(maxHealth) multiplied by (powerSupplied)/(powerNeeded), such as drill speed, craft time, reload speed, etc. 

Notice that this new efficiency does not effect the speed of routers, sorters, underflow gates, etc. (Not sure if that should be implemented)