### PR TITLE
Adds a Pierce Cap Variable

### DIFF
--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -25,6 +25,7 @@ public abstract class BulletType extends Content{
     public float drawSize = 40f;
     public float drag = 0f;
     public boolean pierce, pierceBuilding;
+    public int pierceCap = 1;
     public Effect hitEffect, despawnEffect;
 
     /** Effect created when shooting. */
@@ -235,6 +236,11 @@ public abstract class BulletType extends Content{
     }
 
     public void init(Bullet b){
+        if(pierceCap > 1) {
+            pierce = true;
+            /** pierceBuilding = true; should this be true or not? */
+        }
+
         if(killShooter && b.owner() instanceof Healthc){
             ((Healthc)b.owner()).kill();
         }

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -25,7 +25,7 @@ public abstract class BulletType extends Content{
     public float drawSize = 40f;
     public float drag = 0f;
     public boolean pierce, pierceBuilding;
-    public int pierceCap = 1;
+    public int pierceCap = -1;
     public Effect hitEffect, despawnEffect;
 
     /** Effect created when shooting. */
@@ -236,7 +236,7 @@ public abstract class BulletType extends Content{
     }
 
     public void init(Bullet b){
-        if(pierceCap > 1) {
+        if(pierceCap >= 1) {
             pierce = true;
             pierceBuilding = true;
         }

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -238,7 +238,7 @@ public abstract class BulletType extends Content{
     public void init(Bullet b){
         if(pierceCap > 1) {
             pierce = true;
-            /** pierceBuilding = true; should this be true or not? */
+            pierceBuilding = true;
         }
 
         if(killShooter && b.owner() instanceof Healthc){

--- a/core/src/mindustry/entities/comp/BulletComp.java
+++ b/core/src/mindustry/entities/comp/BulletComp.java
@@ -144,6 +144,10 @@ abstract class BulletComp implements Timedc, Damagec, Hitboxc, Teamc, Posc, Draw
                 return false;
             });
         }
+
+        if(collided.size >= type.pierceCap) {
+            remove();
+        }
     }
 
     @Override

--- a/core/src/mindustry/entities/comp/BulletComp.java
+++ b/core/src/mindustry/entities/comp/BulletComp.java
@@ -145,7 +145,7 @@ abstract class BulletComp implements Timedc, Damagec, Hitboxc, Teamc, Posc, Draw
             });
         }
 
-        if(collided.size >= type.pierceCap) {
+        if(type.pierceCap != -1 && collided.size >= type.pierceCap) {
             remove();
         }
     }


### PR DESCRIPTION
Currently, you can either have `pierce = true`, which makes almost everything OP, or `pierce = false`, which, is a bit underwhelming in certain cases. With a pierce cap variable, devs/contributors/modders have a new way to balance/create projectiles.