### PR TITLE
[editor] Searchable Blocks Implementation

### DIFF
--- a/core/src/mindustry/editor/MapEditorDialog.java
+++ b/core/src/mindustry/editor/MapEditorDialog.java
@@ -666,7 +666,7 @@ public class MapEditorDialog extends Dialog implements Disposable{
         ui.showConfirm("@confirm", "@editor.unsaved", this::hide);
     }
 
-    private void addBlockSelection(Table table){
+    private void addBlockSelection(Table cont){
         blockSelection = new Table();
         pane = new ScrollPane(blockSelection);
         pane.setFadeScrollBars(false);
@@ -677,16 +677,15 @@ public class MapEditorDialog extends Dialog implements Disposable{
             }
         });
 
-        Table searchBar = new Table();
-        searchBar.image(Icon.zoom);
-        searchBar.field("", this::rebuildBlockSelection)
-        .name("editor/search").maxTextLength(maxNameLength).get().setMessageText("@players.search");
-
-        table.add(searchBar).pad(10);
-        table.row();
-        table.table(Tex.underline, extra -> extra.labelWrap(() -> editor.drawBlock.localizedName).width(200f).center()).growX();
-        table.row();
-        table.add(pane).expandY().top().left();
+        cont.table(search -> {
+            search.image(Icon.zoom).padRight(8);
+            search.field("", this::rebuildBlockSelection)
+            .name("editor/search").maxTextLength(maxNameLength).get().setMessageText("@players.search");
+        }).pad(5);
+        cont.row();
+        cont.table(Tex.underline, extra -> extra.labelWrap(() -> editor.drawBlock.localizedName).width(200f).center()).growX();
+        cont.row();
+        cont.add(pane).expandY().top().left();
 
         rebuildBlockSelection("");
     }
@@ -694,7 +693,7 @@ public class MapEditorDialog extends Dialog implements Disposable{
     private void rebuildBlockSelection(String searchText){
         blockSelection.clear();
 
-        ButtonGroup<ImageButton> group = new ButtonGroup<>();
+        Seq<Block> filteredBlocks = new Seq<>();
 
         blocksOut.clear();
         blocksOut.addAll(Vars.content.blocks());
@@ -718,22 +717,22 @@ public class MapEditorDialog extends Dialog implements Disposable{
                     || (!block.localizedName.toLowerCase().contains(searchText.toLowerCase()) && !searchText.isEmpty())
             ) continue;
 
+            filteredBlocks.add(block);
+
             ImageButton button = new ImageButton(Tex.whiteui, Styles.clearTogglei);
             button.getStyle().imageUp = new TextureRegionDrawable(region);
             button.clicked(() -> editor.drawBlock = block);
             button.resizeImage(8 * 4f);
             button.update(() -> button.setChecked(editor.drawBlock == block));
-            group.add(button);
             blockSelection.add(button).size(50f).tooltip(block.localizedName);
 
             if(++i % 4 == 0) blockSelection.row();
         }
 
-        if(group.getButtons().isEmpty()){
+        if(filteredBlocks.isEmpty()){
             blockSelection.add("@none").padLeft(80f).padTop(10f);
         }else{
-            // Select first block
-            group.getButtons().first().fireClick();
+            editor.drawBlock = filteredBlocks.first();
         }
     }
 }

--- a/core/src/mindustry/editor/MapEditorDialog.java
+++ b/core/src/mindustry/editor/MapEditorDialog.java
@@ -693,8 +693,6 @@ public class MapEditorDialog extends Dialog implements Disposable{
     private void rebuildBlockSelection(String searchText){
         blockSelection.clear();
 
-        Seq<Block> filteredBlocks = new Seq<>();
-
         blocksOut.clear();
         blocksOut.addAll(Vars.content.blocks());
         blocksOut.sort((b1, b2) -> {
@@ -714,10 +712,8 @@ public class MapEditorDialog extends Dialog implements Disposable{
 
             if(!Core.atlas.isFound(region) || !block.inEditor
                     || block.buildVisibility == BuildVisibility.debugOnly
-                    || (!block.localizedName.toLowerCase().contains(searchText.toLowerCase()) && !searchText.isEmpty())
+                    || (!searchText.isEmpty() && !block.localizedName.toLowerCase().contains(searchText.toLowerCase()))
             ) continue;
-
-            filteredBlocks.add(block);
 
             ImageButton button = new ImageButton(Tex.whiteui, Styles.clearTogglei);
             button.getStyle().imageUp = new TextureRegionDrawable(region);
@@ -726,13 +722,15 @@ public class MapEditorDialog extends Dialog implements Disposable{
             button.update(() -> button.setChecked(editor.drawBlock == block));
             blockSelection.add(button).size(50f).tooltip(block.localizedName);
 
-            if(++i % 4 == 0) blockSelection.row();
+            if(i == 0) editor.drawBlock = block;
+
+            if(++i % 4 == 0){
+                blockSelection.row();
+            }
         }
 
-        if(filteredBlocks.isEmpty()){
+        if(i == 0){
             blockSelection.add("@none").padLeft(80f).padTop(10f);
-        }else{
-            editor.drawBlock = filteredBlocks.first();
         }
     }
 }

--- a/core/src/mindustry/editor/MapEditorDialog.java
+++ b/core/src/mindustry/editor/MapEditorDialog.java
@@ -724,13 +724,13 @@ public class MapEditorDialog extends Dialog implements Disposable{
             button.resizeImage(8 * 4f);
             button.update(() -> button.setChecked(editor.drawBlock == block));
             group.add(button);
-            blockSelection.add(button).size(50f).grow().top().left().tooltip(block.localizedName);
+            blockSelection.add(button).size(50f).tooltip(block.localizedName);
 
             if(++i % 4 == 0) blockSelection.row();
         }
 
         if(group.getButtons().isEmpty()){
-            blockSelection.add("@none");
+            blockSelection.add("@none").padLeft(80f).padTop(10f);
         }else{
             // Select first block
             group.getButtons().first().fireClick();

--- a/core/src/mindustry/editor/MapEditorDialog.java
+++ b/core/src/mindustry/editor/MapEditorDialog.java
@@ -679,7 +679,7 @@ public class MapEditorDialog extends Dialog implements Disposable{
 
         Table searchBar = new Table();
         searchBar.image(Icon.zoom);
-        searchBar.field(null, this::rebuildBlockSelection)
+        searchBar.field("", this::rebuildBlockSelection)
         .name("editor/search").maxTextLength(maxNameLength).get().setMessageText("@players.search");
 
         table.add(searchBar).pad(10);


### PR DESCRIPTION
It would make it easier to find the block you want. There are lots of blocks and it takes time to look for the one you want, especially because they're all placed in one large uncategorized all-inclusive selection with no indication if they're power blocks, terrain, drills, etc. (@RedstonerKBC)

Little demonstration:

![preview](https://user-images.githubusercontent.com/55251897/98136792-36141180-1eb9-11eb-9827-d1bf5170e328.gif)

Closes Anuken/Mindustry-Suggestions#1012.
