### PR TITLE
Define payload capacity of payload conveyors on the conveyor itself.

### DIFF
--- a/core/src/mindustry/world/blocks/distribution/PayloadConveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/PayloadConveyor.java
@@ -20,6 +20,7 @@ public class PayloadConveyor extends Block{
     public @Load("@-top") TextureRegion topRegion;
     public @Load("@-edge") TextureRegion edgeRegion;
     public Interp interp = Interp.pow5;
+    public float payloadLimit = 2.5f;
 
     public PayloadConveyor(String name){
         super(name);
@@ -216,10 +217,10 @@ public class PayloadConveyor extends Block{
         @Override
         public boolean acceptPayload(Building source, Payload payload){
             if(source == this){
-                return this.item == null && payload.fits();
+                return this.item == null && payload.fits(payloadLimit);
             }
             //accepting payloads from units isn't supported
-            return this.item == null && progress <= 5f && payload.fits();
+            return this.item == null && progress <= 5f && payload.fits(payloadLimit);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/payloads/Payload.java
+++ b/core/src/mindustry/world/blocks/payloads/Payload.java
@@ -26,8 +26,8 @@ public interface Payload{
     }
 
     /** @return whether this payload fits on a standard 3x3 conveyor. */
-    default boolean fits(){
-        return size() / tilesize <= 2.5f;
+    default boolean fits(float s){
+        return size() / tilesize <= s;
     }
 
     /** writes the payload for saving. */

--- a/core/src/mindustry/world/blocks/payloads/Payload.java
+++ b/core/src/mindustry/world/blocks/payloads/Payload.java
@@ -25,7 +25,7 @@ public interface Payload{
         return false;
     }
 
-    /** @return whether this payload fits on a standard 3x3 conveyor. */
+    /** @return whether this payload fits in a given size. 2.5 is the max for a standard 3x3 conveyor. */
     default boolean fits(float s){
         return size() / tilesize <= s;
     }


### PR DESCRIPTION
`payloadLimit` defines the size limit a payload conveyor can carry. 2.5 is the default.