### PR TITLE
Add help button to hosting for pause dialog menu

### DIFF
--- a/core/src/mindustry/ui/dialogs/HostDialog.java
+++ b/core/src/mindustry/ui/dialogs/HostDialog.java
@@ -50,8 +50,6 @@ public class HostDialog extends BaseDialog{
             runHost();
         }).width(w).height(70f);
 
-        cont.button("?", () -> ui.showInfo("@host.info")).size(65f, 70f).padLeft(6f);
-
         shown(() -> {
             if(!steam){
                 Core.app.post(() -> Core.settings.getBoolOnce("hostinfo", () -> ui.showInfo("@host.info")));

--- a/core/src/mindustry/ui/dialogs/PausedDialog.java
+++ b/core/src/mindustry/ui/dialogs/PausedDialog.java
@@ -67,6 +67,7 @@ public class PausedDialog extends BaseDialog{
                         }
                     }
                 }).disabled(b -> !((steam && net.server()) || !net.active())).colspan(2).width(dw * 2 + 20f).update(e -> e.setText(net.server() && steam ? "@invitefriends" : "@hostserver"));
+                cont.button("?", () -> ui.showInfo("@host.info")).size(55f,55f);
             }
 
             cont.row();
@@ -106,6 +107,9 @@ public class PausedDialog extends BaseDialog{
                 s.setText(control.saves.getCurrent() != null && control.saves.getCurrent().isAutosave() ? "@save.quit" : "@quit");
                 s.getLabelCell().growX().wrap();
             });
+
+            cont.row();
+            cont.button("?", () -> ui.showInfo("@host.info")).size(55f,55f).colspan(3);
         }
     }
 


### PR DESCRIPTION
Hi! I'm a beginner to contributing to this repository, so go easy :) 

When I first started playing this game with my friends, I found that hosting was really frustrating because the @host.info button was within the HostDialog, but as soon as you clicked the host button, it would bring you out of the HostDialog back to PausedDialog, and you can't see the @host.info anymore. This made it so everytime I was trying to set hosting up, if I forgot the port number, or had to carefully read the host.info again, I had to stop hosting by quitting the current game, restarting, and then going back to HostDialog. Moving host.info out will help beginners set up hosting easier!

![image](https://user-images.githubusercontent.com/34866813/95147535-df8aaa80-0735-11eb-9062-9579f873ffe3.png)
