### PR TITLE
Add remote call for world.endMapLoad

### DIFF
--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -370,6 +370,11 @@ public class NetClient implements ApplicationListener{
             netClient.disconnectQuietly();
         });
     }
+    
+    @Remote(variants = Variant.both)
+    public static void endMapLoad(){
+        world.endMapLoad();
+    }
 
     @Remote(variants = Variant.one)
     public static void setPosition(float x, float y){


### PR DESCRIPTION
so as discussed in #3488 floor (& wall/darkness) setnet's can't visually update it due to performance reasons.

however, `world.endMapLoad()` gives the desired effect as well.

currently (& in version `5`) the only way around this restriction is to send **the entire map** over again.

this call would simply allow for the (bulk) of changes already sent via setnets to visually update at once.

---

on the version 5 nydus server it got "solved" by tagging the player object with an array of tiles and forcing a sync if the player got close enough to one, aka: "being in an area that significantly changed", so the sync was entirely optional if you worked on another spot of the map, due to fully syncing taking a good solid second most of the time.

with this (on my desktop) it visually updates in the blink of an eye, and i doubt mobile users will have to much problems if this is used few and far in between (maybe several calls per minute, not per second to update small details)

---

i am not sure whether or not this has some side effects, but it just seems to do what i need: reloading world visuals :) 🌍 