### PR TITLE
Unit Deflect Bullet Ability

### DIFF
--- a/core/src/mindustry/content/Fx.java
+++ b/core/src/mindustry/content/Fx.java
@@ -359,6 +359,18 @@ public class Fx{
         Lines.circle(e.x, e.y, 2f + e.finpow() * 7f);
     }),
 
+    deflectWaveDynamic = new Effect(22, e -> {
+        color(Color.valueOf("ffd59e"));
+        stroke(e.fout() * 2.5f);
+        Lines.circle(e.x, e.y, 4f + e.finpow() * e.rotation);
+    }),
+
+    bulletDeflect = new Effect(11, e -> {
+        color(Color.valueOf("ffd59e"));
+        stroke(e.fout() * 2f);
+        Lines.circle(e.x, e.y, 2f + e.finpow() * 7f);
+    }),
+
     hitBulletSmall = new Effect(14, e -> {
         color(Color.white, Pal.lightOrange, e.fin());
 

--- a/core/src/mindustry/entities/abilities/BulletDeflectAbility.java
+++ b/core/src/mindustry/entities/abilities/BulletDeflectAbility.java
@@ -1,0 +1,61 @@
+package mindustry.entities.abilities;
+
+import arc.util.*;
+import arc.func.*;
+import arc.math.*;
+import mindustry.content.*;
+import mindustry.entities.*;
+import mindustry.gen.*;
+
+public class BulletDeflectAbility extends Ability{
+    public float chanceDeflect = 10f, reload = 100, range = 60f;
+    public Effect activeEffect = Fx.deflectWaveDynamic;
+    public Effect applyEffect = Fx.bulletDeflect;
+
+    protected float timer;
+    private static Unit paramUnit;
+    private static BulletDeflectAbility paramField;
+    private static final Cons<Bullet> bulletDeflector = bullet -> {
+        if(bullet.team != paramUnit.team && !(bullet.vel().len() <= 0.1f || !bullet.type.reflectable) && Mathf.chance(paramField.chanceDeflect / bullet.damage())) {
+            bullet.trns(-bullet.vel.x, -bullet.vel.y);
+
+            float angleToUnit = Mathf.angle(bullet.x - paramUnit.x, bullet.y - paramUnit.y) + 90f;
+            float newAngle = 2 * (angleToUnit - bullet.vel.angle());
+
+            bullet.vel.trns(newAngle, bullet.vel.x, bullet.vel.y);
+
+            bullet.owner(paramUnit);
+            bullet.team(paramUnit.team);
+            bullet.time(bullet.time() + 1f);
+
+            paramField.applyEffect.at(bullet.x, bullet.y, paramField.range);
+        }
+    };
+
+    BulletDeflectAbility(){}
+
+    public BulletDeflectAbility(float chanceDeflect, float reload, float range){
+        this.chanceDeflect = chanceDeflect;
+        this.range = range;
+        this.reload = reload;
+    }
+
+    @Override
+    public void update(Unit unit){
+        timer += Time.delta;
+
+        if(timer >= reload){
+            Bullet nearestBullet = Groups.bullet.intersect(unit.x - range, unit.y - range, range*2, range*2).min(b -> b.team == unit.team || !b.type().hittable ? Float.MAX_VALUE : b.dst2(unit.x, unit.y));
+
+            if(nearestBullet != null && nearestBullet.team != unit.team) {
+                activeEffect.at(unit, range);
+
+                paramUnit = unit;
+                paramField = this;
+                Groups.bullet.intersect(unit.x - range, unit.y - range, range * 2f, range * 2f, bulletDeflector);
+            }
+
+            timer = 0f;
+        }
+    }
+}

--- a/core/src/mindustry/entities/abilities/BulletDeflectAbility.java
+++ b/core/src/mindustry/entities/abilities/BulletDeflectAbility.java
@@ -16,13 +16,13 @@ public class BulletDeflectAbility extends Ability{
     private static Unit paramUnit;
     private static BulletDeflectAbility paramField;
     private static final Cons<Bullet> bulletDeflector = bullet -> {
-        if(bullet.team != paramUnit.team && !(bullet.vel().len() <= 0.1f || !bullet.type.reflectable) && Mathf.chance(paramField.chanceDeflect / bullet.damage())) {
+        if(bullet.team != paramUnit.team && !(bullet.vel().len() <= 0.1f || !bullet.type.reflectable) && Mathf.chance(paramField.chanceDeflect / bullet.damage())){
             bullet.trns(-bullet.vel.x, -bullet.vel.y);
 
             float angleToUnit = Mathf.angle(bullet.x - paramUnit.x, bullet.y - paramUnit.y) + 90f;
-            float newAngle = 2 * (angleToUnit - bullet.vel.angle());
+            float rotateAngle = 2 * (angleToUnit - bullet.vel.angle());
 
-            bullet.vel.trns(newAngle, bullet.vel.x, bullet.vel.y);
+            bullet.vel.trns(rotateAngle, bullet.vel.x, bullet.vel.y);
 
             bullet.owner(paramUnit);
             bullet.team(paramUnit.team);
@@ -47,7 +47,7 @@ public class BulletDeflectAbility extends Ability{
         if(timer >= reload){
             Bullet nearestBullet = Groups.bullet.intersect(unit.x - range, unit.y - range, range*2, range*2).min(b -> b.team == unit.team || !b.type().hittable ? Float.MAX_VALUE : b.dst2(unit.x, unit.y));
 
-            if(nearestBullet != null && nearestBullet.team != unit.team) {
+            if(nearestBullet != null && nearestBullet.team != unit.team){
                 activeEffect.at(unit, range);
 
                 paramUnit = unit;


### PR DESCRIPTION
Not sure whether this is new content or not, but oh well. 

Adds a ability that allows a unit to send out a shockwave which reflects bullets in radius (with reflect chance calculated in a similar way to phase walls)

Here's a gif of a crawler reflecting salvo bullets:
![deflective-crawler](https://user-images.githubusercontent.com/68400583/97950584-3773fb80-1d4c-11eb-89ee-a0cad4843348.gif)
