### PR TITLE
Add a planet selection dialog

### DIFF
--- a/core/src/mindustry/content/Planets.java
+++ b/core/src/mindustry/content/Planets.java
@@ -14,6 +14,7 @@ public class Planets implements ContentList{
     @Override
     public void load(){
         sun = new Planet("sun", null, 0, 2){{
+            accessible = false;
             bloom = true;
 
             //lightColor = Color.valueOf("f4ee8e");

--- a/core/src/mindustry/type/Planet.java
+++ b/core/src/mindustry/type/Planet.java
@@ -23,6 +23,8 @@ import mindustry.type.Sector.*;
 import static mindustry.Vars.*;
 
 public class Planet extends UnlockableContent{
+    /** Whether or not this planet is listed in the planet access ui**/
+    public boolean accessible = true;
     /** Default spacing between planet orbits in world units. */
     private static final float orbitSpacing = 6f;
     /** intersect() temp var. */

--- a/core/src/mindustry/type/Planet.java
+++ b/core/src/mindustry/type/Planet.java
@@ -23,7 +23,7 @@ import mindustry.type.Sector.*;
 import static mindustry.Vars.*;
 
 public class Planet extends UnlockableContent{
-    /** Whether or not this planet is listed in the planet access ui**/
+    /** Whether or not this planet is listed in the planet access ui. **/
     public boolean accessible = true;
     /** Default spacing between planet orbits in world units. */
     private static final float orbitSpacing = 6f;

--- a/core/src/mindustry/ui/dialogs/PlanetDialog.java
+++ b/core/src/mindustry/ui/dialogs/PlanetDialog.java
@@ -122,8 +122,8 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
 
     boolean canLaunch(Sector sector){
         return mode == launch &&
-                (sector.tile.v.within(launchSector.tile.v, (launchRange + 0.5f) * planets.planet.sectorApproxRadius*2) //within range
-                        || (sector.preset != null && sector.preset.unlocked())); //is an unlocked preset
+        (sector.tile.v.within(launchSector.tile.v, (launchRange + 0.5f) * planets.planet.sectorApproxRadius*2) //within range
+        || (sector.preset != null && sector.preset.unlocked())); //is an unlocked preset
     }
 
     @Override
@@ -140,9 +140,9 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
 
                     Color color =
                             sec.hasBase() ? Team.sharded.color :
-                                    sec.preset != null ? Team.derelict.color :
-                                            sec.hasEnemyBase() ? Team.crux.color :
-                                                    null;
+                            sec.preset != null ? Team.derelict.color :
+                            sec.hasEnemyBase() ? Team.crux.color :
+                            null;
 
                     if(color != null){
                         planets.drawSelection(sec, Tmp.c1.set(color).mul(0.8f).a(selectAlpha), 0.026f, -0.001f);

--- a/core/src/mindustry/ui/dialogs/PlanetDialog.java
+++ b/core/src/mindustry/ui/dialogs/PlanetDialog.java
@@ -139,10 +139,10 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
                     }
 
                     Color color =
-                            sec.hasBase() ? Team.sharded.color :
-                            sec.preset != null ? Team.derelict.color :
-                            sec.hasEnemyBase() ? Team.crux.color :
-                            null;
+                        sec.hasBase() ? Team.sharded.color :
+                        sec.preset != null ? Team.derelict.color :
+                        sec.hasEnemyBase() ? Team.crux.color :
+                        null;
 
                     if(color != null){
                         planets.drawSelection(sec, Tmp.c1.set(color).mul(0.8f).a(selectAlpha), 0.026f, -0.001f);

--- a/core/src/mindustry/ui/dialogs/PlanetDialog.java
+++ b/core/src/mindustry/ui/dialogs/PlanetDialog.java
@@ -13,6 +13,7 @@ import arc.scene.ui.*;
 import arc.scene.ui.layout.*;
 import arc.util.*;
 import arc.util.ArcAnnotate.*;
+import mindustry.Vars;
 import mindustry.core.*;
 import mindustry.ctype.*;
 import mindustry.game.*;
@@ -240,8 +241,24 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
             //TODO localize
             t.top();
             t.label(() -> mode == launch ? "Select Launch Sector" : "Turn " + universe.turn()).style(Styles.outlineLabel).color(Pal.accent);
+        }),
+        new Table(t -> {
+            t.left();
+            t.pane(Styles.smallPane, pt -> {
+                pt.left();
+                t.add("Planets:");
+                t.row();
+                for(int i = 0; i < content.planets().size; i++){
+                    Planet planet = content.planets().get(i);
+                    if(planet.accessible){
+                        pt.button(planet.localizedName, () -> {
+                            renderer.planets.planet = planet;
+                        }).width(280).growX();
+                        pt.row();
+                    }
+                }
+            });
         })).grow();
-
     }
 
     @Override

--- a/core/src/mindustry/ui/dialogs/PlanetDialog.java
+++ b/core/src/mindustry/ui/dialogs/PlanetDialog.java
@@ -122,8 +122,8 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
 
     boolean canLaunch(Sector sector){
         return mode == launch &&
-        (sector.tile.v.within(launchSector.tile.v, (launchRange + 0.5f) * planets.planet.sectorApproxRadius*2) //within range
-        || (sector.preset != null && sector.preset.unlocked())); //is an unlocked preset
+            (sector.tile.v.within(launchSector.tile.v, (launchRange + 0.5f) * planets.planet.sectorApproxRadius*2) //within range
+            || (sector.preset != null && sector.preset.unlocked())); //is an unlocked preset
     }
 
     @Override
@@ -139,10 +139,10 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
                     }
 
                     Color color =
-                        sec.hasBase() ? Team.sharded.color :
-                        sec.preset != null ? Team.derelict.color :
-                        sec.hasEnemyBase() ? Team.crux.color :
-                        null;
+                    sec.hasBase() ? Team.sharded.color :
+                    sec.preset != null ? Team.derelict.color :
+                    sec.hasEnemyBase() ? Team.crux.color :
+                    null;
 
                     if(color != null){
                         planets.drawSelection(sec, Tmp.c1.set(color).mul(0.8f).a(selectAlpha), 0.026f, -0.001f);

--- a/core/src/mindustry/ui/dialogs/PlanetDialog.java
+++ b/core/src/mindustry/ui/dialogs/PlanetDialog.java
@@ -41,6 +41,7 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
     private CoreBuild launcher;
     Mode mode = look;
     private boolean launching;
+    private int accessiblePlanets;
 
     public PlanetDialog(){
         super("", Styles.fullDialog);
@@ -244,20 +245,26 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
         }),
         new Table(t -> {
             t.left();
-            t.pane(Styles.smallPane, pt -> {
-                pt.left();
-                t.add("Planets:");
-                t.row();
-                for(int i = 0; i < content.planets().size; i++){
-                    Planet planet = content.planets().get(i);
-                    if(planet.accessible){
-                        pt.button(planet.localizedName, () -> {
-                            renderer.planets.planet = planet;
-                        }).width(280).growX();
-                        pt.row();
+            for(int i = 0; i < content.planets().size; i++){
+                accessiblePlanets = i;
+            }
+            if(accessiblePlanets > 1) {
+                t.pane(Styles.smallPane, pt -> {
+                    pt.left();
+                    t.add("Planets:");
+                    t.row();
+
+                    for (int i = 0; i < content.planets().size; i++) {
+                        Planet planet = content.planets().get(i);
+                        if (planet.accessible) {
+                            pt.button(planet.localizedName, () -> {
+                                renderer.planets.planet = planet;
+                            }).width(280).growX();
+                            pt.row();
+                        }
                     }
-                }
-            });
+                });
+            }
         })).grow();
     }
 

--- a/core/src/mindustry/ui/dialogs/PlanetDialog.java
+++ b/core/src/mindustry/ui/dialogs/PlanetDialog.java
@@ -245,6 +245,7 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
                 }),
                 new Table(t -> {
                     t.right();
+                    accessiblePlanets = 0;
                     for(int i = 0; i < content.planets().size; i++){
                         if(content.planets().get(i).accessible) {
                             accessiblePlanets++;


### PR DESCRIPTION
I added a simple planet selection dialog that lets you select what planet to focus on. The dialog is nonexistant if the number of accessible planets is < 2. Now planets have the `accessible` variable, set by default to true (Whether or not they appear in the dialog).

How it looks (i covered the other two planets names as its a thing im working on):

![image](https://raw.githubusercontent.com/ThePythonGuy3/Mindustryv6Resprite/master/h.png)