### PR TITLE
Make bloom be accessible

### DIFF
--- a/core/src/mindustry/core/Renderer.java
+++ b/core/src/mindustry/core/Renderer.java
@@ -100,6 +100,10 @@ public class Renderer implements ApplicationListener{
     public float weatherAlpha(){
         return weatherAlpha;
     }
+    
+    public Bloom renderedBloom(){
+        return bloom;
+    }
 
     public float landScale(){
         return landTime > 0 ? landscale : 1f;


### PR DESCRIPTION
Alternative way: `public Bloom bloom;`  

Make the bloom that is being used in the renderer be public or accessible.
+ The bloom's bloomIntensity, originalIntensity, threshold can be set.  
+ Certain mods can modify it, such as a "high-res" mod or realistic mod(like minecraft's).  

(Also, after tinkering with the bloom I would PR something that implements https://github.com/Anuken/Mindustry-Suggestions/issues/918 later... even if you reject that I can at least make it so in my mods)