### PR TITLE
Json in Mod should be able to define OreBlock type

### DIFF
--- a/core/src/mindustry/mod/ContentParser.java
+++ b/core/src/mindustry/mod/ContentParser.java
@@ -190,6 +190,7 @@ public class ContentParser{
                     "mindustry.world.blocks.defense",
                     "mindustry.world.blocks.defense.turrets",
                     "mindustry.world.blocks.distribution",
+                    "mindustry.world.blocks.environment",
                     "mindustry.world.blocks.liquid",
                     "mindustry.world.blocks.logic",
                     "mindustry.world.blocks.power",


### PR DESCRIPTION
It is currently not possible to use the OreBlock type in json.
That was in `mindustry.world.blocks.environment` package, I think this package should be included.