### PR TITLE
Make LiquidTurret not need to have water as an ammo(bugfix)

### DIFF
--- a/core/src/mindustry/world/blocks/defense/turrets/LiquidTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/LiquidTurret.java
@@ -144,7 +144,7 @@ public class LiquidTurret extends Turret{
         @Override
         public boolean acceptLiquid(Building source, Liquid liquid){
             return ammoTypes.get(liquid) != null
-                && (liquids.current() == liquid || (ammoTypes.containsKey(liquids.current())
+                && (liquids.current() == liquid || (ammoTypes.containsKey(liquid)
                 && liquids.get(liquids.current()) <= 1f / ammoTypes.get(liquids.current()).ammoMultiplier + 0.001f));
         }
     }


### PR DESCRIPTION
Right now, LiquidTurret needs to have a water ammo since liquids.current() with an empty liquid is water.

I honestly think this is just a bug you overlooked...but who knows?