### PR TITLE
[QoL] Chat Modes

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -917,6 +917,7 @@ keybind.toggle_menus.name = Toggle Menus
 keybind.chat_history_prev.name = Chat History Prev
 keybind.chat_history_next.name = Chat History Next
 keybind.chat_scroll.name = Chat Scroll
+keybind.chat_mode.name = Change Chat Mode
 keybind.drop_unit.name = Drop Unit
 keybind.zoom_minimap.name = Zoom Minimap
 mode.help.title = Description of modes

--- a/core/assets/bundles/bundle_es.properties
+++ b/core/assets/bundles/bundle_es.properties
@@ -915,6 +915,7 @@ keybind.toggle_menus.name = Ocultar menús
 keybind.chat_history_prev.name = Historial de chat - Anterior
 keybind.chat_history_next.name = Historial de chat - Siguiente
 keybind.chat_scroll.name = Desplazar el chat
+keybind.chat_mode.name = Cambiar modo de chat
 keybind.drop_unit.name = Soltar unidad
 keybind.zoom_minimap.name = Zoom del minimapa
 mode.help.title = Descripción de modos

--- a/core/assets/bundles/bundle_ko.properties
+++ b/core/assets/bundles/bundle_ko.properties
@@ -915,6 +915,7 @@ keybind.toggle_menus.name = 메뉴 보이기/숨기기
 keybind.chat_history_prev.name = 이전 채팅 기록
 keybind.chat_history_next.name = 다음 채팅 기록
 keybind.chat_scroll.name = 채팅 스크롤
+keybind.chat_mode = 대화 대상 변경
 keybind.drop_unit.name = 유닛 떨구기
 keybind.zoom_minimap.name = 미니맵 확대
 mode.help.title = 모드 설명

--- a/core/assets/bundles/bundle_ru.properties
+++ b/core/assets/bundles/bundle_ru.properties
@@ -918,6 +918,7 @@ keybind.toggle_menus.name = Переключение меню
 keybind.chat_history_prev.name = Пред. история чата
 keybind.chat_history_next.name = След. история чата
 keybind.chat_scroll.name = Прокрутка чата
+keybind.chat_mode.name = Изменить режим чата
 keybind.drop_unit.name = Сбросить боев. ед.
 keybind.zoom_minimap.name = Масштабировать мини-карту
 mode.help.title = Описание режимов

--- a/core/src/mindustry/input/Binding.java
+++ b/core/src/mindustry/input/Binding.java
@@ -69,6 +69,7 @@ public enum Binding implements KeyBind{
     chat_history_prev(KeyCode.up),
     chat_history_next(KeyCode.down),
     chat_scroll(new Axis(KeyCode.scroll)),
+    chat_mode(KeyCode.tab),
     console(KeyCode.f8),
     ;
 

--- a/core/src/mindustry/ui/fragments/ChatFragment.java
+++ b/core/src/mindustry/ui/fragments/ChatFragment.java
@@ -2,6 +2,7 @@ package mindustry.ui.fragments;
 
 import arc.*;
 import arc.Input.*;
+import arc.func.*;
 import arc.graphics.*;
 import arc.graphics.g2d.*;
 import arc.math.*;
@@ -14,6 +15,7 @@ import arc.util.*;
 import mindustry.*;
 import mindustry.gen.*;
 import mindustry.input.*;
+import mindustry.type.*;
 import mindustry.ui.*;
 
 import static arc.Core.*;
@@ -27,6 +29,7 @@ public class ChatFragment extends Table{
     private boolean shown = false;
     private TextField chatfield;
     private Label fieldlabel = new Label(">");
+    private ChatMode mode = ChatMode.normal;
     private Font font;
     private GlyphLayout layout = new GlyphLayout();
     private float offsetx = Scl.scl(4), offsety = Scl.scl(4), fontoffsetx = Scl.scl(2), chatspace = Scl.scl(50);
@@ -75,6 +78,9 @@ public class ChatFragment extends Table{
                 if(input.keyTap(Binding.chat_history_next) && historyPos > 0){
                     historyPos--;
                     updateChat();
+                }
+                if(input.keyTap(Binding.chat_mode)){
+                    nextMode();
                 }
                 scrollPos = (int)Mathf.clamp(scrollPos + input.axis(Binding.chat_scroll), 0, Math.max(0, messages.size - messagesShown));
             }
@@ -216,14 +222,35 @@ public class ChatFragment extends Table{
     }
 
     public void updateChat(){
-        chatfield.setText(history.get(historyPos));
-        chatfield.setCursorPosition(chatfield.getText().length());
+        chatfield.setText(mode.normalizedPrefix() + history.get(historyPos));
+        updateCursor();
+    }
+
+    public void nextMode(){
+        ChatMode prev = mode;
+
+        do{
+            mode = mode.next();
+        }while(!mode.isValid());
+
+        if(chatfield.getText().startsWith(prev.normalizedPrefix())){
+            chatfield.setText(mode.normalizedPrefix() + chatfield.getText().substring(prev.normalizedPrefix().length()));
+        }else{
+            chatfield.setText(mode.normalizedPrefix());
+        }
+
+        updateCursor();
     }
 
     public void clearChatInput(){
         historyPos = 0;
         history.set(0, "");
-        chatfield.setText("");
+        chatfield.setText(mode.normalizedPrefix());
+        updateCursor();
+    }
+
+    public void updateCursor(){
+        chatfield.setCursorPosition(chatfield.getText().length());
     }
 
     public boolean shown(){
@@ -256,4 +283,36 @@ public class ChatFragment extends Table{
         }
     }
 
+    private enum ChatMode{
+        normal(""),
+        team("/t"),
+        admin("/a", player::admin)
+        ;
+
+        public String prefix;
+        public Boolp valid;
+        public static final ChatMode[] all = values();
+
+        ChatMode(String prefix){
+            this.prefix = prefix;
+            this.valid = () -> true;
+        }
+
+        ChatMode(String prefix, Boolp valid){
+            this.prefix = prefix;
+            this.valid = valid;
+        }
+
+        public ChatMode next(){
+            return all[(ordinal() + 1) % all.length];
+        }
+
+        public String normalizedPrefix(){
+            return prefix.isEmpty() ? "" : prefix + " ";
+        }
+
+        public boolean isValid(){
+            return valid.get();
+        }
+    }
 }


### PR DESCRIPTION
It is sometimes annoying when you have to send a lot of messages to your teammates and type "/t" every time, so I made an interesting solution:

Pressing Tab (can be changed in settings):

![preview-chat-modes-tab](https://user-images.githubusercontent.com/55251897/101516201-1750e100-3977-11eb-916c-16abc73f8db7.gif)

Practical use:

![preview-chat-mode](https://user-images.githubusercontent.com/55251897/101515721-909c0400-3976-11eb-80af-1f5b6dfb96b7.gif)

~~Marking as a draft as the implementation is not so good, and there are quite a few bugs.~~

**TODO:**
* [x] Fix all possible bugs.
* [x] Translations for setting.
* [x] ~~Displaying the current mode in UI.~~

**Credits**: @Remint32, @sk7725, @Volas171.