### PR TITLE
More sort and target options

### DIFF
--- a/core/src/mindustry/logic/RadarSort.java
+++ b/core/src/mindustry/logic/RadarSort.java
@@ -6,6 +6,8 @@ import mindustry.gen.*;
 public enum RadarSort{
     distance((pos, other) -> -pos.dst2(other)),
     health((pos, other) -> other.health()),
+    shield((pos, other) -> other.shield()),
+    armor((pos, other) -> other.armor()),
     maxHealth((pos, other) -> other.maxHealth());
 
     public final RadarSortFunc func;
@@ -17,6 +19,6 @@ public enum RadarSort{
     }
 
     public interface RadarSortFunc{
-        float get(Position pos, Healthc other);
+        float get(Position pos, Unit other);
     }
 }

--- a/core/src/mindustry/logic/RadarTarget.java
+++ b/core/src/mindustry/logic/RadarTarget.java
@@ -8,6 +8,7 @@ public enum RadarTarget{
     enemy((team, other) -> team != other.team),
     ally((team, other) -> team == other.team),
     player((team, other) -> other.isPlayer()),
+    attacker((pos, other) -> other.canShoot()),
     flying((team, other) -> other.isFlying()),
     boss((team, other) -> other.isBoss()),
     ground((team, other) -> other.isGrounded());


### PR DESCRIPTION
This adds armor and shield to sorting, and attacker to target. Sometimes, going for the max health may be the wrong option because of a unit with a stronger shield. And, for the attacker target, it can filter between getting support (non-attack) units and attack units.