### PR TITLE
Phase Fabric ammo for Spectre

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -1747,6 +1747,7 @@ public class Blocks implements ContentList{
             ammo(
             Items.graphite, Bullets.standardDenseBig,
             Items.pyratite, Bullets.standardIncendiaryBig,
+            Items.phasefabric, Bullets.standardPhaseBig,
             Items.thorium, Bullets.standardThoriumBig
             );
             reloadTime = 6f;

--- a/core/src/mindustry/content/Bullets.java
+++ b/core/src/mindustry/content/Bullets.java
@@ -31,7 +31,7 @@ public class Bullets implements ContentList{
 
     //standard
     standardCopper, standardDense, standardThorium, standardHoming, standardIncendiary, standardMechSmall,
-    standardGlaive, standardDenseBig, standardThoriumBig, standardIncendiaryBig,
+    standardGlaive, standardDenseBig, standardThoriumBig, standardPhaseBig, standardIncendiaryBig,
 
     //liquid
     waterShot, cryoShot, slagShot, oilShot, heavyWaterShot, heavyCryoShot, heavySlagShot, heavyOilShot,
@@ -354,6 +354,16 @@ public class Bullets implements ContentList{
             width = 16f;
             height = 23f;
             shootEffect = Fx.shootBig;
+        }};
+
+        standardPhaseBig = new BasicBulletType(8f, 45, "bullet"){{
+            width = 4f;
+            height = 28f;
+            pierce = true;
+            backColor = Pal.lightishOrange;
+            shootEffect = Fx.shootBig;
+            ammoMultiplier = 3;
+            reloadMultiplier = 1.1;
         }};
 
         standardIncendiaryBig = new BasicBulletType(7f, 60, "bullet"){{

--- a/core/src/mindustry/content/Bullets.java
+++ b/core/src/mindustry/content/Bullets.java
@@ -363,7 +363,7 @@ public class Bullets implements ContentList{
             backColor = Pal.lightishOrange;
             shootEffect = Fx.shootBig;
             ammoMultiplier = 3;
-            reloadMultiplier = 1.1;
+            reloadMultiplier = 1.1f;
         }};
 
         standardIncendiaryBig = new BasicBulletType(7f, 60, "bullet"){{


### PR DESCRIPTION
The Spectre is a 4x4 all-around turret with a limited selection of projectiles. By adding phase fabric as a form of ammunition, Spectre turrets have more meaning to their name, which results in bullets that do slightly less damage, but pierce through enemy units.