### PR TITLE
add names to lots of ui elements

### DIFF
--- a/core/src/mindustry/ui/dialogs/PausedDialog.java
+++ b/core/src/mindustry/ui/dialogs/PausedDialog.java
@@ -38,14 +38,15 @@ public class PausedDialog extends BaseDialog{
             cont.label(() -> state.getSector() == null ? "" :
             ("[lightgray]Next turn in [accent]" + state.getSector().displayTimeRemaining() +
                 (state.rules.winWave > 0 && !state.getSector().isCaptured() ? "\n[lightgray]Reach wave[accent] " + state.rules.winWave + "[] to capture" : "")))
-            .visible(() -> state.getSector() != null).colspan(2);
+            .visible(() -> state.getSector() != null).colspan(2)
+            .name("turn");
             cont.row();
 
             float dw = 220f;
             cont.defaults().width(dw).height(55).pad(5f);
 
-            cont.button("@back", Icon.left, this::hide);
-            cont.button("@settings", Icon.settings, ui.settings::show);
+            cont.button("@back", Icon.left, this::hide).name("back");
+            cont.button("@settings", Icon.settings, ui.settings::show).name("settings");
 
             if(!state.rules.tutorial){
                 if(!state.isCampaign() && !state.isEditor()){

--- a/core/src/mindustry/ui/dialogs/PlanetDialog.java
+++ b/core/src/mindustry/ui/dialogs/PlanetDialog.java
@@ -32,18 +32,18 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
     //if true, enables launching anywhere for testing
     public static boolean debugSelect = false;
 
-    final FrameBuffer buffer = new FrameBuffer(2, 2, true);
-    final PlanetRenderer planets = renderer.planets;
-    final LaunchLoadoutDialog loadouts = new LaunchLoadoutDialog();
-    final Table stable  = new Table().background(Styles.black3);
+    public final FrameBuffer buffer = new FrameBuffer(2, 2, true);
+    public final PlanetRenderer planets = renderer.planets;
+    public final LaunchLoadoutDialog loadouts = new LaunchLoadoutDialog();
+    public final Table stable  = new Table().background(Styles.black3);
 
-    int launchRange;
-    float zoom = 1f, selectAlpha = 1f;
-    @Nullable Sector selected, hovered, launchSector;
-    CoreBuild launcher;
-    Mode mode = look;
-    boolean launching;
-    Cons<Sector> listener = s -> {};
+    public int launchRange;
+    public float zoom = 1f, selectAlpha = 1f;
+    public @Nullable Sector selected, hovered, launchSector;
+    public CoreBuild launcher;
+    public Mode mode = look;
+    public boolean launching;
+    public Cons<Sector> listener = s -> {};
 
     public PlanetDialog(){
         super("", Styles.fullDialog);
@@ -236,7 +236,6 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
 
         cont.clear();
         titleTable.remove();
-
 
         cont.stack(
         new Element(){
@@ -468,7 +467,7 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
         stable.act(0f);
     }
 
-    enum Mode{
+    public enum Mode{
         /** Look around for existing sectors. Can only deploy. */
         look,
         /** Launch to a new location. */

--- a/core/src/mindustry/ui/dialogs/ResearchDialog.java
+++ b/core/src/mindustry/ui/dialogs/ResearchDialog.java
@@ -31,14 +31,14 @@ import java.util.*;
 import static mindustry.Vars.*;
 
 public class ResearchDialog extends BaseDialog{
-    final float nodeSize = Scl.scl(60f);
-    ObjectSet<TechTreeNode> nodes = new ObjectSet<>();
-    TechTreeNode root = new TechTreeNode(TechTree.root, null);
-    Rect bounds = new Rect();
-    ItemsDisplay itemDisplay;
-    View view;
+    public final float nodeSize = Scl.scl(60f);
+    public ObjectSet<TechTreeNode> nodes = new ObjectSet<>();
+    public TechTreeNode root = new TechTreeNode(TechTree.root, null);
+    public Rect bounds = new Rect();
+    public ItemsDisplay itemDisplay;
+    public View view;
 
-    ItemSeq items;
+    public ItemSeq items;
 
     public ResearchDialog(){
         super("");
@@ -114,7 +114,7 @@ public class ResearchDialog extends BaseDialog{
         buttons.button("@database", Icon.book, () -> {
             hide();
             ui.database.show();
-        }).size(210f, 64f);
+        }).size(210f, 64f).name("database");
 
         //scaling/drag input
         addListener(new InputListener(){
@@ -250,7 +250,7 @@ public class ResearchDialog extends BaseDialog{
         return node.content.unlocked() || !node.objectives.contains(i -> !i.complete());
     }
 
-    void showToast(String info){
+    public void showToast(String info){
         Table table = new Table();
         table.actions(Actions.fadeOut(0.5f, Interp.fade), Actions.remove());
         table.top().add(info);
@@ -279,11 +279,11 @@ public class ResearchDialog extends BaseDialog{
         }
     }
 
-    class TechTreeNode extends TreeNode<TechTreeNode>{
-        final TechNode node;
-        boolean visible = true, selectable = true;
+    public class TechTreeNode extends TreeNode<TechTreeNode>{
+        public final TechNode node;
+        public boolean visible = true, selectable = true;
 
-        TechTreeNode(TechNode node, TechTreeNode parent){
+        public TechTreeNode(TechNode node, TechTreeNode parent){
             this.node = node;
             this.parent = parent;
             this.width = this.height = nodeSize;
@@ -297,11 +297,11 @@ public class ResearchDialog extends BaseDialog{
         }
     }
 
-    class View extends Group{
-        float panX = 0, panY = -200, lastZoom = -1;
-        boolean moved = false;
-        ImageButton hoverNode;
-        Table infoTable = new Table();
+    public class View extends Group{
+        public float panX = 0, panY = -200, lastZoom = -1;
+        public boolean moved = false;
+        public ImageButton hoverNode;
+        public Table infoTable = new Table();
 
         {
             infoTable.touchable = Touchable.enabled;

--- a/core/src/mindustry/ui/fragments/HudFragment.java
+++ b/core/src/mindustry/ui/fragments/HudFragment.java
@@ -205,7 +205,7 @@ public class HudFragment extends Fragment{
             editorMain.name = "editor";
             editorMain.table(Tex.buttonEdge4, t -> {
                 //t.margin(0f);
-                t.name("teams");
+                t.name = "teams";
                 t.add("@editor.teams").growX().left();
                 t.row();
                 t.table(teams -> {

--- a/core/src/mindustry/ui/fragments/HudFragment.java
+++ b/core/src/mindustry/ui/fragments/HudFragment.java
@@ -79,20 +79,23 @@ public class HudFragment extends Fragment{
 
         //paused table
         parent.fill(t -> {
+            t.name = "paused";
             t.top().visible(() -> state.isPaused()).touchable = Touchable.disabled;
             t.table(Styles.black5, top -> top.add("@paused").style(Styles.outlineLabel).pad(8f)).growX();
         });
 
         //minimap + position
         parent.fill(t -> {
+            t.name = "minimap/position";
             t.visible(() -> Core.settings.getBool("minimap") && !state.rules.tutorial && shown);
             //minimap
-            t.add(new Minimap());
+            t.add(new Minimap()).name("minimap");
             t.row();
             //position
             t.label(() -> player.tileX() + "," + player.tileY())
             .visible(() -> Core.settings.getBool("position") && !state.rules.tutorial)
-            .touchable(Touchable.disabled);
+            .touchable(Touchable.disabled)
+            .name("position");
             t.top().right();
         });
 
@@ -104,15 +107,18 @@ public class HudFragment extends Fragment{
 
             if(mobile){
                 cont.table(select -> {
+                    select.name = "mobile buttons";
                     select.left();
                     select.defaults().size(dsize).left();
 
                     ImageButtonStyle style = Styles.clearTransi;
 
-                    select.button(Icon.menu, style, ui.paused::show);
+                    select.button(Icon.menu, style, ui.paused::show).name("menu");
                     flip = select.button(Icon.upOpen, style, this::toggleMenus).get();
+                    flip.name = "flip";
 
-                    select.button(Icon.paste, style, ui.schematics::show);
+                    select.button(Icon.paste, style, ui.schematics::show)
+                    .name("schematics");
 
                     select.button(Icon.pause, style, () -> {
                         if(net.active()){
@@ -141,7 +147,7 @@ public class HudFragment extends Fragment{
                         }else{
                             ui.database.show();
                         }
-                    }).update(i -> {
+                    }).name("chat").update(i -> {
                         if(net.active() && mobile){
                             i.getStyle().imageUp = Icon.chat;
                         }else if(state.isCampaign()){
@@ -167,14 +173,15 @@ public class HudFragment extends Fragment{
 
             Table wavesMain, editorMain;
 
-            cont.stack(wavesMain = new Table(), editorMain = new Table()).height(wavesMain.getPrefHeight());
+            cont.stack(wavesMain = new Table(), editorMain = new Table()).height(wavesMain.getPrefHeight())
+            .name("waves/editor");
 
             wavesMain.visible(() -> shown && !state.isEditor());
-            wavesMain.top().left();
+            wavesMain.top().left().name = "waves";
 
             wavesMain.table(s -> {
                 //wave info button with text
-                s.add(makeStatusTable()).grow();
+                s.add(makeStatusTable()).grow().name("status");
 
                 //table with button to skip wave
                 s.button(Icon.play, Styles.righti, 30f, () -> {
@@ -183,18 +190,22 @@ public class HudFragment extends Fragment{
                     }else{
                         logic.skipWave();
                     }
-                }).growY().fillX().right().width(40f).disabled(b -> !canSkipWave()).visible(() -> state.rules.waves);
+                }).growY().fillX().right().width(40f).disabled(b -> !canSkipWave())
+                .visible(() -> state.rules.waves).name("skip");
             }).width(dsize * 5 + 4f);
 
             wavesMain.row();
 
             wavesMain.table(Tex.button, t -> t.margin(10f).add(new Bar("boss.health", Pal.health, () -> state.boss() == null ? 0f : state.boss().healthf()).blink(Color.white))
-            .grow()).fillX().visible(() -> state.rules.waves && state.boss() != null).height(60f).get();
+            .grow()).fillX().visible(() -> state.rules.waves && state.boss() != null).height(60f).get()
+            .name = "boss";
 
             wavesMain.row();
 
+            editorMain.name = "editor";
             editorMain.table(Tex.buttonEdge4, t -> {
                 //t.margin(0f);
+                t.name("teams");
                 t.add("@editor.teams").growX().left();
                 t.row();
                 t.table(teams -> {
@@ -215,29 +226,33 @@ public class HudFragment extends Fragment{
             }).width(dsize * 5 + 4f);
             editorMain.visible(() -> shown && state.isEditor());
 
-
             //fps display
             cont.table(info -> {
+                info.name = "fps/ping";
                 info.touchable = Touchable.disabled;
                 info.top().left().margin(4).visible(() -> Core.settings.getBool("fps") && shown);
                 info.update(() -> info.setTranslation(state.rules.waves || state.isEditor() ? 0f : -Scl.scl(dsize * 4 + 3), 0));
                 IntFormat fps = new IntFormat("fps");
                 IntFormat ping = new IntFormat("ping");
 
-                info.label(() -> fps.get(Core.graphics.getFramesPerSecond())).left().style(Styles.outlineLabel);
+                info.label(() -> fps.get(Core.graphics.getFramesPerSecond())).left()
+                .style(Styles.outlineLabel).name("fps");
                 info.row();
-                info.label(() -> ping.get(netClient.getPing())).visible(net::client).left().style(Styles.outlineLabel);
+                info.label(() -> ping.get(netClient.getPing())).visible(net::client).left()
+                .style(Styles.outlineLabel).name("ping");
             }).top().left();
         });
 
         //core items
         parent.fill(t -> {
+            t.name = "coreitems";
             t.top().add(coreItems);
             t.visible(() -> Core.settings.getBool("coreitems") && !mobile && !state.isPaused() && shown);
         });
 
         //spawner warning
         parent.fill(t -> {
+            t.name = "nearpoint";
             t.touchable = Touchable.disabled;
             t.table(Styles.black, c -> c.add("@nearpoint")
             .update(l -> l.setColor(Tmp.c1.set(Color.white).lerp(Color.scarlet, Mathf.absin(Time.time(), 10f, 1f))))
@@ -246,12 +261,14 @@ public class HudFragment extends Fragment{
         });
 
         parent.fill(t -> {
+            t.name = "waiting";
             t.visible(() -> netServer.isWaitingForPlayers());
             t.table(Tex.button, c -> c.add("@waiting.players"));
         });
 
         //'core is under attack' table
         parent.fill(t -> {
+            t.name = "coreattack";
             t.touchable = Touchable.disabled;
             float notifDuration = 240f;
             float[] coreAttackTime = {0};
@@ -285,6 +302,7 @@ public class HudFragment extends Fragment{
 
         //tutorial text
         parent.fill(t -> {
+            t.name = "tutorial";
             Runnable resize = () -> {
                 t.clearChildren();
                 t.top().right().visible(() -> state.rules.tutorial);
@@ -307,11 +325,13 @@ public class HudFragment extends Fragment{
 
         //'saving' indicator
         parent.fill(t -> {
+            t.name = "saving";
             t.bottom().visible(() -> control.saves.isSaving());
             t.add("@saving").style(Styles.outlineLabel);
         });
 
         parent.fill(p -> {
+            p.name = "hudtext";
             p.top().table(Styles.black3, t -> t.margin(4).label(() -> hudText)
             .style(Styles.outlineLabel)).padTop(10).visible(p.color.a >= 0.001f);
             p.update(() -> {
@@ -327,6 +347,7 @@ public class HudFragment extends Fragment{
         //TODO DEBUG: rate table
         if(false)
         parent.fill(t -> {
+            t.name = "rates";
             t.bottom().left();
             t.table(Styles.black6, c -> {
                 Bits used = new Bits(content.items().size);

--- a/core/src/mindustry/ui/fragments/MenuFragment.java
+++ b/core/src/mindustry/ui/fragments/MenuFragment.java
@@ -45,7 +45,7 @@ public class MenuFragment extends Fragment{
 
         parent.fill(c -> {
             container = c;
-			c.name = "menu container";
+            c.name = "menu container";
 
             if(!mobile){
                 buildDesktop();
@@ -94,7 +94,7 @@ public class MenuFragment extends Fragment{
 
     private void buildMobile(){
         container.clear();
-		container.name = "buttons";
+        container.name = "buttons";
         container.setSize(Core.graphics.getWidth(), Core.graphics.getHeight());
 
         float size = 120f;
@@ -162,7 +162,7 @@ public class MenuFragment extends Fragment{
         container.add().width(Core.graphics.getWidth()/10f);
         container.table(background, t -> {
             t.defaults().width(width).height(70f);
-			t.name = "buttons";
+            t.name = "buttons";
 
             buttons(t,
                 new Buttoni("@play", Icon.play,
@@ -185,7 +185,7 @@ public class MenuFragment extends Fragment{
 
         container.table(background, t -> {
             submenu = t;
-			t.name = "submenu";
+            t.name = "submenu";
             t.color.a = 0f;
             t.top();
             t.defaults().width(width).height(70f);

--- a/core/src/mindustry/ui/fragments/MenuFragment.java
+++ b/core/src/mindustry/ui/fragments/MenuFragment.java
@@ -45,6 +45,7 @@ public class MenuFragment extends Fragment{
 
         parent.fill(c -> {
             container = c;
+			c.name = "menu container";
 
             if(!mobile){
                 buildDesktop();
@@ -57,8 +58,8 @@ public class MenuFragment extends Fragment{
 
         //info icon
         if(mobile){
-            parent.fill(c -> c.bottom().left().button("", Styles.infot, ui.about::show).size(84, 45));
-            parent.fill(c -> c.bottom().right().button("", Styles.discordt, ui.discord::show).size(84, 45));
+            parent.fill(c -> c.bottom().left().button("", Styles.infot, ui.about::show).size(84, 45).name("info"));
+            parent.fill(c -> c.bottom().right().button("", Styles.discordt, ui.discord::show).size(84, 45).name("discord"));
         }else if(becontrol.active()){
             parent.fill(c -> c.bottom().right().button("@be.check", Icon.refresh, () -> {
                 ui.loadfrag.show();
@@ -68,7 +69,7 @@ public class MenuFragment extends Fragment{
                         ui.showInfo("@be.noupdates");
                     }
                 });
-            }).size(200, 60).update(t -> {
+            }).size(200, 60).name("becheck").update(t -> {
                 t.getLabel().setColor(becontrol.isUpdateAvailable() ? Tmp.c1.set(Color.white).lerp(Pal.accent, Mathf.absin(5f, 1f)) : Color.white);
             }));
         }
@@ -93,6 +94,7 @@ public class MenuFragment extends Fragment{
 
     private void buildMobile(){
         container.clear();
+		container.name = "buttons";
         container.setSize(Core.graphics.getWidth(), Core.graphics.getHeight());
 
         float size = 120f;
@@ -153,7 +155,6 @@ public class MenuFragment extends Fragment{
         container.clear();
         container.setSize(Core.graphics.getWidth(), Core.graphics.getHeight());
 
-
         float width = 230f;
         Drawable background = Styles.black6;
 
@@ -161,6 +162,7 @@ public class MenuFragment extends Fragment{
         container.add().width(Core.graphics.getWidth()/10f);
         container.table(background, t -> {
             t.defaults().width(width).height(70f);
+			t.name = "buttons";
 
             buttons(t,
                 new Buttoni("@play", Icon.play,
@@ -183,6 +185,7 @@ public class MenuFragment extends Fragment{
 
         container.table(background, t -> {
             submenu = t;
+			t.name = "submenu";
             t.color.a = 0f;
             t.top();
             t.defaults().width(width).height(70f);

--- a/core/src/mindustry/ui/fragments/PlayerListFragment.java
+++ b/core/src/mindustry/ui/fragments/PlayerListFragment.java
@@ -24,7 +24,9 @@ public class PlayerListFragment extends Fragment{
 
     @Override
     public void build(Group parent){
+        content.name = "players";
         parent.fill(cont -> {
+            cont.name = "playerlist";
             cont.visible(() -> visible);
             cont.update(() -> {
                 if(!(net.active() && state.isGame())){
@@ -47,6 +49,7 @@ public class PlayerListFragment extends Fragment{
                 sField = pane.field(null, text -> {
                     rebuild();
                 }).grow().pad(8).get();
+                sField.name = "search";
                 sField.setMaxLength(maxNameLength);
                 sField.setMessageText(Core.bundle.format("players.search"));
 
@@ -56,6 +59,7 @@ public class PlayerListFragment extends Fragment{
 
                 pane.table(menu -> {
                     menu.defaults().growX().height(50f).fillY();
+                    menu.name = "menu";
 
                     menu.button("@server.bans", ui.bans::show).disabled(b -> net.client());
                     menu.button("@server.admins", ui.admins::show).disabled(b -> net.client());
@@ -99,6 +103,7 @@ public class PlayerListFragment extends Fragment{
             };
             table.margin(8);
             table.add(new Image(user.icon()).setScaling(Scaling.bounded)).grow();
+            table.name = user.name();
 
             button.add(table).size(h);
             button.labelWrap("[#" + user.color().toString().toUpperCase() + "]" + user.name()).width(170f).pad(10);

--- a/core/src/mindustry/ui/fragments/ScriptConsoleFragment.java
+++ b/core/src/mindustry/ui/fragments/ScriptConsoleFragment.java
@@ -39,7 +39,6 @@ public class ScriptConsoleFragment extends Table{
     };
 
     public ScriptConsoleFragment(){
-
         setFillParent(true);
         font = Fonts.def;
 


### PR DESCRIPTION
Allows for mods to easily modify UI with scene.find rather than obtuse .cells.get(n).get().cells.get(n)...
Possible uses:
- Moving fps around or adding bits to it
- Adding stuff under minimap
- Adding buttons to the main menu
- Planet and tech tree stuff