### PR TITLE
"Per Second" Consumer Stat Display (Iteration 2)

### DIFF
--- a/core/src/mindustry/ui/ItemDisplay.java
+++ b/core/src/mindustry/ui/ItemDisplay.java
@@ -1,7 +1,10 @@
 package mindustry.ui;
 
+import arc.util.*;
+import arc.graphics.*;
 import arc.scene.ui.layout.*;
 import mindustry.type.*;
+import mindustry.world.meta.*;
 
 /** An item image with text. */
 public class ItemDisplay extends Table{
@@ -12,6 +15,10 @@ public class ItemDisplay extends Table{
         this(item, 0);
     }
 
+    public ItemDisplay(Item item, int amount){
+        this(item, amount, true);
+    }
+
     public ItemDisplay(Item item, int amount, boolean showName){
         add(new ItemImage(new ItemStack(item, amount)));
         if(showName) add(item.localizedName).padLeft(4 + amount > 99 ? 4 : 0);
@@ -20,7 +27,12 @@ public class ItemDisplay extends Table{
         this.amount = amount;
     }
 
-    public ItemDisplay(Item item, int amount){
-        this(item, amount, true);
+    public ItemDisplay(Item item, int amount, float timePeriod, boolean showName){
+        add(new ItemImage(item.icon(Cicon.medium), amount));
+        add(Strings.autoFixed(amount / (timePeriod / 60f), 1) + StatUnit.perSecond.localized()).padLeft(2).padRight(5).color(Color.lightGray).style(Styles.outlineLabel);
+        if(showName) add(item.localizedName).padLeft(4 + amount > 99 ? 4 : 0);
+
+        this.item = item;
+        this.amount = amount;
     }
 }

--- a/core/src/mindustry/ui/ItemImage.java
+++ b/core/src/mindustry/ui/ItemImage.java
@@ -1,5 +1,6 @@
 package mindustry.ui;
 
+import arc.util.*;
 import arc.graphics.g2d.*;
 import arc.scene.ui.*;
 import arc.scene.ui.layout.*;
@@ -17,6 +18,19 @@ public class ItemImage extends Stack{
         add(new Table(t -> {
             t.left().bottom();
             t.add(amount + "");
+            t.pack();
+        }));
+    }
+
+    public ItemImage(TextureRegion region, float amount){
+        add(new Table(o -> {
+            o.left();
+            o.add(new Image(region)).size(32f);
+        }));
+
+        add(new Table(t -> {
+            t.left().bottom();
+            t.add(Strings.autoFixed(amount, 1));
             t.pack();
         }));
     }

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -337,11 +337,15 @@ public class Block extends UnlockableContent{
             stats.add(Stat.maxConsecutive, 2, StatUnit.none);
         }
 
-        consumes.display(stats);
+        displayConsumers();
 
         //Note: Power stats are added by the consumers.
         if(hasLiquids) stats.add(Stat.liquidCapacity, liquidCapacity, StatUnit.liquidUnits);
         if(hasItems && itemCapacity > 0) stats.add(Stat.itemCapacity, itemCapacity, StatUnit.items);
+    }
+
+    public void displayConsumers() {
+        consumes.display(stats);
     }
 
     public void setBars(){

--- a/core/src/mindustry/world/blocks/production/Fracker.java
+++ b/core/src/mindustry/world/blocks/production/Fracker.java
@@ -25,6 +25,11 @@ public class Fracker extends SolidPump{
     }
 
     @Override
+    public void displayConsumers() {
+        consumes.display(stats, itemUseTime);
+    }
+
+    @Override
     public boolean outputsItems(){
         return false;
     }

--- a/core/src/mindustry/world/blocks/production/GenericCrafter.java
+++ b/core/src/mindustry/world/blocks/production/GenericCrafter.java
@@ -41,12 +41,17 @@ public class GenericCrafter extends Block{
         stats.add(Stat.productionTime, craftTime / 60f, StatUnit.seconds);
 
         if(outputItem != null){
-            stats.add(Stat.output, outputItem);
+            stats.add(Stat.output, outputItem, craftTime);
         }
 
         if(outputLiquid != null){
             stats.add(Stat.output, outputLiquid.liquid, outputLiquid.amount * (60f / craftTime), true);
         }
+    }
+
+    @Override
+    public void displayConsumers() {
+        consumes.display(stats, craftTime);
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/production/Separator.java
+++ b/core/src/mindustry/world/blocks/production/Separator.java
@@ -46,6 +46,11 @@ public class Separator extends Block{
         stats.add(Stat.productionTime, craftTime / 60f, StatUnit.seconds);
     }
 
+    @Override
+    public void displayConsumers() {
+        consumes.display(stats, craftTime);
+    }
+
     public class SeparatorBuild extends Building{
         public float progress;
         public float totalProgress;

--- a/core/src/mindustry/world/consumers/Consume.java
+++ b/core/src/mindustry/world/consumers/Consume.java
@@ -70,4 +70,6 @@ public abstract class Consume{
     public abstract boolean valid(Building entity);
 
     public abstract void display(Stats stats);
+
+    public abstract void display(Stats stats, float timePeriod);
 }

--- a/core/src/mindustry/world/consumers/ConsumeItemDynamic.java
+++ b/core/src/mindustry/world/consumers/ConsumeItemDynamic.java
@@ -76,4 +76,9 @@ public class ConsumeItemDynamic extends Consume{
     public void display(Stats stats){
         //should be handled by the block
     }
+
+    @Override
+    public void display(Stats stats, float timePeriod){
+        //should be handled by the block
+    }
 }

--- a/core/src/mindustry/world/consumers/ConsumeItemFilter.java
+++ b/core/src/mindustry/world/consumers/ConsumeItemFilter.java
@@ -73,4 +73,9 @@ public class ConsumeItemFilter extends Consume{
     public void display(Stats stats){
         stats.add(booster ? Stat.booster : Stat.input, new ItemFilterValue(filter));
     }
+
+    @Override
+    public void display(Stats stats, float timePeriod){
+        display(stats);
+    }
 }

--- a/core/src/mindustry/world/consumers/ConsumeItems.java
+++ b/core/src/mindustry/world/consumers/ConsumeItems.java
@@ -66,4 +66,9 @@ public class ConsumeItems extends Consume{
     public void display(Stats stats){
         stats.add(booster ? Stat.booster : Stat.input, new ItemListValue(items));
     }
+
+    @Override
+    public void display(Stats stats, float timePeriod){
+        stats.add(booster ? Stat.booster : Stat.input, new ItemListValue(timePeriod, items));
+    }
 }

--- a/core/src/mindustry/world/consumers/ConsumeLiquid.java
+++ b/core/src/mindustry/world/consumers/ConsumeLiquid.java
@@ -48,4 +48,9 @@ public class ConsumeLiquid extends ConsumeLiquidBase{
     public void display(Stats stats){
         stats.add(booster ? Stat.booster : Stat.input, liquid, amount * 60f, true);
     }
+
+    @Override
+    public void display(Stats stats, float timePeriod){
+        display(stats);
+    }
 }

--- a/core/src/mindustry/world/consumers/ConsumeLiquidFilter.java
+++ b/core/src/mindustry/world/consumers/ConsumeLiquidFilter.java
@@ -52,4 +52,9 @@ public class ConsumeLiquidFilter extends ConsumeLiquidBase{
     public void display(Stats stats){
         stats.add(booster ? Stat.booster : Stat.input, new LiquidFilterValue(filter, amount * 60f, true));
     }
+
+    @Override
+    public void display(Stats stats, float timePeriod){
+        display(stats);
+    }
 }

--- a/core/src/mindustry/world/consumers/ConsumePower.java
+++ b/core/src/mindustry/world/consumers/ConsumePower.java
@@ -62,6 +62,11 @@ public class ConsumePower extends Consume{
         }
     }
 
+    @Override
+    public void display(Stats stats, float timePeriod){
+        display(stats);
+    }
+
     /**
      * Retrieves the amount of power which is requested for the given block and entity.
      * @param entity The entity which contains the power module.

--- a/core/src/mindustry/world/consumers/Consumers.java
+++ b/core/src/mindustry/world/consumers/Consumers.java
@@ -116,4 +116,12 @@ public class Consumers{
             }
         }
     }
+
+    public void display(Stats stats, float timePeriod){
+        for(Consume c : map){
+            if(c != null){
+                c.display(stats, timePeriod);
+            }
+        }
+    }
 }

--- a/core/src/mindustry/world/meta/Stats.java
+++ b/core/src/mindustry/world/meta/Stats.java
@@ -50,6 +50,11 @@ public class Stats{
     }
 
     /** Adds an item value. */
+    public void add(Stat stat, ItemStack item, float timePeriod){
+        add(stat, new ItemListValue(timePeriod, item));
+    }
+
+    /** Adds an liquid value. */
     public void add(Stat stat, Liquid liquid, float amount, boolean perSecond){
         add(stat, new LiquidValue(liquid, amount, perSecond));
     }

--- a/core/src/mindustry/world/meta/values/ItemListValue.java
+++ b/core/src/mindustry/world/meta/values/ItemListValue.java
@@ -8,6 +8,7 @@ import mindustry.world.meta.*;
 public class ItemListValue implements StatValue{
     private final ItemStack[] stacks;
     private final boolean displayName;
+    private final float timePeriod;
 
     public ItemListValue(ItemStack... stacks){
         this(true, stacks);
@@ -16,12 +17,23 @@ public class ItemListValue implements StatValue{
     public ItemListValue(boolean displayName, ItemStack... stacks){
         this.stacks = stacks;
         this.displayName = displayName;
+        this.timePeriod = -1f;
+    }
+
+    public ItemListValue(float timePeriod, ItemStack... stacks){
+        this.stacks = stacks;
+        this.displayName = true;
+        this.timePeriod = timePeriod;
     }
 
     @Override
     public void display(Table table){
         for(ItemStack stack : stacks){
-            table.add(new ItemDisplay(stack.item, stack.amount, displayName)).padRight(5);
+            if(timePeriod > 0f){
+                table.add(new ItemDisplay(stack.item, stack.amount, timePeriod, displayName)).padRight(5);
+            }else{
+                table.add(new ItemDisplay(stack.item, stack.amount, displayName)).padRight(5);
+            }
         }
     }
 }


### PR DESCRIPTION
Why a new branch? Because I felt like it would be easier to make a new branch than fix the old one. 

Here's the current layout: 
![current itemspersec](https://user-images.githubusercontent.com/68400583/97787303-6e8cb600-1b6e-11eb-8332-36ea17bc18e4.jpg)

It's messy, so other layout suggestions are appreciated.
Will be a draft until not messy anymore. 
