### PR TITLE
[QOL] Ability to Disable Weather Effects 

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -832,6 +832,7 @@ setting.chatopacity.name = Chat Opacity
 setting.lasersopacity.name = Power Laser Opacity
 setting.bridgeopacity.name = Bridge Opacity
 setting.playerchat.name = Display Player Bubble Chat
+setting.enableweather.name = Enable Weather
 public.confirm = Do you want to make your game public?\n[accent]Anyone will be able to join your games.\n[lightgray]This can be changed later in Settings->Game->Public Game Visibility.
 public.beta = Note that beta versions of the game cannot make public lobbies.
 uiscale.reset = UI scale has been changed.\nPress "OK" to confirm this scale.\n[scarlet]Reverting and exiting in[accent] {0}[] seconds...

--- a/core/src/mindustry/type/Weather.java
+++ b/core/src/mindustry/type/Weather.java
@@ -314,7 +314,7 @@ public class Weather extends UnlockableContent{
 
         @Override
         public void draw(){
-            if(renderer.weatherAlpha() > 0.0001f){
+            if(renderer.weatherAlpha() > 0.0001f && Core.settings.getBool("enableweather")){
                 Draw.draw(Layer.weather, () -> {
                     weather.rand.setSeed(0);
                     Draw.alpha(renderer.weatherAlpha() * opacity * weather.opacityMultiplier);

--- a/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
+++ b/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
@@ -404,6 +404,7 @@ public class SettingsMenuDialog extends SettingsDialog{
         graphics.checkPref("fps", false);
         graphics.checkPref("playerindicators", true);
         graphics.checkPref("indicators", true);
+        graphics.checkPref("enableweather", true);
         graphics.checkPref("animatedwater", true);
         if(Shaders.shield != null){
             graphics.checkPref("animatedshields", !mobile);


### PR DESCRIPTION
Small Quality of Life change to allow users to disable weather effects in the settings menu. 

Still, a draft sill going to disable weather-related code in other areas of the game to stop "unused functions" from running while the user has weather disabled. I am currently only disabling the rendering of weather, the weather still exists just not visible to the user. 

As this is my first time contributing looking for suggestions or comments.