### PR TITLE
Remove timePeriod in LiquidBaseValue

### DIFF
--- a/core/src/mindustry/world/blocks/production/GenericCrafter.java
+++ b/core/src/mindustry/world/blocks/production/GenericCrafter.java
@@ -37,11 +37,6 @@ public class GenericCrafter extends Block{
 
     @Override
     public void setStats(){
-        if(consumes.has(ConsumeType.liquid)){
-            ConsumeLiquidBase cons = consumes.get(ConsumeType.liquid);
-            cons.timePeriod = craftTime;
-        }
-
         super.setStats();
         stats.add(Stat.productionTime, craftTime / 60f, StatUnit.seconds);
 
@@ -50,7 +45,7 @@ public class GenericCrafter extends Block{
         }
 
         if(outputLiquid != null){
-            stats.add(Stat.output, outputLiquid.liquid, outputLiquid.amount, false);
+            stats.add(Stat.output, outputLiquid.liquid, outputLiquid.amount * (60f / craftTime), true);
         }
     }
 

--- a/core/src/mindustry/world/blocks/production/LiquidConverter.java
+++ b/core/src/mindustry/world/blocks/production/LiquidConverter.java
@@ -27,7 +27,7 @@ public class LiquidConverter extends GenericCrafter{
     public void setStats(){
         super.setStats();
         stats.remove(Stat.output);
-        stats.add(Stat.output, outputLiquid.liquid, outputLiquid.amount * craftTime, false);
+        stats.add(Stat.output, outputLiquid.liquid, outputLiquid.amount * 60f, true);
     }
 
     public class LiquidConverterBuild extends GenericCrafterBuild{

--- a/core/src/mindustry/world/blocks/production/Separator.java
+++ b/core/src/mindustry/world/blocks/production/Separator.java
@@ -34,11 +34,6 @@ public class Separator extends Block{
 
     @Override
     public void setStats(){
-        if(consumes.has(ConsumeType.liquid)){
-            ConsumeLiquidBase cons = consumes.get(ConsumeType.liquid);
-            cons.timePeriod = craftTime;
-        }
-
         super.setStats();
 
         stats.add(Stat.output, new ItemFilterValue(item -> {

--- a/core/src/mindustry/world/consumers/ConsumeLiquid.java
+++ b/core/src/mindustry/world/consumers/ConsumeLiquid.java
@@ -46,6 +46,6 @@ public class ConsumeLiquid extends ConsumeLiquidBase{
 
     @Override
     public void display(Stats stats){
-        stats.add(booster ? Stat.booster : Stat.input, liquid, amount * timePeriod, timePeriod == 60);
+        stats.add(booster ? Stat.booster : Stat.input, liquid, amount * 60f, true);
     }
 }

--- a/core/src/mindustry/world/consumers/ConsumeLiquidBase.java
+++ b/core/src/mindustry/world/consumers/ConsumeLiquidBase.java
@@ -5,13 +5,6 @@ import mindustry.gen.*;
 public abstract class ConsumeLiquidBase extends Consume{
     /** amount used per frame */
     public final float amount;
-    /**
-     * How much time is taken to use this liquid, in ticks. Used only for visual purposes.
-     * Example: a normal ConsumeLiquid with 10/s and a 10 second timePeriod would display as "100 seconds".
-     * Without a time override, it would display as "10 liquid/second".
-     * This is used for generic crafters.
-     */
-    public float timePeriod = 60;
 
     public ConsumeLiquidBase(float amount){
         this.amount = amount;

--- a/core/src/mindustry/world/consumers/ConsumeLiquidFilter.java
+++ b/core/src/mindustry/world/consumers/ConsumeLiquidFilter.java
@@ -50,6 +50,6 @@ public class ConsumeLiquidFilter extends ConsumeLiquidBase{
 
     @Override
     public void display(Stats stats){
-        stats.add(booster ? Stat.booster : Stat.input, new LiquidFilterValue(filter, amount * timePeriod, timePeriod == 60f));
+        stats.add(booster ? Stat.booster : Stat.input, new LiquidFilterValue(filter, amount * 60f, true));
     }
 }


### PR DESCRIPTION
People only care for /sec values for liquid consumers/producers, not for the amount it takes/makes when a factory produces once.

Yeah I'm not very sure about the success of this PR especially considering all it does is delete things...