### PR TITLE
Only command if there are units to command

### DIFF
--- a/core/src/mindustry/entities/comp/CommanderComp.java
+++ b/core/src/mindustry/entities/comp/CommanderComp.java
@@ -63,6 +63,8 @@ abstract class CommanderComp implements Entityc, Posc{
                 units.add(u);
             }
         });
+        
+        if(units.isEmpty()) return;
 
         //sort by hitbox size, then by distance
         units.sort(Structs.comps(Structs.comparingFloat(u -> -u.hitSize), Structs.comparingFloat(u -> u.dst2(this))));


### PR DESCRIPTION
Currently this if toggles even when the command list is empty:
https://github.com/Anuken/Mindustry/blob/master/core/src/mindustry/input/InputHandler.java#L373

not sure if this is the best way to fix this, nor if the command list resets when all the commanded units die.

maybe `if(commander.isCommanding()){` should (also) check the count of how many are alive, who knows.

leaving this as a draft for now until @Anuken decides where he would like what. 🤔 

code used to test: (triggers only once every two command keybind presses)
<img width="350" alt="Screen Shot 2020-11-21 at 10 00 01" src="https://user-images.githubusercontent.com/3179271/99872205-64476000-2be0-11eb-8ef4-ca8474f0b874.png">
