### PR TITLE
allow mods to easily load icon region

### DIFF
--- a/core/src/mindustry/ctype/UnlockableContent.java
+++ b/core/src/mindustry/ctype/UnlockableContent.java
@@ -59,9 +59,11 @@ public abstract class UnlockableContent extends MappableContent{
             cicons[icon.ordinal()] =
                 Core.atlas.find(getContentType().name() + "-" + name + "-" + icon.name(),
                 Core.atlas.find(getContentType().name() + "-" + name + "-full",
+                Core.atlas.find(name + "-" + icon.name(),
+                Core.atlas.find(name + "-full",
                 Core.atlas.find(name,
                 Core.atlas.find(getContentType().name() + "-" + name,
-                Core.atlas.find(name + "1")))));
+                Core.atlas.find(name + "1")))))));
         }
         return cicons[icon.ordinal()];
     }


### PR DESCRIPTION
It's troublesome to create icon regions for mods as the name is always `<mod-name>-<sprite-name>`, which means `AtlasRegion` with the name `unit-examplemod-chrome-wraith` is impossible, only `examplemod-unit-chrome-wraith`.

In this PR, I allow `UnlockableContent` to take icon regions just from `<mod-name>-<sprite-name>-<cicon-name>`. I'm kinda sure this will help modders a lot.