### PR TITLE
Visualize maximum amount of power node wires

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -628,6 +628,7 @@ bar.powerbalance = Power: {0}/s
 bar.powerstored = Stored: {0}/{1}
 bar.poweramount = Power: {0}
 bar.poweroutput = Power Output: {0}
+bar.powerlines = Connections: {0}/{1}
 bar.items = Items: {0}
 bar.capacity = Capacity: {0}
 bar.unitcap = {0} {1}/{2}

--- a/core/src/mindustry/world/blocks/power/PowerNode.java
+++ b/core/src/mindustry/world/blocks/power/PowerNode.java
@@ -112,6 +112,12 @@ public class PowerNode extends PowerBlock{
             (UI.formatAmount((int)entity.power.graph.getLastPowerStored())), UI.formatAmount((int)entity.power.graph.getLastCapacity())),
             () -> Pal.powerBar,
             () -> Mathf.clamp(entity.power.graph.getLastPowerStored() / entity.power.graph.getLastCapacity())));
+
+        bars.add("connections", entity -> new Bar(() ->
+        Core.bundle.format("bar.powerlines", entity.power.links.size, maxNodes),
+            () -> Pal.ammo,
+            () -> (float)entity.power.links.size / (float)maxNodes
+        ));
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/power/PowerNode.java
+++ b/core/src/mindustry/world/blocks/power/PowerNode.java
@@ -115,7 +115,7 @@ public class PowerNode extends PowerBlock{
 
         bars.add("connections", entity -> new Bar(() ->
         Core.bundle.format("bar.powerlines", entity.power.links.size, maxNodes),
-            () -> Pal.ammo,
+            () -> Pal.items,
             () -> (float)entity.power.links.size / (float)maxNodes
         ));
     }


### PR DESCRIPTION
on the same ruinous shore map as my other pull request i ran into an old friend: 12f1ee95373b0e531c55efcb858e7a5ec92acb88
(that commit ~~lowered~~ nerfed the max amount of power node connections)

people used to the normal wire count might expect to be able to link the water extractor to this node, as i have:

![Screen Shot 2020-10-11 at 14 24 34](https://user-images.githubusercontent.com/3179271/95679369-9a9dc280-0bd2-11eb-96d6-43dad123fb57.png)

the only problem that there is no real visual indication of the node being full, clicking does nothing and the only hint as to why is in the core database.

i propose to add a bar to power nodes that list the max and current amount of connections:
![Screen Shot 2020-10-11 at 14 57 48](https://user-images.githubusercontent.com/3179271/95679415-f5cfb500-0bd2-11eb-8b1a-db6795f3b97a.png)

> the naming of its bar & bundle entry doesn't feel quite right, accepting suggestions on how to (re)name those*

