### PR TITLE
Fixes the * float int error in the space shader (merge to close all 5 issues automatically)

### DIFF
--- a/core/assets/shaders/space.frag
+++ b/core/assets/shaders/space.frag
@@ -1,6 +1,6 @@
 #define HIGHP
 #define NSCALE 2700.0
-#define CAMSCALE (NSCALE*5)
+#define CAMSCALE (NSCALE*5.0)
 
 uniform sampler2D u_texture;
 uniform sampler2D u_stars;


### PR DESCRIPTION
`'*' does not operate on 'float' and 'int'`