### PR TITLE
Distribution/PowerNode/TractorBeamTurret fields for modding

### DIFF
--- a/core/src/mindustry/world/blocks/defense/TractorBeamTurret.java
+++ b/core/src/mindustry/world/blocks/defense/TractorBeamTurret.java
@@ -31,6 +31,7 @@ public class TractorBeamTurret extends Block{
     public float scaledForce = 0f;
     public float damage = 0f;
     public boolean targetAir = true, targetGround = false;
+    public Color laserColor = Color.white;
 
     public TractorBeamTurret(String name){
         super(name);
@@ -113,7 +114,7 @@ public class TractorBeamTurret extends Block{
                 float ang = angleTo(lastX, lastY);
                 float len = 5f;
 
-                Draw.mixcol(Color.white, Mathf.absin(4f, 0.6f));
+                Draw.mixcol(laserColor, Mathf.absin(4f, 0.6f));
 
                 Drawf.laser(team, laser, laserEnd,
                 x + Angles.trnsx(ang, len), y + Angles.trnsy(ang, len),

--- a/core/src/mindustry/world/blocks/distribution/MassDriver.java
+++ b/core/src/mindustry/world/blocks/distribution/MassDriver.java
@@ -1,5 +1,6 @@
 package mindustry.world.blocks.distribution;
 
+import arc.audio.*;
 import arc.graphics.g2d.*;
 import arc.math.*;
 import arc.math.geom.*;
@@ -30,6 +31,7 @@ public class MassDriver extends Block{
     public Effect shootEffect = Fx.shootBig2;
     public Effect smokeEffect = Fx.shootBigSmoke2;
     public Effect receiveEffect = Fx.mineBig;
+    public Sound shootSound = Sounds.none;
     public float shake = 3f;
     public @Load("@-base") TextureRegion baseRegion;
 
@@ -265,6 +267,8 @@ public class MassDriver extends Block{
             y + Angles.trnsy(angle, translation), angle);
 
             Effect.shake(shake, shake, this);
+            
+            shootSound.at(tile, Mathf.random(0.9f, 1.1f));
         }
 
         public void handlePayload(Bullet bullet, DriverBulletData data){

--- a/core/src/mindustry/world/blocks/distribution/MassDriver.java
+++ b/core/src/mindustry/world/blocks/distribution/MassDriver.java
@@ -31,7 +31,7 @@ public class MassDriver extends Block{
     public Effect shootEffect = Fx.shootBig2;
     public Effect smokeEffect = Fx.shootBigSmoke2;
     public Effect receiveEffect = Fx.mineBig;
-    public Sound shootSound = Sounds.none;
+    public Sound shootSound = Sounds.shootBig;
     public float shake = 3f;
     public @Load("@-base") TextureRegion baseRegion;
 

--- a/core/src/mindustry/world/blocks/distribution/StackConveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/StackConveyor.java
@@ -6,6 +6,7 @@ import arc.util.*;
 import arc.util.io.*;
 import mindustry.annotations.Annotations.*;
 import mindustry.content.*;
+import mindustry.entities.*;
 import mindustry.entities.units.*;
 import mindustry.gen.*;
 import mindustry.graphics.*;
@@ -27,6 +28,8 @@ public class StackConveyor extends Block implements Autotiler{
     public float speed = 0f;
     public boolean splitOut = true;
     public float recharge = 2f;
+    public Effect loadEffect = Fx.plasticburn;
+    public Effect unloadEffect = Fx.plasticburn;
 
     public StackConveyor(String name){
         super(name);
@@ -221,11 +224,11 @@ public class StackConveyor extends Block implements Autotiler{
 
         protected void poofIn(){
             link = tile.pos();
-            Fx.plasticburn.at(this);
+            loadEffect.at(this);
         }
 
         protected void poofOut(){
-            Fx.plasticburn.at(this);
+            unloadEffect.at(this);
             link = -1;
         }
 

--- a/core/src/mindustry/world/blocks/power/PowerNode.java
+++ b/core/src/mindustry/world/blocks/power/PowerNode.java
@@ -33,6 +33,8 @@ public class PowerNode extends PowerBlock{
     public @Load("laser-end") TextureRegion laserEnd;
     public float laserRange = 6;
     public int maxNodes = 3;
+    public Color laserColor1 = Color.white;
+    public Color laserColor2 = Pal.powerLight;
 
     public PowerNode(String name){
         super(name);
@@ -158,7 +160,7 @@ public class PowerNode extends PowerBlock{
 
         float fract = 1f - satisfaction;
 
-        Draw.color(Color.white, Pal.powerLight, fract * 0.86f + Mathf.absin(3f, 0.1f));
+        Draw.color(laserColor1, laserColor2, fract * 0.86f + Mathf.absin(3f, 0.1f));
         Draw.alpha(opacity);
         Drawf.laser(team, laser, laserEnd, x1, y1, x2, y2, 0.25f);
         Draw.color();


### PR DESCRIPTION
- PowerNode/TractorBeamTurret: `laserColor`(since RepairPoint had laserColor, I thought it would work for these laser blocks to have one too(for PowerNode it is split into `laserColor1` and `laserColor2`))
- Plastanium Conveyor: `loadEffect`, `unloadEffect`(effects now customizable)
- MassDriver: `shootSound`(just like the other turrets, Sounds.none by default)

*...This should be my last json-related PR for now, you've done lots well already, it was really hard trying to find PR-worthy stuff!*