### PR TITLE
Removing spaces at start and end of a message (trim)

### DIFF
--- a/core/src/mindustry/ui/fragments/ChatFragment.java
+++ b/core/src/mindustry/ui/fragments/ChatFragment.java
@@ -163,8 +163,9 @@ public class ChatFragment extends Table{
 
         Draw.color();
 
-        if(fadetime > 0 && !shown)
+        if(fadetime > 0 && !shown){
             fadetime -= Time.delta / 180f;
+        }
     }
 
     private void sendMessage(){

--- a/core/src/mindustry/ui/fragments/ChatFragment.java
+++ b/core/src/mindustry/ui/fragments/ChatFragment.java
@@ -168,10 +168,10 @@ public class ChatFragment extends Table{
     }
 
     private void sendMessage(){
-        String message = chatfield.getText();
+        String message = chatfield.getText().trim();
         clearChatInput();
 
-        if(message.replace(" ", "").isEmpty()) return;
+        if(message.isEmpty()) return;
 
         history.insert(1, message);
 


### PR DESCRIPTION
This will avoid exceeding the message length limit if player send a message with spaces in end/start message.

For example in this case:
![javaw_eXTqiAgxxV](https://user-images.githubusercontent.com/55407440/97093084-ec722e00-1651-11eb-82a6-06760ad1a6b6.png)
or:
![image](https://user-images.githubusercontent.com/55407440/97093110-13c8fb00-1652-11eb-8c2b-ae565f1ec5bf.png)

