### PR TITLE
Add @echo off to run-server.bat

### DIFF
--- a/server/server_template/run_server.bat
+++ b/server/server_template/run_server.bat
@@ -1,1 +1,2 @@
+@echo off
 java -jar server.jar


### PR DESCRIPTION
Thereby, entering the command `java -jar server.jar` will not be logged.
