### PR TITLE
add more info to schematic errors

### DIFF
--- a/core/src/mindustry/game/Schematics.java
+++ b/core/src/mindustry/game/Schematics.java
@@ -133,6 +133,7 @@ public class Schematics implements Loadable{
         try{
             write(newSchematic, target.file);
         }catch(Exception e){
+            Log.err("Failed to overwrite schematic '@' (@)", newSchematic.name, target.file);
             Log.err(e);
             ui.showException(e);
         }
@@ -153,6 +154,7 @@ public class Schematics implements Loadable{
 
             return s;
         }catch(Throwable e){
+            Log.err("Failed to read schematic from file '@'", file);
             Log.err(e);
         }
         return null;
@@ -188,6 +190,7 @@ public class Schematics implements Loadable{
         try{
             return getBuffer(schematic).getTexture();
         }catch(Throwable t){
+            Log.err("Failed to get preview for schematic '@' (@)", schematic.name, schematic.file);
             Log.err(t);
             errored.add(schematic);
             return errorTexture;


### PR DESCRIPTION
\> stack trace eating f8
\> have to delete half my schematics to find which one errored

this pull gives info on which schematic had an error with i/o stuff to make deleting faulty files easier.