### PR TITLE
F O R C E P R O J E C T O R S

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -596,6 +596,8 @@ blocks.inaccuracy = Inaccuracy
 blocks.shots = Shots
 blocks.reload = Shots/Second
 blocks.ammo = Ammo
+blocks.shieldhealth = Shield Health
+blocks.cooldowntime = Cooldown Time
 
 bar.drilltierreq = Better Drill Required
 bar.noresources = Missing Resources
@@ -641,6 +643,7 @@ unit.seconds = seconds
 unit.persecond = /sec
 unit.timesspeed = x speed
 unit.percent = %
+unit.shieldhealth = shield health
 unit.items = items
 unit.thousands = k
 unit.millions = mil

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -879,7 +879,7 @@ public class Blocks implements ContentList{
         forceProjector = new ForceProjector("force-projector"){{
             requirements(Category.effect, with(Items.lead, 100, Items.titanium, 75, Items.silicon, 125));
             size = 3;
-            phaseRadiusBoost = 80f;
+            phaseBoost = 80f;
             radius = 101.7f;
             breakage = 750f;
             cooldownNormal = 1.5f;

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -879,7 +879,7 @@ public class Blocks implements ContentList{
         forceProjector = new ForceProjector("force-projector"){{
             requirements(Category.effect, with(Items.lead, 100, Items.titanium, 75, Items.silicon, 125));
             size = 3;
-            phaseBoost = 80f;
+            phaseRadiusBoost = 80f;
             radius = 101.7f;
             breakage = 750f;
             cooldownNormal = 1.5f;

--- a/core/src/mindustry/world/blocks/defense/ForceProjector.java
+++ b/core/src/mindustry/world/blocks/defense/ForceProjector.java
@@ -69,7 +69,8 @@ public class ForceProjector extends Block{
         stats.add(BlockStat.shieldHealth, breakage, StatUnit.none);
         stats.add(BlockStat.cooldownTime, (int) (breakage / cooldownBrokenBase / 60f), StatUnit.seconds);
         stats.add(BlockStat.powerUse, basePowerDraw * 60f, StatUnit.powerSecond);
-        stats.add(BlockStat.boostEffect, phaseRadiusBoost / tilesize, StatUnit.blocks);
+        stats.add(BlockStat.boostEffect, phaseBoost / tilesize, StatUnit.blocks);
+        stats.add(BlockStat.boostEffect, phaseBoost * 5f, StatUnit.shieldHealth);
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/defense/ForceProjector.java
+++ b/core/src/mindustry/world/blocks/defense/ForceProjector.java
@@ -65,7 +65,7 @@ public class ForceProjector extends Block{
         stats.add(BlockStat.cooldownTime, (int) (breakage / cooldownBrokenBase / 60f), StatUnit.seconds);
         stats.add(BlockStat.powerUse, basePowerDraw * 60f, StatUnit.powerSecond);
         stats.add(BlockStat.boostEffect, phaseRadiusBoost / tilesize, StatUnit.blocks);
-        stats.add(BlockStat.boostEffect, phaseShieldBoost * 5f, StatUnit.shieldHealth);
+        stats.add(BlockStat.boostEffect, phaseShieldBoost, StatUnit.shieldHealth);
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/defense/ForceProjector.java
+++ b/core/src/mindustry/world/blocks/defense/ForceProjector.java
@@ -22,7 +22,8 @@ public class ForceProjector extends Block{
     public final int timerUse = timers++;
     public float phaseUseTime = 350f;
 
-    public float phaseBoost = 80f;
+    public float phaseRadiusBoost = 80f;
+    public float phaseShieldBoost = 400f;
     public float radius = 101.7f;
     public float breakage = 550f;
     public float cooldownNormal = 1.75f;
@@ -63,8 +64,8 @@ public class ForceProjector extends Block{
         stats.add(BlockStat.shieldHealth, breakage, StatUnit.none);
         stats.add(BlockStat.cooldownTime, (int) (breakage / cooldownBrokenBase / 60f), StatUnit.seconds);
         stats.add(BlockStat.powerUse, basePowerDraw * 60f, StatUnit.powerSecond);
-        stats.add(BlockStat.boostEffect, phaseBoost / tilesize, StatUnit.blocks);
-        stats.add(BlockStat.boostEffect, phaseBoost * 5f, StatUnit.shieldHealth);
+        stats.add(BlockStat.boostEffect, phaseRadiusBoost / tilesize, StatUnit.blocks);
+        stats.add(BlockStat.boostEffect, phaseShieldBoost * 5f, StatUnit.shieldHealth);
     }
 
     @Override
@@ -79,7 +80,7 @@ public class ForceProjector extends Block{
         Lines.poly(x * tilesize, y * tilesize, 6, radius);
         Draw.color();
 
-        float phaseBoostedRadius = radius + phaseBoost;
+        float phaseBoostedRadius = radius + phaseRadiusBoost;
         Draw.color(Pal.gray);
         Lines.stroke(3f);
         Lines.poly(x * tilesize, y * tilesize, 6, phaseBoostedRadius);
@@ -130,7 +131,7 @@ public class ForceProjector extends Block{
                 broken = false;
             }
 
-            if(buildup >= breakage + (phaseBoost * 5f) && !broken){
+            if(buildup >= breakage + phaseShieldBoost && !broken){
                 broken = true;
                 buildup = breakage;
                 Fx.shieldBreak.at(x, y, radius, team.color);
@@ -149,7 +150,7 @@ public class ForceProjector extends Block{
         }
 
         float realRadius(){
-            return (radius + phaseHeat * phaseBoost) * radscl;
+            return (radius + phaseHeat * phaseRadiusBoost) * radscl;
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/defense/ForceProjector.java
+++ b/core/src/mindustry/world/blocks/defense/ForceProjector.java
@@ -79,15 +79,6 @@ public class ForceProjector extends Block{
         Lines.stroke(1f);
         Lines.poly(x * tilesize, y * tilesize, 6, radius);
         Draw.color();
-
-        float phaseBoostedRadius = radius + phaseRadiusBoost;
-        Draw.color(Pal.gray);
-        Lines.stroke(3f);
-        Lines.poly(x * tilesize, y * tilesize, 6, phaseBoostedRadius);
-        Draw.color(player.team().color);
-        Lines.stroke(1f);
-        Lines.poly(x * tilesize, y * tilesize, 6, phaseBoostedRadius);
-        Draw.color();
     }
 
     public class ForceProjectorEntity extends Building{

--- a/core/src/mindustry/world/blocks/defense/ForceProjector.java
+++ b/core/src/mindustry/world/blocks/defense/ForceProjector.java
@@ -41,12 +41,6 @@ public class ForceProjector extends Block{
         }
     };
 
-    static final Cons<Unitc> unitPusher = unit -> {
-        if(unit.team() != paramEntity.team && Intersector.isInsideHexagon(paramEntity.x, paramEntity.y, paramEntity.realRadius() * 2f, unit.x(), unit.y())){
-            unit.impulse(Tmp.v3.set(unit).sub(paramEntity.x, paramEntity.y).nor().scl(100f));
-        }
-    };
-
     public ForceProjector(String name){
         super(name);
         update = true;
@@ -151,7 +145,6 @@ public class ForceProjector extends Block{
             if(realRadius > 0 && !broken){
                 paramEntity = this;
                 Groups.bullet.intersect(x - realRadius, y - realRadius, realRadius * 2f, realRadius * 2f, shieldConsumer);
-                Groups.unit.intersect(x - realRadius, y - realRadius, realRadius * 2f, realRadius * 2f, unitPusher);
             }
         }
 

--- a/core/src/mindustry/world/meta/BlockStat.java
+++ b/core/src/mindustry/world/meta/BlockStat.java
@@ -45,6 +45,8 @@ public enum BlockStat{
     targetsGround(StatCategory.shooting),
     damage(StatCategory.shooting),
     ammo(StatCategory.shooting),
+    shieldHealth(StatCategory.shooting),
+    cooldownTime(StatCategory.shooting),
 
     booster(StatCategory.optional),
     boostEffect(StatCategory.optional),

--- a/core/src/mindustry/world/meta/StatUnit.java
+++ b/core/src/mindustry/world/meta/StatUnit.java
@@ -19,6 +19,7 @@ public enum StatUnit{
     perSecond,
     timesSpeed(false),
     percent(false),
+    shieldHealth,
     none,
     items;
 


### PR DESCRIPTION
Did some quality of life stuff, like:
Making queued force projectors display phased and regular range (see https://github.com/Anuken/Mindustry/pull/2251)
Making the phase boost also boost the strength of the shield
Displaying "Shield Health" and "Cooldown Time" (The time it takes for a shield to "respawn" after being broken) in the stats. 

Hopefully everything works.

Here's a suggestion (If I may): Maybe boost force projectors a bit? Their shields have less HP than a large copper wall, rendering them useless mid/late-game