### PR TITLE
store building class with constructor

### DIFF
--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -197,7 +197,7 @@ public class Block extends UnlockableContent{
     public boolean instantTransfer = false;
 
     protected Prov<Building> entityType = null; //initialized later
-    public Class<T> entityClass = Building.class;
+    public Class<?> entityClass = Building.class;
     public ObjectMap<Class<?>, Cons2> configurations = new ObjectMap<>();
 
     protected TextureRegion[] generatedIcons;

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -197,6 +197,7 @@ public class Block extends UnlockableContent{
     public boolean instantTransfer = false;
 
     protected Prov<Building> entityType = null; //initialized later
+    public Class<T> entityClass = Building.class;
     public ObjectMap<Class<?>, Cons2> configurations = new ObjectMap<>();
 
     protected TextureRegion[] generatedIcons;
@@ -598,6 +599,7 @@ public class Block extends UnlockableContent{
                             throw new RuntimeException(e);
                         }
                     };
+                    entityClass = type;
                 }
 
                 //scan through every superclass looking for it


### PR DESCRIPTION
Mods can use block.entityClass instead of needing to know the building too.
However, I'm not sure if rhino will be able to extend a Class<T> or if it needs a JavaClass which i have no idea how to get.

Use case:
`routerify(Blocks.router, Router.RouterBuild, "h", {}, {})`
becomes
`routerify(Blocks.router, "h", {}, {})`
and `block.entityClass`

I'll need to read some rhino docs though