### PR TITLE
copy-paste tool for map editor

### DIFF
--- a/core/src/mindustry/editor/CopyData.java
+++ b/core/src/mindustry/editor/CopyData.java
@@ -1,0 +1,6 @@
+package mindustry.editor;
+
+// Class that holds data about selected tiles.
+// It handles rotation of selection.
+public class CopyData {
+}


### PR DESCRIPTION
In this pr i will (maybe) implement copy-paste for map editor. I attempted this before, but i chosen a wrong time and i also wasn't very experienced (absolute fool) with java and github. 

To describe this shortly, pr will add copy-paste tool, that will draw rectangle with adjustable size (size may be limited but that depends on your decision). You would then move with selection by clicking to selected area and dragging it. 

Now there is a problem with pasting and changing a selection. My idea is to bind paste to a key and deselect by simply clicking of the rectangle. It's not really consistent with other tools, though, I do not see any other option, other than making select and paste mode, which can slow down editing process for a user. 