### PR TITLE
Fix spelling in CrashSender.java

### DIFF
--- a/core/src/mindustry/net/CrashSender.java
+++ b/core/src/mindustry/net/CrashSender.java
@@ -25,7 +25,7 @@ import static mindustry.Vars.*;
 public class CrashSender{
 
     public static String createReport(String error){
-        String report = "Mindustry has crashed. How unforunate.\n";
+        String report = "Mindustry has crashed. How unfortunate.\n";
         if(mods.list().size == 0 && Version.build != -1){
             report += "Report this at " + Vars.reportIssueURL + "\n\n";
         }


### PR DESCRIPTION
"How unforunate" -> "How unfortunate"

I didn't see it getting fixed in the last commit so might as well.