### PR TITLE
fix the wrong unit ai path of mod content parser

### DIFF
--- a/core/src/mindustry/mod/ContentParser.java
+++ b/core/src/mindustry/mod/ContentParser.java
@@ -312,7 +312,7 @@ public class ContentParser{
                 }
 
                 if(value.has("controller")){
-                    unit.defaultController = make(resolve(value.getString("controller"), "mindustry.ai.type"));
+                    unit.defaultController = make(resolve(value.getString("controller"), "mindustry.ai.types"));
                 }
 
                 //read extra default waves


### PR DESCRIPTION
mod content parser use wrong package path to resolve the default unit controller. this should fix it