### PR TITLE
Respawning player won't respawn in a formation

### DIFF
--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -417,7 +417,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         }
 
         if(controlledType != null && player.dead()){
-            Unit unit = Units.closest(player.team(), player.x, player.y, u -> !u.isPlayer() && u.type == controlledType && !u.dead);
+            Unit unit = Units.closest(player.team(), player.x, player.y, u -> !u.isPlayer() && u.type == controlledType && !u.dead && !(u.controller() instanceof FormationAI));
 
             if(unit != null){
                 //only trying controlling once a second to prevent packet spam


### PR DESCRIPTION
There is nothing more infuriating than someone being an idiot and dying on loop and stealing all of your formation units, the purpose of this pr is to reduce the likelihood of that happening. Players wont automatically respawn as a unit that is part of someone's formation anymore.