### PR TITLE
use JumpI for end

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -782,14 +782,6 @@ public class LExecutor{
         }
     }
 
-    public static class EndI implements LInstruction{
-
-        @Override
-        public void run(LExecutor exec){
-            exec.vars[varCounter].numval = exec.instructions.length;
-        }
-    }
-
     public static class NoopI implements LInstruction{
         @Override
         public void run(LExecutor exec){}

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -644,7 +644,8 @@ public class LStatements{
 
         @Override
         public LInstruction build(LAssembler builder){
-            return new EndI();
+            //jump to the first line
+            return new JumpI(ConditionOp.always, 0, 0, 0);
         }
 
         @Override


### PR DESCRIPTION
since its equivalent to `jump 0 always`, may as well make it that
removes EndI as it's redundant.