### PR TITLE
Change "Alternate" calculation in Turret.java

### DIFF
--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -364,7 +364,7 @@ public abstract class Turret extends ReloadTurret{
                 //otherwise, use the normal shot pattern(s)
 
                 if(alternate){
-                    float i = (shotCounter % shots) - shots/2f + (((shots+1)%2) / 2f);
+                    float i = (shotCounter % shots) - (shots-1)/2f;
 
                     tr.trns(rotation - 90, spread * i + Mathf.range(xRand), size * tilesize / 2f);
                     bullet(type, rotation + Mathf.range(inaccuracy));


### PR DESCRIPTION
Why?
1. It looks cleaner
2. It supports cases where `shots > 2`, instead of just when `shots = 2` (Easier for modders)
3. It works (I think, only tested cases where `shots = 2, 3, or 12`)

