### PR TITLE
Add `pierceCap` Info

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -652,6 +652,7 @@ bullet.homing = [stat]homing
 bullet.shock = [stat]shock
 bullet.frag = [stat]frag
 bullet.knockback = [stat]{0}[lightgray] knockback
+bullet.pierce = [stat]{0}[lightgray] pierce
 bullet.freezing = [stat]freezing
 bullet.tarred = [stat]tarred
 bullet.multiplier = [stat]{0}[lightgray]x ammo multiplier

--- a/core/src/mindustry/world/meta/values/AmmoListValue.java
+++ b/core/src/mindustry/world/meta/values/AmmoListValue.java
@@ -50,6 +50,10 @@ public class AmmoListValue<T extends UnlockableContent> implements StatValue{
                     sep(bt, Core.bundle.format("bullet.knockback", Strings.fixed(type.knockback, 1)));
                 }
 
+                if(type.pierce){
+                    sep(bt, Core.bundle.format("bullet.pierce", type.pierceCap == -1 ? "infinite" : type.pierceCap));
+                }
+
                 if((type.status == StatusEffects.burning || type.status == StatusEffects.melting) || type.incendAmount > 0){
                     sep(bt, "@bullet.incendiary");
                 }


### PR DESCRIPTION
Now that there is a `pierceCap` variable, people should be able to see how much pierce a bullet has. 
![pierce-info](https://user-images.githubusercontent.com/68400583/95693939-fae93000-0be3-11eb-91b7-e0de4198f4e1.jpg)
