### PR TITLE
Update Unit Locate instruction to access located building

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -212,8 +212,9 @@ public class LExecutor{
         public BlockFlag flag = BlockFlag.core;
         public int enemy, ore;
         public int outX, outY, outFound;
+        public Object getOut;
 
-        public UnitLocateI(LLocate locate, BlockFlag flag, int enemy, int ore, int outX, int outY, int outFound){
+        public UnitLocateI(LLocate locate, BlockFlag flag, int enemy, int ore, int outX, int outY, int outFound, Object getOut){
             this.locate = locate;
             this.flag = flag;
             this.enemy = enemy;
@@ -221,6 +222,7 @@ public class LExecutor{
             this.outX = outX;
             this.outY = outY;
             this.outFound = outFound;
+            this.getOut = getOut;
         }
 
         public UnitLocateI(){
@@ -266,6 +268,7 @@ public class LExecutor{
                         exec.setnum(outX, cache.x = build ? res.build.x : res.worldx());
                         exec.setnum(outY, cache.y = build ? res.build.y : res.worldy());
                         exec.setnum(outFound, 1);
+                        exec.obj(getOut);
                     }else{
                         cache.found = false;
                         exec.setnum(outFound, 0);

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -268,7 +268,7 @@ public class LExecutor{
                         exec.setnum(outX, cache.x = build ? res.build.x : res.worldx());
                         exec.setnum(outY, cache.y = build ? res.build.y : res.worldy());
                         exec.setnum(outFound, 1);
-                        //access result building
+                        //access result building to use as variable
                         exec.building(getOut);
                     }else{
                         cache.found = false;

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -212,9 +212,9 @@ public class LExecutor{
         public BlockFlag flag = BlockFlag.core;
         public int enemy, ore;
         public int outX, outY, outFound;
-        public Object getOut;
+        public Building getOut;
 
-        public UnitLocateI(LLocate locate, BlockFlag flag, int enemy, int ore, int outX, int outY, int outFound, Object getOut){
+        public UnitLocateI(LLocate locate, BlockFlag flag, int enemy, int ore, int outX, int outY, int outFound, Building getOut){
             this.locate = locate;
             this.flag = flag;
             this.enemy = enemy;
@@ -268,7 +268,8 @@ public class LExecutor{
                         exec.setnum(outX, cache.x = build ? res.build.x : res.worldx());
                         exec.setnum(outY, cache.y = build ? res.build.y : res.worldy());
                         exec.setnum(outFound, 1);
-                        exec.obj(getOut);
+                        //access result building
+                        exec.building(getOut);
                     }else{
                         cache.found = false;
                         exec.setnum(outFound, 0);

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -820,6 +820,7 @@ public class LStatements{
         public BlockFlag flag = BlockFlag.core;
         public String enemy = "true", ore = "@copper";
         public String outX = "outx", outY = "outy", outFound = "found";
+        public String getOut = "out";
 
         @Override
         public void build(Table table){
@@ -903,8 +904,14 @@ public class LStatements{
             row(table);
 
             table.add(" found ").left();
-            fields(table, outFound, str -> outFound = str);
+            fields(table, outFound, str -> outFound = str)
 
+            if(locate == building) {
+                row(table);
+
+                table.add(" outGet ").left();
+                fields(table, getOut, str -> getOut = str);
+            }
 
         }
 

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -904,7 +904,7 @@ public class LStatements{
             row(table);
 
             table.add(" found ").left();
-            fields(table, outFound, str -> outFound = str)
+            fields(table, outFound, str -> outFound = str);
 
             if(locate == building) {
                 row(table);


### PR DESCRIPTION
Update the instruction so that when a "building" is specified for locating, it also returns the building itself to allow access to its variables and as a variable. This would allow a controlled unit to directly interact with the block


An example of a logic process that would work from this change is:
```
 ubind @nova
 sensor cnt @unit @totalItems
 sensor icp @unit @itemCapacity
 ucontrol boost 1 0 0 0
 ulocate building core false @copper creX creY found cre
 ucontrol approach creX creY 10 0
 ucontrol itemTake cre @silicon icp 0
```

The current unitLocate command doesn't return the block; currently the nova would just hover endlessly over the core through this process and take no items whatsoever.

![image](https://user-images.githubusercontent.com/19158169/96287931-9dbcf800-0fb0-11eb-90ab-c802fa8e2bc8.png)
I'm certain this would probably get rejected, because I am uncertain as to why 