### PR TITLE
Add new logic categories

### DIFF
--- a/core/src/mindustry/logic/LCategory.java
+++ b/core/src/mindustry/logic/LCategory.java
@@ -8,7 +8,9 @@ public enum LCategory{
     control(Color.cyan.cpy().shiftSaturation(-0.6f).mul(0.7f)),
     operations(Pal.place.cpy().shiftSaturation(-0.5f).mul(0.7f)),
     io(Pal.remove.cpy().shiftSaturation(-0.5f).mul(0.7f)),
-    units(Pal.bulletYellowBack.cpy().shiftSaturation(-0.3f).mul(0.8f));
+    units(Pal.bulletYellowBack.cpy().shiftSaturation(-0.3f).mul(0.8f)),
+    modded(Color.pink.cpy().shiftSaturation(-0.6f).mul(0.7f)),
+    custom(Pal.accent.cpy().shiftSaturation(-0.2f).mul(0.3f));
 
     public final Color color;
 


### PR DESCRIPTION
As far as I know, js has no way of tempering with `enum`s.
This adds 2 new `LCategory`s that mods can use.