### PR TITLE
Fix Vars.loops declaration

### DIFF
--- a/core/src/mindustry/Vars.java
+++ b/core/src/mindustry/Vars.java
@@ -184,7 +184,7 @@ public class Vars implements Loadable{
     public static GameState state;
     public static EntityCollisions collisions;
     public static DefaultWaves defaultWaves;
-    public static mindustry.audio.LoopControl loops;
+    public static LoopControl loops;
     public static Platform platform = new Platform(){};
     public static Mods mods;
     public static Schematics schematics;


### PR DESCRIPTION
`mindustry.audio.LoopControl` seems weird, there is `import mindustry.audio.*;` so we don't need to write full package name. Compiles fine.