### PR TITLE
add more info to print object

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -878,6 +878,7 @@ public class LExecutor{
                     v.objval == null ? "null" :
                     v.objval instanceof String ? (String)v.objval :
                     v.objval instanceof MappableContent ? "[content] " + ((MappableContent)v.objval).name :
+                    v.objval instanceof Content ? "[content]" :
                     v.objval instanceof Building ? "[building] " + ((Building)v.objval).block.name :
                     v.objval instanceof Unit ? "[unit] " + ((Unit)v.objval).type.name :
                     "[object]";

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -876,11 +876,11 @@ public class LExecutor{
             if(v.isobj && value != 0){
                 String strValue =
                     v.objval == null ? "null" :
-                    v.objval instanceof String ? (String)v.objval :
-                    v.objval instanceof MappableContent ? ((MappableContent)v.objval).name :
+                    v.objval instanceof String s ? s :
+                    v.objval instanceof MappableContent content ? content.name :
                     v.objval instanceof Content ? "[content]" :
-                    v.objval instanceof Building ? ((Building)v.objval).block.name :
-                    v.objval instanceof Unit ? ((Unit)v.objval).type.name :
+                    v.objval instanceof Building build ? build.block.name :
+                    v.objval instanceof Unit unit ? unit.type.name :
                     "[object]";
 
                 exec.textBuffer.append(strValue);

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -877,9 +877,9 @@ public class LExecutor{
                 String strValue =
                     v.objval == null ? "null" :
                     v.objval instanceof String ? (String)v.objval :
-                    v.objval instanceof Content ? "[content]" :
-                    v.objval instanceof Building ? "[building]" :
-                    v.objval instanceof Unit ? "[unit]" :
+                    v.objval instanceof MappableContent ? "[content] " + ((MappableContent)v.objval).name :
+                    v.objval instanceof Building ? "[building] " + ((Building)v.objval).block.name :
+                    v.objval instanceof Unit ? "[unit] " + ((Unit)v.objval).type.name :
                     "[object]";
 
                 exec.textBuffer.append(strValue);

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -877,10 +877,10 @@ public class LExecutor{
                 String strValue =
                     v.objval == null ? "null" :
                     v.objval instanceof String ? (String)v.objval :
-                    v.objval instanceof MappableContent ? "[content] " + ((MappableContent)v.objval).name :
+                    v.objval instanceof MappableContent ? ((MappableContent)v.objval).name :
                     v.objval instanceof Content ? "[content]" :
-                    v.objval instanceof Building ? "[building] " + ((Building)v.objval).block.name :
-                    v.objval instanceof Unit ? "[unit] " + ((Unit)v.objval).type.name :
+                    v.objval instanceof Building ? ((Building)v.objval).block.name :
+                    v.objval instanceof Unit ? ((Unit)v.objval).type.name :
                     "[object]";
 
                 exec.textBuffer.append(strValue);


### PR DESCRIPTION
Adds content name to the end of some printed objects.

`print @routorio-solar-router`: [content] -> **routorio-solar-router**
`print distributor1`: [building] -> **distributor**
`ubind @routorio-sexy-router; print @unit` : [unit] -> **routorio-sexy-router**