### PR TITLE
Make oct ACTUALLY have the most durability of any T5 unit

### DIFF
--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -1300,7 +1300,7 @@ public class UnitTypes implements ContentList{
 
         oct = new UnitType("oct"){{
             armor = 16f;
-            health = 24000;
+            health = 31000;
             speed = 0.6f;
             rotateSpeed = 1f;
             accel = 0.04f;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19158169/94365256-3f7db300-009d-11eb-9763-38b53fe48e35.png)
Not true; Reign has the same amount of health. This fixes that