### PR TITLE
add @commanded for units

### DIFF
--- a/core/src/mindustry/entities/comp/UnitComp.java
+++ b/core/src/mindustry/entities/comp/UnitComp.java
@@ -129,6 +129,7 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
             case mineY -> mining() ? mineTile.y : -1;
             case flag -> flag;
             case controlled -> controller instanceof LogicAI || controller instanceof Player ? 1 : 0;
+            case commanded -> controller instanceof FormationAI ? 1 : 0;
             case payloadCount -> self() instanceof Payloadc pay ? pay.payloads().size : 0;
             default -> 0;
         };

--- a/core/src/mindustry/logic/LAccess.java
+++ b/core/src/mindustry/logic/LAccess.java
@@ -34,6 +34,7 @@ public enum LAccess{
     type,
     flag,
     controlled,
+    commanded,
     name,
     config,
     payloadCount,


### PR DESCRIPTION
allows processors to detect units commanded by a player (`controller instanceof FormationAI`)
implements https://github.com/Anuken/Mindustry-Suggestions/issues/1490, can be used alongside @controlled to detect players or their squads