### PR TITLE
raw strings for SurfaceShaders 

### DIFF
--- a/core/src/mindustry/graphics/Shaders.java
+++ b/core/src/mindustry/graphics/Shaders.java
@@ -1,6 +1,7 @@
 package mindustry.graphics;
 
 import arc.*;
+import arc.files.Fi;
 import arc.graphics.*;
 import arc.graphics.Texture.*;
 import arc.graphics.g2d.*;
@@ -225,11 +226,18 @@ public class Shaders{
         }
     }
 
-    public static class SurfaceShader extends LoadShader{
-
+    public static class SurfaceShader extends Shader{
         public SurfaceShader(String frag){
-            super(frag, "screenspace");
+            super(getShaderFi("screenspace.vert"), getShaderFi(frag+".frag"));
+            loadNoise();
+        }
 
+        public SurfaceShader(String vertRaw, String fragRaw){
+            super(vertRaw, fragRaw);
+            loadNoise();
+        }
+
+        public void loadNoise(){
             Core.assets.load("sprites/noise.png", Texture.class).loaded = t -> {
                 ((Texture)t).setFilter(TextureFilter.linear);
                 ((Texture)t).setWrap(TextureWrap.repeat);
@@ -252,9 +260,12 @@ public class Shaders{
     }
 
     public static class LoadShader extends Shader{
-
         public LoadShader(String frag, String vert){
-            super(Core.files.internal("shaders/" + vert + ".vert"), Core.files.internal("shaders/" + frag + ".frag"));
+            super(getShaderFi(vert + ".vert"), getShaderFi(frag + ".frag"));
         }
+    }
+
+    public static Fi getShaderFi(String file){
+        return Core.files.internal("shaders/" + file);
     }
 }

--- a/core/src/mindustry/graphics/Shaders.java
+++ b/core/src/mindustry/graphics/Shaders.java
@@ -1,7 +1,7 @@
 package mindustry.graphics;
 
 import arc.*;
-import arc.files.Fi;
+import arc.files.*;
 import arc.graphics.*;
 import arc.graphics.Texture.*;
 import arc.graphics.g2d.*;

--- a/core/src/mindustry/mod/ContentParser.java
+++ b/core/src/mindustry/mod/ContentParser.java
@@ -312,7 +312,7 @@ public class ContentParser{
                 }
 
                 if(value.has("controller")){
-                    unit.defaultController = make(resolve(value.getString("controller"), "mindustry.ai.type"));
+                    unit.defaultController = make(resolve(value.getString("controller"), "mindustry.ai.types"));
                 }
 
                 //read extra default waves


### PR DESCRIPTION
This small pr allows Shaders.SurfaceShaders to be constructed with two Strings containing the raw shader code for modding purposes.
Mainly to turn this*
```js
var water = new Shader(readString("shaders/screenspace.vert"), readString("shaders/myWater.frag"));
Shaders.water = extend(Shaders.SurfaceShader, "water", {
	setVertexAttribute(name, size, type, normalize, stride, buffer) {
		water.setVertexAttribute(name, size, type, normalize, stride, buffer);
	},
	enableVertexAttribute(location){
		water.enableVertexAttribute(location);
	},
	disableVertexAttribute(name){
		water.disableVertexAttribute(name);
	},
	fetchUniformLocation(name, pedantic) {
		return water.fetchUniformLocation(name,pedantic);
	},
	getAttributeLocation(name){
		return water.getAttributeLocation(name);
	},
	getAttributes(){
		return water.getAttributes();
	},
	getUniforms(){
		return water.getUniforms();
	},
	getAttributeSize(name){
		return water.getAttributeSize(name);
	},
	bind(){
		water.bind();
	},
	hasUniform(name) {
		return water.hasUniform(name);
	},
	getUniformType(name) {
		return water.getUniformType(name);
	},
	getUniformLocation(name) {
		return water.getUniformLocation(name);
	},
	getUniformSize(name) {
		return water.getUniformSize(name);
	},
	dispose() {
		water.dispose();
		this.super$dispose();
	},
	isDisposed() {
		return water.isDisposed();
	}
});
```
into
```js
Shaders.water = new Shaders.SurfaceShader(readString("shaders/screenspace.vert"), readString("shaders/myWater.frag"));
```
Otherwise, no new functionality is added.

*The workaround code doesn't function fully either, as shaders are sometimes unbinding incorrectly.

