### PR TITLE
add universe draw events

### DIFF
--- a/core/src/mindustry/game/EventType.java
+++ b/core/src/mindustry/game/EventType.java
@@ -35,7 +35,10 @@ public class EventType{
         preDraw,
         postDraw,
         uiDrawBegin,
-        uiDrawEnd
+        uiDrawEnd,
+        //before/after bloom used, skybox or planets drawn - use Vars.renderer.planets
+        universeDrawBegin,
+        universeDrawEnd
     }
 
     public static class WinEvent{}

--- a/core/src/mindustry/game/EventType.java
+++ b/core/src/mindustry/game/EventType.java
@@ -36,8 +36,11 @@ public class EventType{
         postDraw,
         uiDrawBegin,
         uiDrawEnd,
-        //before/after bloom used, skybox or planets drawn - use Vars.renderer.planets
+        //before/after bloom used, skybox or planets drawn
         universeDrawBegin,
+        //skybox drawn and bloom is enabled - use Vars.renderer.planets
+        universeDraw,
+        //planets drawn and bloom disabled
         universeDrawEnd
     }
 

--- a/core/src/mindustry/graphics/g3d/PlanetRenderer.java
+++ b/core/src/mindustry/graphics/g3d/PlanetRenderer.java
@@ -10,6 +10,7 @@ import arc.math.geom.*;
 import arc.struct.*;
 import arc.util.*;
 import mindustry.content.*;
+import mindustry.game.EventType.*;
 import mindustry.graphics.*;
 import mindustry.graphics.g3d.PlanetGrid.*;
 import mindustry.type.*;
@@ -38,19 +39,19 @@ public class PlanetRenderer implements Disposable{
     public float zoom = 1f;
 
     private final Mesh[] outlines = new Mesh[10];
-    private final PlaneBatch3D projector = new PlaneBatch3D();
-    private final Mat3D mat = new Mat3D();
-    private final FrameBuffer buffer = new FrameBuffer(2, 2, true);
-    private PlanetInterfaceRenderer irenderer;
+    public final PlaneBatch3D projector = new PlaneBatch3D();
+    public final Mat3D mat = new Mat3D();
+    public final FrameBuffer buffer = new FrameBuffer(2, 2, true);
+    public PlanetInterfaceRenderer irenderer;
 
-    private final Bloom bloom = new Bloom(Core.graphics.getWidth()/4, Core.graphics.getHeight()/4, true, false){{
+    public final Bloom bloom = new Bloom(Core.graphics.getWidth()/4, Core.graphics.getHeight()/4, true, false){{
         setThreshold(0.8f);
         blurPasses = 6;
     }};
-    private final Mesh atmosphere = MeshBuilder.buildHex(Color.white, 2, false, 1.5f);
+    public final Mesh atmosphere = MeshBuilder.buildHex(Color.white, 2, false, 1.5f);
 
     //seed: 8kmfuix03fw
-    private final CubemapMesh skybox = new CubemapMesh(new Cubemap("cubemaps/stars/"));
+    public final CubemapMesh skybox = new CubemapMesh(new Cubemap("cubemaps/stars/"));
 
     public PlanetRenderer(){
         camPos.set(0, 0f, camLength);
@@ -82,6 +83,8 @@ public class PlanetRenderer implements Disposable{
         projector.proj(cam.combined);
         batch.proj(cam.combined);
 
+        Events.fire(Trigger.universeDrawBegin);
+
         beginBloom();
 
         skybox.render(cam.combined);
@@ -89,6 +92,8 @@ public class PlanetRenderer implements Disposable{
         renderPlanet(solarSystem);
 
         endBloom();
+
+        Events.fire(Trigger.universeDrawEnd);
 
         Gl.enable(Gl.blend);
 
@@ -100,16 +105,16 @@ public class PlanetRenderer implements Disposable{
         cam.update();
     }
 
-    private void beginBloom(){
+    public void beginBloom(){
         bloom.resize(Core.graphics.getWidth() / 4, Core.graphics.getHeight() / 4);
         bloom.capture();
     }
 
-    private void endBloom(){
+    public void endBloom(){
         bloom.render();
     }
 
-    private void renderPlanet(Planet planet){
+    public void renderPlanet(Planet planet){
         //render planet at offsetted position in the world
         planet.mesh.render(cam.combined, planet.getTransform(mat));
 
@@ -137,7 +142,7 @@ public class PlanetRenderer implements Disposable{
         }
     }
 
-    private void renderOrbit(Planet planet){
+    public void renderOrbit(Planet planet){
         if(planet.parent == null) return;
 
         Vec3 center = planet.parent.position;
@@ -147,7 +152,7 @@ public class PlanetRenderer implements Disposable{
         batch.flush(Gl.lineLoop);
     }
 
-    private void renderSectors(Planet planet){
+    public void renderSectors(Planet planet){
         //apply transformed position
         batch.proj().mul(planet.getTransform(mat));
 
@@ -268,7 +273,7 @@ public class PlanetRenderer implements Disposable{
         }
     }
 
-    private Mesh outline(int size){
+    public Mesh outline(int size){
         if(outlines[size] == null){
             outlines[size] = MeshBuilder.buildHex(new HexMesher(){
                 @Override

--- a/core/src/mindustry/graphics/g3d/PlanetRenderer.java
+++ b/core/src/mindustry/graphics/g3d/PlanetRenderer.java
@@ -89,6 +89,8 @@ public class PlanetRenderer implements Disposable{
 
         skybox.render(cam.combined);
 
+        Events.fire(Trigger.universeDraw);
+
         renderPlanet(solarSystem);
 
         endBloom();


### PR DESCRIPTION
Adds these events for universe drawing:
- Trigger.universeDrawBegin, before bloom, skybox, planets
- Trigger.universeDraw, after bloom and skybox
- Trigger.universeDrawEnd, after solar system drawn and bloom disabled

Also made almost all drawing funcs and fields public to facilitate this.

These should be used for things like comets, asteroids, etc. that aren't tied to planets (see Planet#draw pr for laser beams, etc.)