### PR TITLE
Ore priority fix

### DIFF
--- a/core/src/mindustry/world/blocks/production/Drill.java
+++ b/core/src/mindustry/world/blocks/production/Drill.java
@@ -163,10 +163,10 @@ public class Drill extends Block{
         int lowPriority = -1000;
         for(Tile other : tile.getLinkedTilesAs(this, tempTiles)){
             if(canMine(other)){
-                if(other.floor() instanceof OreBlock) {
-                    oreCount.increment(getDrop(other), 0, 1);
-                }else{
+                if(other.floor().playerUnmineable) {
                     oreCount.increment(getDrop(other), lowPriority, 1); //sand and etc. is low priority
+                }else{
+                    oreCount.increment(getDrop(other), 0, 1);
                 }
             }
         }

--- a/core/src/mindustry/world/blocks/production/Drill.java
+++ b/core/src/mindustry/world/blocks/production/Drill.java
@@ -160,10 +160,10 @@ public class Drill extends Block{
         itemArray.clear();
 
 
-        int lowPriority = -1000;
+        int lowPriority = -1000; // max drill area is 4 by 4 so it's not a big deal
         for(Tile other : tile.getLinkedTilesAs(this, tempTiles)){
             if(canMine(other)){
-                if(other.floor().playerUnmineable) {
+                if(other.floor().playerUnmineable){
                     oreCount.increment(getDrop(other), lowPriority, 1); //sand and etc. is low priority
                 }else{
                     oreCount.increment(getDrop(other), 0, 1);

--- a/core/src/mindustry/world/blocks/production/Drill.java
+++ b/core/src/mindustry/world/blocks/production/Drill.java
@@ -160,13 +160,13 @@ public class Drill extends Block{
         itemArray.clear();
 
 
-        int lowPriority = -1000; // max drill area is 4 by 4 so it's not a big deal
+        int lowPriority = -1000; //max drill area is 4 by 4 so it's not a big deal
         for(Tile other : tile.getLinkedTilesAs(this, tempTiles)){
             if(canMine(other)){
-                if(other.floor().playerUnmineable){
-                    oreCount.increment(getDrop(other), lowPriority, 1); //sand and etc. is low priority
-                }else{
+                if(other.overlay() != null && other.overlay().itemDrop != null){ //there is an ore
                     oreCount.increment(getDrop(other), 0, 1);
+                }else{
+                    oreCount.increment(getDrop(other), lowPriority, 1); //sand and etc. is low priority
                 }
             }
         }

--- a/core/src/mindustry/world/blocks/production/Drill.java
+++ b/core/src/mindustry/world/blocks/production/Drill.java
@@ -20,8 +20,6 @@ import mindustry.world.blocks.environment.*;
 import mindustry.world.meta.*;
 import mindustry.world.meta.values.*;
 
-import java.util.Comparator;
-
 import static mindustry.Vars.*;
 
 public class Drill extends Block{

--- a/core/src/mindustry/world/blocks/production/Drill.java
+++ b/core/src/mindustry/world/blocks/production/Drill.java
@@ -175,7 +175,11 @@ public class Drill extends Block{
             itemArray.add(item);
         }
 
-        itemArray.sort(Comparator.comparingInt((Item item) -> oreCount.get(item, 0)).thenComparingInt(item -> item.id));
+        itemArray.sort((item1, item2) -> {
+            int amounts = Integer.compare(oreCount.get(item1, 0), oreCount.get(item2, 0));
+            if(amounts != 0) return amounts;
+            return Integer.compare(item1.id, item2.id);
+        });
 
         if(itemArray.size == 0){
             return;


### PR DESCRIPTION
Sand low priority is hard coded. Bad for mods having floors with drops.

~~For some reason other.floor().playerUnmineable() is always true so priority doesn't work~~