### PR TITLE
Logic processor hollographic label

### DIFF
--- a/core/src/mindustry/graphics/Pal.java
+++ b/core/src/mindustry/graphics/Pal.java
@@ -100,6 +100,7 @@ public class Pal{
 	
     adminChat = Color.valueOf("ff4000"),
 
+    logicVerbose = Color.valueOf("808080"),
     logicBlocks = Color.valueOf("d4816b"),
     logicControl = Color.valueOf("6bb2b2"),
     logicOperations = Color.valueOf("877bad"),

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -16,6 +16,7 @@ import mindustry.gen.*;
 import mindustry.type.*;
 import mindustry.world.*;
 import mindustry.world.blocks.logic.*;
+import mindustry.world.blocks.logic.LogicBlock.*;
 import mindustry.world.blocks.logic.LogicDisplay.*;
 import mindustry.world.blocks.logic.MemoryBlock.*;
 import mindustry.world.blocks.logic.MessageBlock.*;
@@ -176,6 +177,23 @@ public class LExecutor{
 
     public interface LInstruction{
         void run(LExecutor exec);
+    }
+
+    public static class LabelI implements LInstruction{
+        public int p1;
+
+        public LabelI(int p1){
+            this.p1 = p1;
+        }
+
+        @Override
+        public void run(LExecutor exec){
+            int icon = exec.obj(p1) instanceof UnlockableContent u ? u.iconId : 0;
+
+            if(exec.building(varThis) instanceof LogicBuild){
+                ((LogicBuild) exec.building(varThis)).label = icon;
+            }
+        }
     }
 
     /** Binds the processor to a unit based on some filters. */

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -190,8 +190,8 @@ public class LExecutor{
         public void run(LExecutor exec){
             int icon = exec.obj(p1) instanceof UnlockableContent u ? u.iconId : 0;
 
-            if(exec.building(varThis) instanceof LogicBuild){
-                ((LogicBuild) exec.building(varThis)).label = icon;
+            if(exec.building(varThis) instanceof LogicBuild build){
+                build.label = icon;
             }
         }
     }

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -20,7 +20,7 @@ import static mindustry.world.blocks.logic.LogicDisplay.*;
 public class LStatements{
 
     //TODO broken
-    //@RegisterStatement("#")
+    @RegisterStatement("#")
     public static class CommentStatement extends LStatement{
         public String comment = "";
 
@@ -31,12 +31,37 @@ public class LStatements{
 
         @Override
         public Color color(){
-            return Pal.logicControl;
+            return Pal.logicVerbose;
         }
 
         @Override
         public LInstruction build(LAssembler builder){
             return null;
+        }
+    }
+
+    @RegisterStatement("label")
+    public static class LabelStatement extends LStatement{
+        public String image = "@crawler";
+
+//        @Override
+//        public void build(Table table){
+//            fields(table, "image", image, v -> image = v).width(240f);
+//        }
+
+        @Override
+        public void build(Table table){
+            table.area(image, Styles.nodeArea, v -> image = v).growX().height(45f).padLeft(2).padRight(6).color(table.color);
+        }
+
+        @Override
+        public LInstruction build(LAssembler builder){
+            return new LabelI(builder.var(image));
+        }
+
+        @Override
+        public Color color(){
+            return Pal.logicVerbose;
         }
     }
 

--- a/core/src/mindustry/world/blocks/logic/LogicBlock.java
+++ b/core/src/mindustry/world/blocks/logic/LogicBlock.java
@@ -1,6 +1,7 @@
 package mindustry.world.blocks.logic;
 
 import arc.func.*;
+import arc.graphics.g2d.*;
 import arc.math.geom.*;
 import arc.scene.ui.layout.*;
 import arc.struct.Bits;
@@ -194,6 +195,7 @@ public class LogicBlock extends Block{
         public LExecutor executor = new LExecutor();
         public float accumulator = 0;
         public Seq<LogicLink> links = new Seq<>();
+        public int label = 0;
 
         public void readCompressed(byte[] data, boolean relative){
             DataInputStream stream = new DataInputStream(new InflaterInputStream(new ByteArrayInputStream(data)));
@@ -423,6 +425,17 @@ public class LogicBlock extends Block{
                 copy.add(c);
             }
             return copy;
+        }
+
+        @Override
+        public void draw(){
+            super.draw();
+
+            if(label == 0) return;
+
+            Draw.alpha(0.75f);
+            Draw.rect(Fonts.logicIcon(label), x, y, 4 * size, 4 * size);
+            Draw.reset();
         }
 
         @Override


### PR DESCRIPTION
> not fit to be merged without further modification: imports / casting / comments / etc (mostly just a proof of concept)

**problem**
currently there is no way of knowing what processors do without opening them one by one.

**exhibit 1**
computer with a keyboard, tons of buttons that need their own message block:
(labeling anything other than processors is currently outside the scope)
https://cdn.discordapp.com/attachments/663063622791987203/789197420864602133/Mindustry_cYK2bm36BQ.png

**exhibit 2**
a thing that retreats units when their health is low, but no real sense as to which logic proccessor controls which type:
![Screen Shot 2020-12-18 at 13 58 57](https://user-images.githubusercontent.com/3179271/102617797-043dce00-413a-11eb-858d-657790c9feb7.png)

**exhibit 3**
a t5 feeder with 1 or 2 logic processors per resource, again no idea which one does what aside from bruteforce opening:
![](https://cdn.discordapp.com/attachments/640604827344306207/785159189529624576/img_850ae03e-0499-4d28-9a86-c78e19744bd8.png)

**concept**
being able to label processors (and possibly some other logic blocks?) with a sort of hologram of what they can do:
(ignore the display screens, was just debugging the drawing sizes with them)
![Screen Shot 2020-12-18 at 13 58 46](https://user-images.githubusercontent.com/3179271/102618076-6d254600-413a-11eb-8d05-37488ede2c89.png)

![Screen Shot 2020-12-18 at 13 59 11](https://user-images.githubusercontent.com/3179271/102618122-875f2400-413a-11eb-9ef7-b20a7f310b94.png)

![Screen Shot 2020-12-18 at 14 08 47](https://user-images.githubusercontent.com/3179271/102618137-9219b900-413a-11eb-9328-e392b4c68b3c.png)

**backstory**
took place on the nydus discord, shows some initial thoughts going on, somewhat different to what this resulted into:

<img width="856" alt="Screen Shot 2020-12-18 at 14 09 22" src="https://user-images.githubusercontent.com/3179271/102618261-c2f9ee00-413a-11eb-9525-f5f4b1c4cd72.png">

<img width="853" alt="Screen Shot 2020-12-18 at 14 09 50" src="https://user-images.githubusercontent.com/3179271/102618266-c3928480-413a-11eb-91e6-6c5fb0dceb58.png">

<img width="798" alt="Screen Shot 2020-12-18 at 14 10 01" src="https://user-images.githubusercontent.com/3179271/102618269-c42b1b00-413a-11eb-8546-abd7653bdb5a.png">

**technical**
- first time i tried adding logic, so i probably did it wrong
- intelij updated and broke a lot of stuff (red), so had to code blind, imports & castings might be sub-optimal
- enabled the commented out comment block to make the dialog look nice (and gave them both a new color)

**future**
no idea actually, its more of a concept at this point and it might be neat if the icons could be put on e.g. buttons to, or even persist in schematic previews or maybe even cycle through several, who knows, for now ima leave this as a discussion 🍿 
