### PR TITLE
Prevent plated conduits from leaking

### DIFF
--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -507,15 +507,15 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
         }
     }
 
-    public float moveLiquidForward(float leakResistance, Liquid liquid){
+    public float moveLiquidForward(boolean leaks, Liquid liquid){
         Tile next = tile.getNearby(rotation);
 
         if(next == null) return 0;
 
         if(next.build != null){
             return moveLiquid(next.build, liquid);
-        }else if(leakResistance != 100f && !next.block().solid && !next.block().hasLiquids){
-            float leakAmount = liquids.get(liquid) / leakResistance;
+        }else if(leaks && !next.block().solid && !next.block().hasLiquids){
+            float leakAmount = liquids.get(liquid) / 1.5f;
             Puddles.deposit(next, tile, liquid, leakAmount);
             liquids.remove(liquid, leakAmount);
         }

--- a/core/src/mindustry/world/blocks/liquid/ArmoredConduit.java
+++ b/core/src/mindustry/world/blocks/liquid/ArmoredConduit.java
@@ -11,7 +11,7 @@ public class ArmoredConduit extends Conduit{
 
     public ArmoredConduit(String name){
         super(name);
-        leakResistance = 10f;
+        leaks = false;
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/liquid/Conduit.java
+++ b/core/src/mindustry/world/blocks/liquid/Conduit.java
@@ -27,7 +27,7 @@ public class Conduit extends LiquidBlock implements Autotiler{
     public @Load(value = "@-top-#", length = 5) TextureRegion[] topRegions;
     public @Load(value = "@-bottom-#", length = 5, fallback = "conduit-bottom-#") TextureRegion[] botRegions;
 
-    public float leakResistance = 1.5f;
+    public boolean leaks = true;
 
     public Conduit(String name){
         super(name);
@@ -131,7 +131,7 @@ public class Conduit extends LiquidBlock implements Autotiler{
             smoothLiquid = Mathf.lerpDelta(smoothLiquid, liquids.currentAmount() / liquidCapacity, 0.05f);
 
             if(liquids.total() > 0.001f && timer(timerFlow, 1)){
-                moveLiquidForward(leakResistance, liquids.current());
+                moveLiquidForward(leaks, liquids.current());
                 noSleep();
             }else{
                 sleep();


### PR DESCRIPTION
> implements the popular 🚀 suggestion from https://github.com/Anuken/Mindustry-Suggestions/issues/717

this prevents plated conduits from leaking at all due to the cap texture region forming a visible seal:

![Screen Shot 2020-10-09 at 10 07 09](https://user-images.githubusercontent.com/3179271/95558976-57e3bb00-0a17-11eb-9697-8c5dba8af7d2.png)

this also removes the `leak resistance` property from conduits because its a technical nightmare that has bugged me forever:
- a resistance of exactly 100 would stop leaking, while it was actually a valid value.
- it was not really intuitive, `1.5f` would mean leak half, and `10f` close to but not exactly a tenth?
- https://github.com/topics/mindustry-mod?q=leakResistance no mod with this topic appears to use the property.
- https://github.com/topics/mindustry-mods?q=leakResistance no mod with this topic appears to use the property.

so this commit reverts that addition made in #999 and just puts the conduit leak rate back at what it was before.

personally i think this is the best solution for the problem, because even though it did leak less you would still not want to leave it unconnected for long or all the pressure would still drain rapidly over time the longer the pipe was, so now you can actually lay a purple pipe while it is already filling with fluids but without wasting any of it vs a blue pipe, i feel like this would be a good improvement to make the 3rd tier stand out more from the 2nd tier, and the votes on the suggestion seem to agree 😃 

> (re)named it `leaks` instead of `leak` since it sounded a bit better, but i'll leave a clickable code suggestion for anuke :)