### PR TITLE
unified extend and extendContent to work for any class

### DIFF
--- a/core/assets/scripts/base.js
+++ b/core/assets/scripts/base.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const log = function(context, obj){
+function log(context, obj){
     Vars.mods.scripts.log(context, String(obj))
 }
 
@@ -19,13 +19,26 @@ let modName = "none"
 
 const print = text => log(modName + "/" + scriptName, text);
 
-const extendContent = function(classType, name, params){
-    return new JavaAdapter(classType, params, name)
+// js 'extend(Base, ..., {})' = java 'new Base(...) {}'
+function extend(/*Base, ..., def*/) {
+    const Base = arguments[0];
+    const def = arguments[arguments.length - 1];
+    // swap order from Base, def, ... to Base, ..., def
+    const args = [Base, def].concat(Array.from(arguments).splice(1, arguments.length - 2));
+
+    // forward constructor arguments to new JavaAdapter
+    const instance = JavaAdapter.apply(null, args);
+    // JavaAdapter only overrides functions; set fields too
+    for (var i in def) {
+        if (typeof(def[i]) != "function") {
+            instance[i] = def[i];
+        }
+    }
+    return instance;
 }
 
-const extend = function(classType, params){
-    return new JavaAdapter(classType, params)
-}
+// For backwards compatibility, use extend instead
+const extendContent = extend;
 
 //these are not sctrictly necessary, but are kept for edge cases
 const run = method => new java.lang.Runnable(){run: method}
@@ -38,4 +51,4 @@ const prov = method => new Prov(){get: method}
 const func = method => new Func(){get: method}
 
 const newEffect = (lifetime, renderer) => new Effects.Effect(lifetime, new Effects.EffectRenderer({render: renderer}))
-Call = Packages.mindustry.gen.Call
+const Call = Packages.mindustry.gen.Call

--- a/core/assets/scripts/global.js
+++ b/core/assets/scripts/global.js
@@ -2,7 +2,7 @@
 
 "use strict";
 
-const log = function(context, obj){
+function log(context, obj){
     Vars.mods.getScripts().log(context, String(obj))
 }
 
@@ -21,13 +21,26 @@ let modName = "none"
 
 const print = text => log(modName + "/" + scriptName, text);
 
-const extendContent = function(classType, name, params){
-    return new JavaAdapter(classType, params, name)
+// js 'extend(Base, ..., {})' = java 'new Base(...) {}'
+function extend(/*Base, ..., def*/) {
+    const Base = arguments[0];
+    const def = arguments[arguments.length - 1];
+    // swap order from Base, def, ... to Base, ..., def
+    const args = [Base, def].concat(Array.from(arguments).splice(1, arguments.length - 2));
+
+    // forward constructor arguments to new JavaAdapter
+    const instance = JavaAdapter.apply(null, args);
+    // JavaAdapter only overrides functions; set fields too
+    for (var i in def) {
+        if (typeof(def[i]) != "function") {
+            instance[i] = def[i];
+        }
+    }
+    return instance;
 }
 
-const extend = function(classType, params){
-    return new JavaAdapter(classType, params)
-}
+// For backwards compatibility, use extend instead
+const extendContent = extend;
 
 //these are not sctrictly necessary, but are kept for edge cases
 const run = method => new java.lang.Runnable(){run: method}
@@ -40,7 +53,7 @@ const prov = method => new Prov(){get: method}
 const func = method => new Func(){get: method}
 
 const newEffect = (lifetime, renderer) => new Effects.Effect(lifetime, new Effects.EffectRenderer({render: renderer}))
-Call = Packages.mindustry.gen.Call
+const Call = Packages.mindustry.gen.Call
 
 importPackage(Packages.arc)
 importPackage(Packages.arc.func)


### PR DESCRIPTION
changed extend to be extend(class, constructorargs..., def) which works with old extend(class, def) and deprecated extendContent(class, name, def) which is an alias.
pros:
- backwards compatible
- you now never need to use JavaAdapter unless working with interfaces
- supports any number of constructor args (think planets, bullets)
- also merges non-functions removing need for `a.b = c` over and over
cons:
- none

example:
```js
// Backwards compat alias
extendContent(Block, "name", {test(){print("i am " + this.name)}}).test();
// New variadic args stuff
extend(Block, "egg", {test(){print("i am " + this.name)}}).test();
extend(BasicBulletType, 10, 0.5, {test(){print("my dmg " + this.damage)}}).test();
// Setting variables for you - old extendContent didn't do this.
print("Speed: " + extend(UnitType, "fast", {speed: 1000}).speed);
```