### PR TITLE
Less Capacity For Plastanium Conveyor

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -913,7 +913,7 @@ public class Blocks implements ContentList{
             requirements(Category.distribution, with(Items.plastanium, 1, Items.silicon, 1, Items.graphite, 1));
             health = 75;
             speed = 4f / 60f;
-            itemCapacity = 10;
+            itemCapacity = 5;
         }};
 
         armoredConveyor = new ArmoredConveyor("armored-conveyor"){{


### PR DESCRIPTION
10 is a lot and it takes long to fill, i think 5 would be better because the max items anything can use in a frame is 4 with Alloy Smelter using Lead, also, lower capacity means better for worse drills so that'd be a buff to plastanium conveyors and makes it usable with other drills. I couldn't test how 5 capacity would do and btw you can change it.