### PR TITLE
Why is this protected in the first place?

### DIFF
--- a/core/src/mindustry/entities/bullet/LaserBoltBulletType.java
+++ b/core/src/mindustry/entities/bullet/LaserBoltBulletType.java
@@ -6,7 +6,7 @@ import mindustry.gen.*;
 import mindustry.content.*;
 
 public class LaserBoltBulletType extends BasicBulletType{
-    protected float height = 7f, width = 2f;
+    public float width = 2f, height = 7f;
 
     public LaserBoltBulletType(float speed, float damage){
         super(speed, damage);


### PR DESCRIPTION
This seems to mess up when trying to do `b.type.width/height` since when I try to use that it's calling `BasicBulletType`'s width and height instead.
Also swapped the order of width and height to make it consistent with `BasicBulletType`