### PR TITLE
Draw item in the drill center when in place mode

### DIFF
--- a/core/src/mindustry/world/blocks/production/Drill.java
+++ b/core/src/mindustry/world/blocks/production/Drill.java
@@ -124,6 +124,12 @@ public class Drill extends Block{
             Draw.rect(returnItem.icon(Cicon.small), dx, dy - 1);
             Draw.reset();
             Draw.rect(returnItem.icon(Cicon.small), dx, dy);
+
+            if(drawMineItem){
+                Draw.color(returnItem.color);
+                Draw.rect("drill-top", tile.worldx() + offset, tile.worldy() + offset);
+                Draw.color();
+            }
         }else{
             Tile to = tile.getLinkedTilesAs(this, tempTiles).find(t -> t.drop() != null && t.drop().hardness > tier);
             Item item = to == null ? null : to.drop();

--- a/core/src/mindustry/world/blocks/production/Drill.java
+++ b/core/src/mindustry/world/blocks/production/Drill.java
@@ -127,7 +127,7 @@ public class Drill extends Block{
 
             if(drawMineItem){
                 Draw.color(returnItem.color);
-                Draw.rect("drill-top", tile.worldx() + offset, tile.worldy() + offset);
+                Draw.rect(itemRegion, tile.worldx() + offset, tile.worldy() + offset);
                 Draw.color();
             }
         }else{


### PR DESCRIPTION
drills show the preview item when built, or while in the build queue, but not yet while you hover with a fresh one:

before:
![Screen Shot 2020-12-20 at 18 30 39](https://user-images.githubusercontent.com/3179271/102720189-321a4280-42f3-11eb-8c6f-0288fe47b372.png)

during: (during development, this was when using the drawxy on the tile instance*)
![Screen Shot 2020-12-20 at 18 32 29](https://user-images.githubusercontent.com/3179271/102720193-347c9c80-42f3-11eb-89d2-9dad058f4228.png)

after:
![Screen Shot 2020-12-20 at 18 41 30](https://user-images.githubusercontent.com/3179271/102720190-334b6f80-42f3-11eb-9af0-0aed4b85da53.png)

