### PR TITLE
Ignore Control Weapons

### DIFF
--- a/core/src/mindustry/entities/comp/WeaponsComp.java
+++ b/core/src/mindustry/entities/comp/WeaponsComp.java
@@ -35,7 +35,9 @@ abstract class WeaponsComp implements Teamc, Posc, Rotc, Velc, Statusc{
 
     void setWeaponRotation(float rotation){
         for(WeaponMount mount : mounts){
-            mount.rotation = rotation;
+            if(!mount.weapon.ignoreControl){
+                mount.rotation = rotation;
+            }
         }
     }
 
@@ -52,8 +54,10 @@ abstract class WeaponsComp implements Teamc, Posc, Rotc, Velc, Statusc{
 
     void controlWeapons(boolean rotate, boolean shoot){
         for(WeaponMount mount : mounts){
-            mount.rotate = rotate;
-            mount.shoot = shoot;
+            if(!mount.weapon.ignoreControl){
+                mount.rotate = rotate;
+                mount.shoot = shoot;
+            }
         }
         isRotate = rotate;
         isShooting = shoot;
@@ -72,8 +76,10 @@ abstract class WeaponsComp implements Teamc, Posc, Rotc, Velc, Statusc{
         y = Tmp.v1.y + this.y;
 
         for(WeaponMount mount : mounts){
-            mount.aimX = x;
-            mount.aimY = y;
+            if(!mount.weapon.ignoreControl){
+                mount.aimX = x;
+                mount.aimY = y;
+            }
         }
 
         aimX = x;

--- a/core/src/mindustry/entities/units/AIController.java
+++ b/core/src/mindustry/entities/units/AIController.java
@@ -116,7 +116,7 @@ public class AIController implements UnitController{
             float mountX = unit.x + Angles.trnsx(rotation, weapon.x, weapon.y),
                 mountY = unit.y + Angles.trnsy(rotation, weapon.x, weapon.y);
 
-            if(unit.type.singleTarget){
+            if(unit.type.singleTarget && !weapon.ignoreControl){
                 targets[i] = target;
             }else{
                 if(ret){

--- a/core/src/mindustry/type/Weapon.java
+++ b/core/src/mindustry/type/Weapon.java
@@ -88,6 +88,8 @@ public class Weapon{
     public StatusEffect shootStatus = StatusEffects.none;
     /** status effect duration when shot */
     public float shootStatusDuration = 60f * 5f;
+    /** weather the weapon should ignore mass control such as player or commander control */
+    public boolean ignoreControl = false;
 
     public Weapon(String name){
         this.name = name;


### PR DESCRIPTION
Allows weapons to ignore mass control, such as `singleTarget = true`, commander control, or player control.
[Video](https://youtu.be/HKTzDHnVBgQ)