### PR TITLE
Block Fields for Modding

### DIFF
--- a/core/assets/contributors
+++ b/core/assets/contributors
@@ -89,3 +89,4 @@ Daniel Dusek
 DeltaNedas
 GioIacca9
 SnakkiZXZ
+sk7725

--- a/core/src/mindustry/graphics/OverlayRenderer.java
+++ b/core/src/mindustry/graphics/OverlayRenderer.java
@@ -140,7 +140,7 @@ public class OverlayRenderer{
                    build.drawDisabled();
                 }
 
-                if(Core.input.keyDown(Binding.rotateplaced) && build.block.rotate && build.interactable(player.team())){
+                if(Core.input.keyDown(Binding.rotateplaced) && build.block.rotate && build.block.quickRotate && build.interactable(player.team())){
                     control.input.drawArrow(build.block, build.tileX(), build.tileY(), build.rotation, true);
                     Draw.color(Pal.accent, 0.3f + Mathf.absin(4f, 0.2f));
                     Fill.square(build.x, build.y, build.block.size * tilesize/2f);

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -116,7 +116,7 @@ public class DesktopInput extends InputHandler{
         //draw request being moved
         if(sreq != null){
             boolean valid = validPlace(sreq.x, sreq.y, sreq.block, sreq.rotation, sreq);
-            if(sreq.block.rotate){
+            if(sreq.block.rotate && sreq.block.rotateArrow){
                 drawArrow(sreq.block, sreq.x, sreq.y, sreq.rotation, valid);
             }
 
@@ -146,13 +146,13 @@ public class DesktopInput extends InputHandler{
             if(mode == placing && block != null){
                 for(int i = 0; i < lineRequests.size; i++){
                     BuildPlan req = lineRequests.get(i);
-                    if(i == lineRequests.size - 1 && req.block.rotate){
+                    if(i == lineRequests.size - 1 && req.block.rotate && req.block.rotateArrow){
                         drawArrow(block, req.x, req.y, req.rotation);
                     }
                     drawRequest(lineRequests.get(i));
                 }
             }else if(isPlacing()){
-                if(block.rotate){
+                if(block.rotate && block.rotateArrow){
                     drawArrow(block, cursorX, cursorY, rotation);
                 }
                 Draw.color();
@@ -306,7 +306,7 @@ public class DesktopInput extends InputHandler{
                 cursorType = ui.unloadCursor;
             }
 
-            if(cursor.build != null && cursor.interactable(player.team()) && !isPlacing() && Math.abs(Core.input.axisTap(Binding.rotate)) > 0 && Core.input.keyDown(Binding.rotateplaced) && cursor.block().rotate){
+            if(cursor.build != null && cursor.interactable(player.team()) && !isPlacing() && Math.abs(Core.input.axisTap(Binding.rotate)) > 0 && Core.input.keyDown(Binding.rotateplaced) && cursor.block().rotate && cursor.block().quickRotate){
                 Call.rotateBlock(player, cursor.build, Core.input.axisTap(Binding.rotate) > 0);
             }
         }

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -116,7 +116,7 @@ public class DesktopInput extends InputHandler{
         //draw request being moved
         if(sreq != null){
             boolean valid = validPlace(sreq.x, sreq.y, sreq.block, sreq.rotation, sreq);
-            if(sreq.block.rotate && sreq.block.rotateArrow){
+            if(sreq.block.rotate){
                 drawArrow(sreq.block, sreq.x, sreq.y, sreq.rotation, valid);
             }
 
@@ -146,13 +146,13 @@ public class DesktopInput extends InputHandler{
             if(mode == placing && block != null){
                 for(int i = 0; i < lineRequests.size; i++){
                     BuildPlan req = lineRequests.get(i);
-                    if(i == lineRequests.size - 1 && req.block.rotate && req.block.rotateArrow){
+                    if(i == lineRequests.size - 1 && req.block.rotate){
                         drawArrow(block, req.x, req.y, req.rotation);
                     }
                     drawRequest(lineRequests.get(i));
                 }
             }else if(isPlacing()){
-                if(block.rotate && block.rotateArrow){
+                if(block.rotate){
                     drawArrow(block, cursorX, cursorY, rotation);
                 }
                 Draw.color();

--- a/core/src/mindustry/input/MobileInput.java
+++ b/core/src/mindustry/input/MobileInput.java
@@ -304,7 +304,7 @@ public class MobileInput extends InputHandler implements GestureListener{
                 //draw placing
                 for(int i = 0; i < lineRequests.size; i++){
                     BuildPlan request = lineRequests.get(i);
-                    if(i == lineRequests.size - 1 && request.block.rotate){
+                    if(i == lineRequests.size - 1 && request.block.rotate && request.block.rotateArrow){
                         drawArrow(block, request.x, request.y, request.rotation);
                     }
                     request.block.drawRequest(request, allRequests(), validPlace(request.x, request.y, request.block, request.rotation) && getRequest(request.x, request.y, request.block.size, null) == null);
@@ -346,7 +346,7 @@ public class MobileInput extends InputHandler implements GestureListener{
 
             if(!request.breaking && request == lastPlaced && request.block != null){
                 Draw.mixcol();
-                if(request.block.rotate) drawArrow(request.block, tile.x, tile.y, request.rotation);
+                if(request.block.rotate && request.block.rotateArrow) drawArrow(request.block, tile.x, tile.y, request.rotation);
             }
 
             Draw.reset();

--- a/core/src/mindustry/input/MobileInput.java
+++ b/core/src/mindustry/input/MobileInput.java
@@ -304,7 +304,7 @@ public class MobileInput extends InputHandler implements GestureListener{
                 //draw placing
                 for(int i = 0; i < lineRequests.size; i++){
                     BuildPlan request = lineRequests.get(i);
-                    if(i == lineRequests.size - 1 && request.block.rotate && request.block.rotateArrow){
+                    if(i == lineRequests.size - 1 && request.block.rotate){
                         drawArrow(block, request.x, request.y, request.rotation);
                     }
                     request.block.drawRequest(request, allRequests(), validPlace(request.x, request.y, request.block, request.rotation) && getRequest(request.x, request.y, request.block.size, null) == null);
@@ -346,7 +346,7 @@ public class MobileInput extends InputHandler implements GestureListener{
 
             if(!request.breaking && request == lastPlaced && request.block != null){
                 Draw.mixcol();
-                if(request.block.rotate && request.block.rotateArrow) drawArrow(request.block, tile.x, tile.y, request.rotation);
+                if(request.block.rotate) drawArrow(request.block, tile.x, tile.y, request.rotation);
             }
 
             Draw.reset();

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -195,6 +195,8 @@ public class Block extends UnlockableContent{
     public float buildCostMultiplier = 1f;
     /** Whether this block has instant transfer.*/
     public boolean instantTransfer = false;
+    /** Whether you can rotate this block with Keybind rotateplaced + Scroll Wheel. */
+    public boolean quickRotate = true;
 
     protected Prov<Building> entityType = null; //initialized later
     public ObjectMap<Class<?>, Cons2> configurations = new ObjectMap<>();

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -197,6 +197,8 @@ public class Block extends UnlockableContent{
     public boolean instantTransfer = false;
     /** Whether you can rotate this block with Keybind rotateplaced + Scroll Wheel. */
     public boolean quickRotate = true;
+    /** Whether to guide the placement of this block with an arrow icon; rotate needs to be true to work. */
+    public boolean rotateArrow = true;
 
     protected Prov<Building> entityType = null; //initialized later
     public ObjectMap<Class<?>, Cons2> configurations = new ObjectMap<>();

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -197,8 +197,6 @@ public class Block extends UnlockableContent{
     public boolean instantTransfer = false;
     /** Whether you can rotate this block with Keybind rotateplaced + Scroll Wheel. */
     public boolean quickRotate = true;
-    /** Whether to guide the placement of this block with an arrow icon; rotate needs to be true to work. */
-    public boolean rotateArrow = true;
 
     protected Prov<Building> entityType = null; //initialized later
     public ObjectMap<Class<?>, Cons2> configurations = new ObjectMap<>();


### PR DESCRIPTION
+ `quickRotate`: whether the block can be rotated with R(or Binding.rotateplaced) + Scroll Wheel.
This is because modded blocks are sometimes not meant to be rotated after placed, and a block cannot tell if it has been rotated unless it keeps track of its rotation, so in some cases it is better if the block is just not rotated at all after placed.
+ `rotateArrow`: whether the block placement is guided by the arrow icon.
This is because some modded block are using the `rotation` of the block in an "unintended" way, such as making only whether it was vertically or horizontally placed count(a.k.a only `rotation%2` matters), and in some cases it just makes sense to get rid of the arrow icon.