### PR TITLE
add LogicBuild LExecutor,Assembler#processor

### DIFF
--- a/core/src/mindustry/logic/LAssembler.java
+++ b/core/src/mindustry/logic/LAssembler.java
@@ -10,6 +10,7 @@ import mindustry.logic.LExecutor.*;
 import mindustry.logic.LStatements.*;
 import mindustry.type.*;
 import mindustry.world.*;
+import mindustry.world.blocks.logic.*;
 
 /** "Compiles" a sequence of statements into instructions. */
 public class LAssembler{
@@ -20,8 +21,12 @@ public class LAssembler{
     public ObjectMap<String, BVar> vars = new ObjectMap<>();
     /** All instructions to be executed. */
     public LInstruction[] instructions;
+    /** Processor assembling the code */
+    public final LogicBuild processor;
 
-    public LAssembler(){
+    public LAssembler(LogicBuild processor){
+        this.processor = processor;
+
         //instruction counter
         putVar("@counter").value = 0;
         //unix timestamp
@@ -68,8 +73,8 @@ public class LAssembler{
         }
     }
 
-    public static LAssembler assemble(String data, int maxInstructions){
-        LAssembler asm = new LAssembler();
+    public static LAssembler assemble(LogicBuild processor, String data, int maxInstructions){
+        LAssembler asm = new LAssembler(processor);
 
         Seq<LStatement> st = read(data, maxInstructions);
 

--- a/core/src/mindustry/logic/LAssembler.java
+++ b/core/src/mindustry/logic/LAssembler.java
@@ -10,7 +10,7 @@ import mindustry.logic.LExecutor.*;
 import mindustry.logic.LStatements.*;
 import mindustry.type.*;
 import mindustry.world.*;
-import mindustry.world.blocks.logic.*;
+import mindustry.world.blocks.logic.LogicBlock.*;
 
 /** "Compiles" a sequence of statements into instructions. */
 public class LAssembler{

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -78,7 +78,7 @@ public class LExecutor{
     }
 
     public void load(String data, int maxInstructions){
-        load(LAssembler.assemble(data, maxInstructions));
+        load(LAssembler.assemble(processor, data, maxInstructions));
     }
 
     /** Loads with a specified assembler. Resets all variables. */

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -16,6 +16,7 @@ import mindustry.gen.*;
 import mindustry.type.*;
 import mindustry.world.*;
 import mindustry.world.blocks.logic.*;
+import mindustry.world.blocks.logic.LogicBlock.*;
 import mindustry.world.blocks.logic.LogicDisplay.*;
 import mindustry.world.blocks.logic.MemoryBlock.*;
 import mindustry.world.blocks.logic.MessageBlock.*;

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -51,6 +51,13 @@ public class LExecutor{
     public IntSet linkIds = new IntSet();
     public Team team = Team.derelict;
 
+    /** Shortcut for (LogicBuild) exec.obj(builder.var("@this")) */
+    public final LogicBuild processor;
+
+    public LExecutor(LogicBuild processor){
+        this.processor = processor;
+    }
+
     public boolean initialized(){
         return instructions != null && vars != null && instructions.length > 0;
     }

--- a/core/src/mindustry/world/blocks/logic/LogicBlock.java
+++ b/core/src/mindustry/world/blocks/logic/LogicBlock.java
@@ -181,7 +181,7 @@ public class LogicBlock extends Block{
     public class LogicBuild extends Building implements Ranged{
         /** logic "source code" as list of asm statements */
         public String code = "";
-        public LExecutor executor = new LExecutor();
+        public LExecutor executor = new LExecutor(this);
         public float accumulator = 0;
         public Seq<LogicLink> links = new Seq<>();
 
@@ -279,7 +279,7 @@ public class LogicBlock extends Block{
 
                 try{
                     //create assembler to store extra variables
-                    LAssembler asm = LAssembler.assemble(str, LExecutor.maxInstructions);
+                    LAssembler asm = LAssembler.assemble(this, str, LExecutor.maxInstructions);
 
                     //store connections
                     for(LogicLink link : links){


### PR DESCRIPTION
a pointer to the processor running and assembling code respectively.
example use cases:
- limited more higher level instructions to fast processors, i.e. build a NoopI if too slow
- shortcut for modifying the processor in some way in LInstruction#run
- etc