### PR TITLE
make ending direction follow the path

### DIFF
--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1213,7 +1213,14 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
             line.x = point.x;
             line.y = point.y;
             if(!overrideLineRotation || diagonal){
-                line.rotation = next != null ? Tile.relativeTo(point.x, point.y, next.x, next.y) : baseRotation;
+                if (next != null){
+                    line.rotation = Tile.relativeTo(point.x, point.y, next.x, next.y);
+                }else if (block.conveyorPlacement && i > 0){
+                    Point2 prev = points.get(i - 1);
+                    line.rotation = Tile.relativeTo(prev.x, prev.y, point.x, point.y);
+                }else{
+                    line.rotation = baseRotation;
+                }                
             }else{
                 line.rotation = rotation;
             }

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1213,14 +1213,14 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
             line.x = point.x;
             line.y = point.y;
             if(!overrideLineRotation || diagonal){
-                if (next != null){
+                if(next != null){
                     line.rotation = Tile.relativeTo(point.x, point.y, next.x, next.y);
-                }else if (block.conveyorPlacement && i > 0){
+                }else if(block.conveyorPlacement && i > 0){
                     Point2 prev = points.get(i - 1);
                     line.rotation = Tile.relativeTo(prev.x, prev.y, point.x, point.y);
                 }else{
                     line.rotation = baseRotation;
-                }                
+                }
             }else{
                 line.rotation = rotation;
             }


### PR DESCRIPTION
Current logic is annoying (make final tile rotation as relation between start and end) and IMHO rarely useful.
Examples (before and after fix):
![example1](https://user-images.githubusercontent.com/4013688/97092460-5c79b780-1644-11eb-95da-2dbe81937f8d.png)
![example2](https://user-images.githubusercontent.com/4013688/97092466-626f9880-1644-11eb-9cf6-ee43fa30c4e9.png)
