### PR TITLE
disallow descriptions after mod version

### DIFF
--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -647,6 +647,14 @@ public class Mods implements Loadable{
                 meta.hidden = true;
             }
 
+            //disallow putting a description after the version
+            if(meta.version != null){
+                int line = meta.version.indexOf('\n');
+                if(line != -1){
+                    meta.version = meta.version.substring(0, line);
+                }
+            }
+
             if(!headless){
                 Log.info("Loaded mod '@' in @ms", meta.name, Time.elapsed());
             }


### PR DESCRIPTION
This mod.json
```json
{
	"name": "aaa",
	"version": "1.0\nyes i am version",
	"minGameVersion": "105"
}
```

has a "description" `yes i am version` below the version.
the issue is that this has no bounds checking and can break the dialog, along with being a hack.
having `shortDescription` would be fine.

this pr addresses this by removing any extra lines in a mod's version field.