### PR TITLE
Make Glass Frag Size = Other Frag Size

### DIFF
--- a/core/src/mindustry/content/Bullets.java
+++ b/core/src/mindustry/content/Bullets.java
@@ -210,8 +210,6 @@ public class Bullets implements ContentList{
             ammoMultiplier = 3f;
             shootEffect = Fx.shootSmall;
             reloadMultiplier = 0.8f;
-            width = 6f;
-            height = 8f;
             hitEffect = Fx.flakExplosion;
             splashDamage = 18f;
             splashDamageRadius = 16f;


### PR DESCRIPTION
Didn't like how glass frag was the only cyclone bullet that had a smaller size than its other ones. 