### PR TITLE
Fast forward boulder deconstruction

### DIFF
--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -126,7 +126,7 @@ public class Block extends UnlockableContent{
     public BlockGroup group = BlockGroup.none;
     /** List of block flags. Used for AI indexing. */
     public EnumSet<BlockFlag> flags = EnumSet.of();
-    /** Targeting priority of this block, as seen by enemies.*/
+    /** Targeting priority of this block, as seen by enemies .*/
     public TargetPriority priority = TargetPriority.base;
     /** How much this block affects the unit cap by.
      * The block flags must contain unitModifier in order for this to work. */
@@ -139,9 +139,9 @@ public class Block extends UnlockableContent{
     public boolean consumesTap;
     /** Whether to draw the glow of the liquid for this block, if it has one. */
     public boolean drawLiquidLight = true;
-    /** Whether to periodically sync this block across the network.*/
+    /** Whether to periodically sync this block across the network. */
     public boolean sync;
-    /** Whether this block uses conveyor-type placement mode.*/
+    /** Whether this block uses conveyor-type placement mode. */
     public boolean conveyorPlacement;
     /**
      * The color of this block when displayed on the minimap or map preview.
@@ -173,12 +173,12 @@ public class Block extends UnlockableContent{
     /** Radius of the light emitted by this block. */
     public float lightRadius = 60f;
 
-    /** The sound that this block makes while active. One sound loop. Do not overuse.*/
+    /** The sound that this block makes while active. One sound loop. Do not overuse. */
     public Sound loopSound = Sounds.none;
     /** Active sound base volume. */
     public float loopSoundVolume = 0.5f;
 
-    /** The sound that this block makes while idle. Uses one sound loop for all blocks.*/
+    /** The sound that this block makes while idle. Uses one sound loop for all blocks. */
     public Sound ambientSound = Sounds.none;
     /** Idle sound base volume. */
     public float ambientSoundVolume = 0.05f;
@@ -193,6 +193,8 @@ public class Block extends UnlockableContent{
     public BuildVisibility buildVisibility = BuildVisibility.hidden;
     /** Multiplier for speed of building this block. */
     public float buildCostMultiplier = 1f;
+    /** Build completion at which deconstruction finishes. */
+    public float deconstructThreshold = 0f;
     /** Multiplier for cost of research in tech tree. */
     public float researchCostMultiplier = 1;
     /** Whether this block has instant transfer.*/

--- a/core/src/mindustry/world/blocks/ConstructBlock.java
+++ b/core/src/mindustry/world/blocks/ConstructBlock.java
@@ -289,7 +289,7 @@ public class ConstructBlock extends Block{
 
             progress = Mathf.clamp(progress - amount);
 
-            if(progress <= previous.deconstructThreshold || state.rules.infiniteResources){
+            if(progress <= (previous == null ? 0 : previous.deconstructThreshold) || state.rules.infiniteResources){
                 if(lastBuilder == null) lastBuilder = builder;
                 Call.deconstructFinish(tile, this.cblock == null ? previous : this.cblock, lastBuilder);
             }

--- a/core/src/mindustry/world/blocks/ConstructBlock.java
+++ b/core/src/mindustry/world/blocks/ConstructBlock.java
@@ -288,6 +288,9 @@ public class ConstructBlock extends Block{
             }
 
             progress = Mathf.clamp(progress - amount);
+            
+            // fast forward boulder deconstruction when visually already gone
+            if(progress <= 0.35f && previous instanceof Boulder) progress = 0;
 
             if(progress <= 0 || state.rules.infiniteResources){
                 if(lastBuilder == null) lastBuilder = builder;

--- a/core/src/mindustry/world/blocks/ConstructBlock.java
+++ b/core/src/mindustry/world/blocks/ConstructBlock.java
@@ -19,6 +19,7 @@ import mindustry.graphics.*;
 import mindustry.type.*;
 import mindustry.ui.*;
 import mindustry.world.*;
+import mindustry.world.blocks.environment.*;
 import mindustry.world.blocks.storage.CoreBlock.*;
 import mindustry.world.modules.*;
 

--- a/core/src/mindustry/world/blocks/ConstructBlock.java
+++ b/core/src/mindustry/world/blocks/ConstructBlock.java
@@ -19,7 +19,6 @@ import mindustry.graphics.*;
 import mindustry.type.*;
 import mindustry.ui.*;
 import mindustry.world.*;
-import mindustry.world.blocks.environment.*;
 import mindustry.world.blocks.storage.CoreBlock.*;
 import mindustry.world.modules.*;
 
@@ -289,11 +288,8 @@ public class ConstructBlock extends Block{
             }
 
             progress = Mathf.clamp(progress - amount);
-            
-            // fast forward boulder deconstruction when visually already gone
-            if(progress <= 0.35f && previous instanceof Boulder) progress = 0;
 
-            if(progress <= 0 || state.rules.infiniteResources){
+            if(progress <= previous.deconstructThreshold || state.rules.infiniteResources){
                 if(lastBuilder == null) lastBuilder = builder;
                 Call.deconstructFinish(tile, this.cblock == null ? previous : this.cblock, lastBuilder);
             }

--- a/core/src/mindustry/world/blocks/environment/Boulder.java
+++ b/core/src/mindustry/world/blocks/environment/Boulder.java
@@ -13,7 +13,7 @@ public class Boulder extends Block{
         breakable = true;
         alwaysReplace = true;
         
-        deconstructThreshold = 0.35;
+        deconstructThreshold = 0.35f;
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/environment/Boulder.java
+++ b/core/src/mindustry/world/blocks/environment/Boulder.java
@@ -12,6 +12,8 @@ public class Boulder extends Block{
         super(name);
         breakable = true;
         alwaysReplace = true;
+        
+        deconstructThreshold = 0.35;
     }
 
     @Override


### PR DESCRIPTION
(all types of) boulder(s) still need to deconstruct ~35% more when visibly it has already reached the stage of emptyness.

this pull fast forwards the deconstruction once it has reached that point.

notable:
- static wall extends the boulder class, but it cannot be constructed. (`previous.getClass() == Boulder.class` failed)
- 0.35 is just my `Log.info(progress)` guess where i compared it visually, the sweet spot may lie slightly higher or lower.

old:

![Dec-02-2020 16-26-58](https://user-images.githubusercontent.com/3179271/100893068-3f45cd80-34bb-11eb-9733-f6b506ddf5aa.gif)

new:

![Dec-02-2020 16-24-18](https://user-images.githubusercontent.com/3179271/100893098-4967cc00-34bb-11eb-8cb7-9567fe9c2502.gif)
