### PR TITLE
Fix the two largest drills previewing ores in build requests

### DIFF
--- a/core/src/mindustry/world/blocks/production/Drill.java
+++ b/core/src/mindustry/world/blocks/production/Drill.java
@@ -77,7 +77,7 @@ public class Drill extends Block{
         if(tile == null) return;
 
         countOre(req.tile());
-        if(returnItem == null) return;
+        if(returnItem == null || !drawMineItem) return;
 
         Draw.color(returnItem.color);
         Draw.rect("drill-top", req.drawx(), req.drawy());


### PR DESCRIPTION
mildly related to #3889 , this won't be needed anymore if that passes, but this would still be good for other modded drills:

![Screen Shot 2020-12-18 at 16 21 20](https://user-images.githubusercontent.com/3179271/102630635-170dce00-414d-11eb-8b34-ae1f320949c9.png)

> this pic shows how it currently looks before fixing*