### PR TITLE
Show Core Database Button in Custom Game.

### DIFF
--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -345,6 +345,10 @@ public class DesktopInput extends InputHandler{
             ui.schematics.show();
         }).tooltip("@schematics");
 
+        table.button(Icon.book, Styles.clearPartiali, () -> {
+            ui.database.show();
+        }).tooltip("@database");
+
         table.button(Icon.tree, Styles.clearPartiali, () -> {
             ui.research.show();
         }).visible(() -> state.isCampaign()).tooltip("@research");
@@ -352,8 +356,6 @@ public class DesktopInput extends InputHandler{
         table.button(Icon.map, Styles.clearPartiali, () -> {
             ui.planet.show();
         }).visible(() -> state.isCampaign()).tooltip("@planetmap");
-
-        table.add();
     }
 
     void pollInput(){


### PR DESCRIPTION
As some people said, core database is very needed in custom or multiplayer game, so I decided to add it.

In custom game:
![custom](https://user-images.githubusercontent.com/55251897/97784380-38235b00-1baf-11eb-918c-601850a64bd1.png)

In campaign:
![campaign](https://user-images.githubusercontent.com/55251897/97784417-859fc800-1baf-11eb-96d7-09246cad1039.png)

Actually suggested to me by @Makc-Carbon.