### PR TITLE
GitHub Actions: Manual Triggers

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push]
+on: [push, workflow_dispatch]
 
 jobs:
   buildJava14:


### PR DESCRIPTION
Added `workflow_dispatch` event, so now you can press "Run build" button instead of making a new commit.

You can use it for testing BE builds, that is pretty useful.