### PR TITLE
Make deconstructing scrap walls return scrap

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -829,27 +829,27 @@ public class Blocks implements ContentList{
         }};
 
         scrapWall = new Wall("scrap-wall"){{
-            requirements(Category.defense, BuildVisibility.sandboxOnly, with());
+            requirements(Category.defense, BuildVisibility.sandboxOnly, with(Items.scrap, 6));
             health = 60 * wallHealthMultiplier;
             variants = 5;
         }};
 
         scrapWallLarge = new Wall("scrap-wall-large"){{
-            requirements(Category.defense, BuildVisibility.sandboxOnly, with());
+            requirements(Category.defense, BuildVisibility.sandboxOnly, ItemStack.mult(scrapWall.requirements, 4));
             health = 60 * 4 * wallHealthMultiplier;
             size = 2;
             variants = 4;
         }};
 
         scrapWallHuge = new Wall("scrap-wall-huge"){{
-            requirements(Category.defense, BuildVisibility.sandboxOnly, with());
+            requirements(Category.defense, BuildVisibility.sandboxOnly, ItemStack.mult(scrapWall.requirements, 9));
             health = 60 * 9 * wallHealthMultiplier;
             size = 3;
             variants = 3;
         }};
 
         scrapWallGigantic = new Wall("scrap-wall-gigantic"){{
-            requirements(Category.defense, BuildVisibility.sandboxOnly, with());
+            requirements(Category.defense, BuildVisibility.sandboxOnly, ItemStack.mult(scrapWall.requirements, 16));
             health = 60 * 16 * wallHealthMultiplier;
             size = 4;
         }};


### PR DESCRIPTION
found myself deconstructing some scrap walls on ruinous shores just now (ironically to uncover a scrap patch) and it dawned on me that scrap walls return nothing when deconstructing.

but now that the core can contain any item (including scrap) it would make sense that scrap walls return the expected amount.

even though you can't build them (yet) it just seems like a quality of life change.

- to keep the theme of wall costs i have kept the size 1 cost 6 like the other walls, but maybe less would make some more sense since there are chunks missing in the texture, though ironically that would make it even worth more scrap.

- sizes 3 and 4 are also multiplied from size 1 to make the calculation visibly easier to understand.

- technically just a suggestion, feel free to either merge of close this at your discretion: @Anuken ❤️ 

![Screen Shot 2020-10-11 at 14 02 54](https://user-images.githubusercontent.com/3179271/95678083-7ccc5f80-0bca-11eb-80c4-f373defb22c5.png)
