### PR TITLE
M A K E S P E C T R E G R E A T E R

### DIFF
--- a/core/src/mindustry/content/Bullets.java
+++ b/core/src/mindustry/content/Bullets.java
@@ -350,18 +350,21 @@ public class Bullets implements ContentList{
         standardDenseBig = new BasicBulletType(7f, 55, "bullet"){{
             width = 15f;
             height = 21f;
+            pierce = true;
             shootEffect = Fx.shootBig;
         }};
 
         standardThoriumBig = new BasicBulletType(8f, 80, "bullet"){{
             width = 16f;
             height = 23f;
+            pierce = true;
             shootEffect = Fx.shootBig;
         }};
 
         standardIncendiaryBig = new BasicBulletType(7f, 60, "bullet"){{
             width = 16f;
             height = 21f;
+            pierce = true;
             frontColor = Pal.lightishOrange;
             backColor = Pal.lightOrange;
             status = StatusEffects.burning;

--- a/core/src/mindustry/content/Bullets.java
+++ b/core/src/mindustry/content/Bullets.java
@@ -350,6 +350,7 @@ public class Bullets implements ContentList{
         standardDenseBig = new BasicBulletType(7f, 55, "bullet"){{
             width = 15f;
             height = 21f;
+            knockback = 0.8f;
             pierce = true;
             shootEffect = Fx.shootBig;
         }};
@@ -357,6 +358,7 @@ public class Bullets implements ContentList{
         standardThoriumBig = new BasicBulletType(8f, 80, "bullet"){{
             width = 16f;
             height = 23f;
+            knockback = 1.0f;
             pierce = true;
             shootEffect = Fx.shootBig;
         }};
@@ -364,6 +366,7 @@ public class Bullets implements ContentList{
         standardIncendiaryBig = new BasicBulletType(7f, 60, "bullet"){{
             width = 16f;
             height = 21f;
+            knockback = 0.5f;
             pierce = true;
             frontColor = Pal.lightishOrange;
             backColor = Pal.lightOrange;


### PR DESCRIPTION
Specter costs a lot of material, but it’s less useful than ripple, cyclone
Moreover it consumes 120 liquid/second
So players seldom use specter 
I think specter should be greater and more useful