### PR TITLE
Keep items inside reconstructor when construction booped

### DIFF
--- a/core/src/mindustry/world/Build.java
+++ b/core/src/mindustry/world/Build.java
@@ -37,8 +37,12 @@ public class Build{
         Block previous = tile.block();
         Block sub = ConstructBlock.get(previous.size);
 
+        Seq<Building> prevBuild = new Seq<>(1);
+        if(tile.build != null) prevBuild.add(tile.build);
+
         tile.setBlock(sub, team, rotation);
         tile.<ConstructBuild>bc().setDeconstruct(previous);
+        tile.<ConstructBuild>bc().prevBuild = prevBuild;
         tile.build.health = tile.build.maxHealth * prevPercent;
         if(unit != null && unit.isPlayer()) tile.build.lastAccessed = unit.getPlayer().name;
 

--- a/core/src/mindustry/world/blocks/units/Reconstructor.java
+++ b/core/src/mindustry/world/blocks/units/Reconstructor.java
@@ -115,6 +115,13 @@ public class Reconstructor extends UnitBlock{
         }
 
         @Override
+        public void overwrote(Seq<Building> builds){
+            if(builds.first().block == block){
+                items.add(builds.first().items);
+            }
+        }
+
+        @Override
         public void draw(){
             Draw.rect(region, x, y);
 


### PR DESCRIPTION
its a pretty common occurrence that the reconstructor is deconstructed partially for a split second to clear out the unit currently stuck in there, the only problem is that it also gets rid of any items still remaining in there.

this pull does two things:

- returns you all the items if you complete the partially deconstructed reconstructor again (must be the same block)
- tags all deconstructing blocks with what they were so they can be restored if they have custom overwrote logic

during testing i found that you can place a larger reconstructor over a smaller one (and that does not transfer any compatible items), but i am leaving that outside the scope of this pull request (+ who even does that?)

![Dec-02-2020 12-18-19](https://user-images.githubusercontent.com/3179271/100866138-82427980-3498-11eb-807c-4e8322df57f3.gif)
