### PR TITLE
Make Pal.java colors changable for texturepack-mods tweaks

### DIFF
--- a/core/src/mindustry/graphics/Pal.java
+++ b/core/src/mindustry/graphics/Pal.java
@@ -3,7 +3,7 @@ package mindustry.graphics;
 import arc.graphics.Color;
 
 public class Pal{
-    public static final Color
+    public static Color
 
     items = Color.valueOf("2ea756"),
     command = Color.valueOf("eab678"),


### PR DESCRIPTION
> I don't know about other people, but I would like to use these fields for modding.

I noticed this when I was re-texturing logical displays and when they were placed, they displayed the default base color on screen, not the texture color, because it is hardcoded.

I know that it is correct not to change the base classes and options, but to create your own in modifications and use them instead, but this is an exception.