### PR TITLE
sprite load mod support

### DIFF
--- a/annotations/src/main/java/mindustry/annotations/misc/LoadRegionProcessor.java
+++ b/annotations/src/main/java/mindustry/annotations/misc/LoadRegionProcessor.java
@@ -108,6 +108,7 @@ public class LoadRegionProcessor extends BaseProcessor{
         value = value.replace("#1", "\" + INDEX0 + \"");
         value = value.replace("#2", "\" + INDEX1 + \"");
         value = value.replace("#", "\" + INDEX0 + \"");
+        value = value.replace("$", "\" + (content.loadPrefix ? content.prefix : \"\") + \"");
         return value;
     }
 

--- a/core/src/mindustry/core/ContentLoader.java
+++ b/core/src/mindustry/core/ContentLoader.java
@@ -175,8 +175,8 @@ public class ContentLoader{
         this.currentMod = mod;
     }
 
-    public String transformName(String name){
-        return currentMod == null ? name : currentMod.name + "-" + name;
+    public String getModPrefix(){
+        return currentMod == null ? "" : currentMod.name + "-";
     }
 
     public void handleMappableContent(MappableContent content){

--- a/core/src/mindustry/ctype/MappableContent.java
+++ b/core/src/mindustry/ctype/MappableContent.java
@@ -3,7 +3,7 @@ package mindustry.ctype;
 import mindustry.*;
 
 public abstract class MappableContent extends Content{
-    public final String name;
+    public final String name, prefix;
 
     public MappableContent(String name){
         this.name = Vars.content.transformName(name);

--- a/core/src/mindustry/ctype/MappableContent.java
+++ b/core/src/mindustry/ctype/MappableContent.java
@@ -3,10 +3,11 @@ package mindustry.ctype;
 import mindustry.*;
 
 public abstract class MappableContent extends Content{
-    public final String name;
+    public final String name, prefix;
 
     public MappableContent(String name){
-        this.name = Vars.content.transformName(name);
+        prefix = Vars.content.getModPrefix();
+        this.name = prefix + name;
         Vars.content.handleMappableContent(this);
     }
 

--- a/core/src/mindustry/ctype/MappableContent.java
+++ b/core/src/mindustry/ctype/MappableContent.java
@@ -6,7 +6,7 @@ public abstract class MappableContent extends Content{
     public final String name, prefix;
 
     public MappableContent(String name){
-        this.name = Vars.content.transformName(name);
+        this.name = Vars.content.transformName(name, prefix);
         Vars.content.handleMappableContent(this);
     }
 

--- a/core/src/mindustry/ctype/MappableContent.java
+++ b/core/src/mindustry/ctype/MappableContent.java
@@ -4,6 +4,7 @@ import mindustry.*;
 
 public abstract class MappableContent extends Content{
     public final String name, prefix;
+    public boolean loadPrefix;
 
     public MappableContent(String name){
         prefix = Vars.content.getModPrefix();

--- a/core/src/mindustry/ctype/MappableContent.java
+++ b/core/src/mindustry/ctype/MappableContent.java
@@ -3,10 +3,10 @@ package mindustry.ctype;
 import mindustry.*;
 
 public abstract class MappableContent extends Content{
-    public final String name, prefix;
+    public final String name;
 
     public MappableContent(String name){
-        this.name = Vars.content.transformName(name, prefix);
+        this.name = Vars.content.transformName(name);
         Vars.content.handleMappableContent(this);
     }
 

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -66,7 +66,7 @@ public abstract class Turret extends ReloadTurret{
     protected Vec2 tr = new Vec2();
     protected Vec2 tr2 = new Vec2();
 
-    public @Load(value = "base-@", fallback = "block-@size") TextureRegion baseRegion;
+    public @Load(value = "base-@", fallback = "$block-@size") TextureRegion baseRegion;
     public @Load("@-heat") TextureRegion heatRegion;
 
     public Cons<TurretBuild> drawer = tile -> Draw.rect(region, tile.x + tr2.x, tile.y + tr2.y, tile.rotation - 90);

--- a/core/src/mindustry/world/blocks/production/PayloadAcceptor.java
+++ b/core/src/mindustry/world/blocks/production/PayloadAcceptor.java
@@ -16,9 +16,9 @@ import static mindustry.Vars.*;
 public class PayloadAcceptor extends Block{
     public float payloadSpeed = 0.5f;
 
-    public @Load(value = "@-top", fallback = "factory-top-@size") TextureRegion topRegion;
-    public @Load(value = "@-out", fallback = "factory-out-@size") TextureRegion outRegion;
-    public @Load(value = "@-in", fallback = "factory-in-@size") TextureRegion inRegion;
+    public @Load(value = "@-top", fallback = "$factory-top-@size") TextureRegion topRegion;
+    public @Load(value = "@-out", fallback = "$factory-out-@size") TextureRegion outRegion;
+    public @Load(value = "@-in", fallback = "$factory-in-@size") TextureRegion inRegion;
 
     public PayloadAcceptor(String name){
         super(name);


### PR DESCRIPTION
just overriding sprite is dangerous if multiple mods are overriding same sprite.
So I pr this as solution of the problem.
this allows `mod-name-block-4` instead `block-4` as fallback

