### PR TITLE
display the repair field healed effect at the healed unit(s)

### DIFF
--- a/core/src/mindustry/entities/abilities/RepairFieldAbility.java
+++ b/core/src/mindustry/entities/abilities/RepairFieldAbility.java
@@ -30,7 +30,7 @@ public class RepairFieldAbility extends Ability{
 
             Units.nearby(unit.team, unit.x, unit.y, range, other -> {
                 if(other.damaged()){
-                    healEffect.at(unit);
+                    healEffect.at(other);
                     wasHealed = true;
                 }
                 other.heal(amount);


### PR DESCRIPTION
just something i noticed while commanding an army of player corvuses as an oct 🩹 