### PR TITLE
Switch places of titanium and thorium ammo in `Blocks.java`

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -1651,19 +1651,19 @@ public class Blocks implements ContentList{
             float brange = range + 10f;
 
             ammo(
-            Items.thorium, new ShrapnelBulletType(){{
-                length = brange;
-                damage = 105f;
-                ammoMultiplier = 5f;
-                toColor = Pal.thoriumPink;
-                shootEffect = smokeEffect = Fx.thoriumShoot;
-            }},
             Items.titanium, new ShrapnelBulletType(){{
                 length = brange;
                 damage = 66f;
                 ammoMultiplier = 4f;
                 width = 17f;
                 reloadMultiplier = 1.3f;
+            }},
+            Items.thorium, new ShrapnelBulletType(){{
+                length = brange;
+                damage = 105f;
+                ammoMultiplier = 5f;
+                toColor = Pal.thoriumPink;
+                shootEffect = smokeEffect = Fx.thoriumShoot;
             }}
             );
         }};


### PR DESCRIPTION
Typically, ammos are listed from weakest to strongest, so I found it weird that thorium ammo was listed before titanium. 

Lets hope this compiles because I don't have time to test it. 