### PR TITLE
Allow hidden blocks to be revealed by plugins

### DIFF
--- a/core/src/mindustry/game/Rules.java
+++ b/core/src/mindustry/game/Rules.java
@@ -80,6 +80,8 @@ public class Rules{
     public Seq<WeatherEntry> weather = new Seq<>(1);
     /** Blocks that cannot be placed. */
     public ObjectSet<Block> bannedBlocks = new ObjectSet<>();
+    /** Reveals blocks normally hidden by build visibility */
+    public ObjectSet<Block> revealedBlocks = new ObjectSet<>();
     /** Unlocked content names. Only used in multiplayer when the campaign is enabled. */
     public ObjectSet<String> researched = new ObjectSet<>();
     /** Whether ambient lighting is enabled. */

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -518,7 +518,7 @@ public class Block extends UnlockableContent{
     }
 
     public boolean isVisible(){
-        return buildVisibility.visible() && !isHidden();
+        return (buildVisibility.visible() || state.rules.revealedBlocks.contains(this)) && !isHidden();
     }
 
     public boolean isPlaceable(){
@@ -714,7 +714,7 @@ public class Block extends UnlockableContent{
 
     @Override
     public boolean isHidden(){
-        return !buildVisibility.visible();
+        return !buildVisibility.visible() && !state.rules.revealedBlocks.contains(this);
     }
 
     @Override


### PR DESCRIPTION
backstory: on nydus (bleeding edge) i often experiment with the hidden blocks like the forge, interplanetary accelerator, launchpads, etc, but to construct those i often come up with weird multiblock constructions or overriding existing blocks when placed, which is not ideal since it does not use the intended resources required for construction.

scope: this pull adds a custom rule that enables servers (with custom plugins can use, not much use outside of that for stuff like the 3 block payload ones) to make certain blocks visible without having to mess with sector rules or other weird server sided shenanigans, this would be a lovely solution.

technical: the check is duplicated in both the hidden and visible function since that is how its currently already doing it for just the buildvisibility check, mimicked that behaviour.

usage: probably not that much outside of servers that don't run specialized plugins to give the inert blocks some purpose, i forsee mostly myself using it on the aforementioned server, but its a relatively small chance to the code that won't really cause problems elsewhere or become totally unmanageable since its basically just 3 lines and won't get in the way anywhere. 

> rules add revealedBlocks [launch-pad]

![Screen Shot 2020-12-17 at 15 48 27](https://user-images.githubusercontent.com/3179271/102503624-34289b00-4080-11eb-915a-60e9fd52583a.png)
