### PR TITLE
New feature request: bullet homing delay

### DIFF
--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -104,6 +104,8 @@ public abstract class BulletType extends Content{
     public float incendChance = 1f;
     public float homingPower = 0f;
     public float homingRange = 50f;
+    /** Use a negative value to disable homing delay. */
+    public float homingDelay = -1f;
 
     public Color lightningColor = Pal.surge;
     public int lightning;
@@ -260,7 +262,7 @@ public abstract class BulletType extends Content{
     }
 
     public void update(Bullet b){
-        if(homingPower > 0.0001f){
+        if(homingPower > 0.0001f && b.time >= homingDelay){
             Teamc target = Units.closestTarget(b.team, b.x, b.y, homingRange, e -> (e.isGrounded() && collidesGround) || (e.isFlying() && collidesAir), t -> collidesGround);
             if(target != null){
                 b.vel.setAngle(Mathf.slerpDelta(b.rotation(), b.angleTo(target), homingPower));


### PR DESCRIPTION
I'm a mod creator, I want a feature that adds a delay for bullet homing, to get some funny effects.
The image below shows the difference between homing delay or not, the left turret has a delay, the right one has no delay.
![图片](https://user-images.githubusercontent.com/6198193/96281892-8ad81100-100c-11eb-8fa7-184f35caeb88.png)
