### PR TITLE
Allow for plugins to trigger the same alerts as sectors and guardians

### DIFF
--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -21,6 +21,7 @@ import mindustry.net.Administration.*;
 import mindustry.net.Net.*;
 import mindustry.net.*;
 import mindustry.net.Packets.*;
+import mindustry.ui.*;
 import mindustry.world.*;
 import mindustry.world.modules.*;
 

--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -339,6 +339,13 @@ public class NetClient implements ApplicationListener{
 
         ui.showInfoToast(message, duration);
     }
+    
+    @Remote(variants = Variant.both)
+    public static void warningToast(int unicode, String text){
+        if(text == null || mindustry.ui.Fonts.def.getData().getGlyph((char)unicode) == null) return;
+
+        ui.hudfrag.showToast(mindustry.ui.Fonts.getGlyph(mindustry.ui.Fonts.def, (char)unicode), text);
+    }
 
     @Remote(variants = Variant.both)
     public static void setRules(Rules rules){

--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -345,7 +345,7 @@ public class NetClient implements ApplicationListener{
     public static void warningToast(int unicode, String text){
         if(text == null || Fonts.def.getData().getGlyph((char)unicode) == null) return;
 
-        ui.hudfrag.showToast(Fonts.getGlyph(ui.Fonts.def, (char)unicode), text);
+        ui.hudfrag.showToast(Fonts.getGlyph(Fonts.def, (char)unicode), text);
     }
 
     @Remote(variants = Variant.both)

--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -343,9 +343,9 @@ public class NetClient implements ApplicationListener{
     
     @Remote(variants = Variant.both)
     public static void warningToast(int unicode, String text){
-        if(text == null || Fonts.def.getData().getGlyph((char)unicode) == null) return;
+        if(text == null || Fonts.icon.getData().getGlyph((char)unicode) == null) return;
 
-        ui.hudfrag.showToast(Fonts.getGlyph(Fonts.def, (char)unicode), text);
+        ui.hudfrag.showToast(Fonts.getGlyph(Fonts.icon, (char)unicode), text);
     }
 
     @Remote(variants = Variant.both)

--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -342,9 +342,9 @@ public class NetClient implements ApplicationListener{
     
     @Remote(variants = Variant.both)
     public static void warningToast(int unicode, String text){
-        if(text == null || mindustry.ui.Fonts.def.getData().getGlyph((char)unicode) == null) return;
+        if(text == null || Fonts.def.getData().getGlyph((char)unicode) == null) return;
 
-        ui.hudfrag.showToast(mindustry.ui.Fonts.getGlyph(mindustry.ui.Fonts.def, (char)unicode), text);
+        ui.hudfrag.showToast(Fonts.getGlyph(ui.Fonts.def, (char)unicode), text);
     }
 
     @Remote(variants = Variant.both)


### PR DESCRIPTION
> as discussed with @Anuken on [discord](https://discord.com/channels/391020510269669376/653294015969624064/778606437857099816)

not sure if `Fonts.def` is the correct font to use, but my guess is that it controls the size at which it shows so i kept it 🤔 

(if i am not mistaken this allows the use of both the `Icon` and `Iconc` classes, but not sure if the above plays a role ^)