### PR TITLE
Update LAccess.java

### DIFF
--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -1187,6 +1187,7 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
 
     @Override
     public double sense(LAccess sensor){
+        if(sensor == LAccess.name) return block.name;
         if(sensor == LAccess.x) return x;
         if(sensor == LAccess.y) return y;
         if(sensor == LAccess.team) return team.id;

--- a/core/src/mindustry/entities/comp/UnitComp.java
+++ b/core/src/mindustry/entities/comp/UnitComp.java
@@ -77,6 +77,7 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
         if(sensor == LAccess.health) return health;
         if(sensor == LAccess.x) return x;
         if(sensor == LAccess.y) return y;
+        if(sensor == LAccess.name) return type.name;
         if(sensor == LAccess.team) return team.id;
         if(sensor == LAccess.shooting) return isShooting() ? 1 : 0;
         if(sensor == LAccess.shootX) return aimX();

--- a/core/src/mindustry/logic/LAccess.java
+++ b/core/src/mindustry/logic/LAccess.java
@@ -24,6 +24,7 @@ public enum LAccess{
     shootY,
     shooting,
     team,
+    name,
 
     //values with parameters are considered controllable
     enabled("to"), //"to" is standard for single parameter access


### PR DESCRIPTION
This PR adds a constant returning the block's full name, to be able to determine the block type even if a block is prelinked or mixed with alike blocks (i.e. different tier walls, reactors, conveyors). 