### PR TITLE
Sync construction blocks

### DIFF
--- a/core/src/mindustry/world/blocks/ConstructBlock.java
+++ b/core/src/mindustry/world/blocks/ConstructBlock.java
@@ -40,6 +40,7 @@ public class ConstructBlock extends Block{
         consumesTap = true;
         solidifes = true;
         consBlocks[size - 1] = this;
+        sync = true;
     }
 
     /** Returns a ConstructBlock by size. */


### PR DESCRIPTION
when resources for buildings are being used by several players on the map and the core lacks stuff, it desyncs.

i have had this on at the nydus v5 server for basically forever, and also turned it on for v6 bleeding edge.

in the previous version of the game it wasn't such a big deal, but this versions has a lot more expensive / larger builds.

while its weird to see the construction progress jump every ~8 seconds, its better than not having building accuracy.

(most noticeable with the higher tier reconstructors, where progress accuracy can easily shift by 25%)

> maybe a smoother fix would be to send progress along with construction packets, but this is a least a good step ❤️ 