### PR TITLE
Changes to water extractor requirements

### DIFF
--- a/core/src/mindustry/content/TechTree.java
+++ b/core/src/mindustry/content/TechTree.java
@@ -121,7 +121,7 @@ public class TechTree implements ContentList{
 
                             });
 
-                            node(waterExtractor, Seq.with(new SectorComplete(saltFlats)), () -> {
+                            node(waterExtractor, Seq.with(new SectorComplete(ruinousShores)), () -> {
                                 node(oilExtractor, () -> {
 
                                 });


### PR DESCRIPTION
It is a common complaint that the water extractor shouldn't require you to beat Salt Flats, so I changed the requirements for water extractor to completing Ruinous Shores. I think this pull request should also be accompanied by a slightly harder Salt flats (steam gens, some salvos near the base etc.) 