### PR TITLE
Fix BlockForge progress bar & recenter payload

### DIFF
--- a/core/src/mindustry/world/blocks/experimental/BlockForge.java
+++ b/core/src/mindustry/world/blocks/experimental/BlockForge.java
@@ -41,7 +41,7 @@ public class BlockForge extends PayloadAcceptor{
     public void setBars(){
         super.setBars();
 
-        bars.add("progress", entity -> new Bar("bar.progress", Pal.ammo, () -> ((BlockForgeBuild)entity).progress));
+        bars.add("progress", (BlockForgeBuild entity) -> new Bar("bar.progress", Pal.ammo, () -> entity.payload != null ? 1f : entity.recipe == null ? 0f : (float)(entity.progress / entity.recipe.buildCost)));
     }
 
     @Override
@@ -83,6 +83,7 @@ public class BlockForge extends PayloadAcceptor{
                 if(progress >= recipe.buildCost){
                     consume();
                     payload = new BuildPayload(recipe, team);
+                    payVector.setZero();
                     progress = 0f;
                 }
             }else{

--- a/core/src/mindustry/world/blocks/experimental/BlockForge.java
+++ b/core/src/mindustry/world/blocks/experimental/BlockForge.java
@@ -41,7 +41,7 @@ public class BlockForge extends PayloadAcceptor{
     public void setBars(){
         super.setBars();
 
-        bars.add("progress", (BlockForgeBuild entity) -> new Bar("bar.progress", Pal.ammo, () -> entity.payload != null ? 1f : entity.recipe == null ? 0f : (float)(entity.progress / entity.recipe.buildCost)));
+        bars.add("progress", (BlockForgeBuild entity) -> new Bar("bar.progress", Pal.ammo, () -> entity.recipe == null ? 0f : (float)(entity.progress / entity.recipe.buildCost)));
     }
 
     @Override


### PR DESCRIPTION
> experimenting with the block forge for custom plugins, so kinda fixing the stuff i'm running into, this has 2 fixes:

- when it has constructed a block it moves from the center to the edge, but it never resets for future output.

- progress bar was ~~wrong~~ inaccurate, now it stays at 100% when it has stuff in it, and shows actual progress.