### PR TITLE
Update speed of junctions

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -982,7 +982,7 @@ public class Blocks implements ContentList{
 
         junction = new Junction("junction"){{
             requirements(Category.distribution, with(Items.copper, 2), true);
-            speed = 26;
+            speed = 13;
             capacity = 6;
             health = 30;
             buildCostMultiplier = 6f;


### PR DESCRIPTION
With the reduction of junction capacity their max transfer speed was also reduced, which breaks may factory designs. Made speed faster to compensate. Due to 121.3 patch notes I assume that the transfer speed change was unintentional? Please ignore if not.