### PR TITLE
Begin reloading continuous weapons  after the bullet finishes.

### DIFF
--- a/core/assets/contributors
+++ b/core/assets/contributors
@@ -96,6 +96,7 @@ YellOw139
 PetrGasparik
 LeoDog896
 Summet
+MEEP of Faith
 jalastram (freesound.org)
 newlocknew (freesound.org)
 dsmolenaers (freesound.org)

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -431,7 +431,7 @@ public class UnitTypes implements ContentList{
 
                 firstShotDelay = Fx.greenLaserChargeSmall.lifetime - 1f;
 
-                reload = 320f;
+                reload = 160f;
                 recoil = 0f;
                 chargeSound = Sounds.lasercharge2;
                 shootSound = Sounds.beam;

--- a/core/src/mindustry/entities/comp/WeaponsComp.java
+++ b/core/src/mindustry/entities/comp/WeaponsComp.java
@@ -117,6 +117,7 @@ abstract class WeaponsComp implements Teamc, Posc, Rotc, Velc, Statusc{
                 }else{
                     mount.bullet.rotation(weaponRotation + 90);
                     mount.bullet.set(shootX, shootY);
+                    mount.reload = weapon.reload;
                     vel.add(Tmp.v1.trns(rotation + 180f, mount.bullet.type.recoil));
                     if(weapon.shootSound != Sounds.none && !headless){
                         if(mount.sound == null) mount.sound = new SoundLoop(weapon.shootSound, 1f);


### PR DESCRIPTION
Reason: Make weapons with recoil begin to return to normal position after the bullet finishes.

Before:
![Before](https://user-images.githubusercontent.com/54301439/99323503-3dc3a680-2827-11eb-95af-0650440546ab.gif)

After:
![After](https://user-images.githubusercontent.com/54301439/99323509-40be9700-2827-11eb-9b08-a65a0e5f532e.gif)