### PR TITLE
Try fix 'Cannot attach to current VM' problem in IDEA

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -262,6 +262,8 @@ project(":ios"){
 project(":core"){
     apply plugin: "java-library"
 
+    compileJava.options.fork = true
+
     task preGen{
         outputs.upToDateWhen{ false }
         generateLocales()


### PR DESCRIPTION
Seems add a `fork` option to core module solves this problem.

I have tried running `:desktop:run` and `:server:run` in my IDEA or `gradlew` in powershell, no problems were found.

I'm not sure if it will cause other problems, on platforms other than windows。