### PR TITLE
Make payload units able to pick up bigger blocks based on its capacity

### DIFF
--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -129,7 +129,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         if(tile != null && tile.team == unit.team && pay.payloads().size < unit.type().payloadCapacity
             && unit.within(tile, tilesize * tile.block.size * 1.2f)){
             //pick up block directly
-            if(tile.block().buildVisibility != BuildVisibility.hidden && tile.block().size <= 2 && tile.canPickup()){
+            if(tile.block().buildVisibility != BuildVisibility.hidden && tile.block().size * tile.block().size <= unit.type().payloadCapacity - pay.payloads().size && tile.canPickup()){
                 pay.pickup(tile);
             }else{ //pick up block payload
                 Payload current = tile.getPayload();


### PR DESCRIPTION
Make payload units be able to pick up blocks of sizes that are smaller or equal to its capacity, not a fixed number(2).   
Units will now be able to pick up blocks if `size^2`(area) is less or equal to its current capacity left.   
1. This will impose that the unit and block storage will be shared, which may be logical(if not, just remove `- pay.payloade().size`)   
2. This will have no effect of `mega`'s capability, as its capacity is 4(although if there are units on board it will only be able to pick up 1x1)   
3. This will let modded units be able to carry meltdowns, or give them more freedom