### PR TITLE
Allow plastanium conveyor to be unloaded

### DIFF
--- a/core/src/mindustry/world/blocks/distribution/StackConveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/StackConveyor.java
@@ -29,7 +29,7 @@ public class StackConveyor extends Block implements Autotiler{
 
     public float speed = 0f;
     public boolean splitOut = true;
-    /** (minimum) amount of loading docks needed to fill a line */
+    /** (minimum) amount of loading docks needed to fill a line. */
     public float recharge = 2f;
     public Effect loadEffect = Fx.plasticburn;
     public Effect unloadEffect = Fx.plasticburn;
@@ -46,7 +46,6 @@ public class StackConveyor extends Block implements Autotiler{
 
         ambientSound = Sounds.conveyor;
         ambientSoundVolume = 0.004f;
-        unloadable = false;
     }
 
     @Override
@@ -267,6 +266,11 @@ public class StackConveyor extends Block implements Autotiler{
             }finally{
                 if(items.empty()) poofOut();
             }
+        }
+
+        @Override
+        public void itemTaken(Item item){
+            if(items.empty()) poofOut();
         }
 
         @Override


### PR DESCRIPTION
> popularized by Natalie 🐬 on the discord: https://discord.com/channels/391020510269669376/391020510269669378/791240119927177246

not their original concept, but it would be very interesting to see this mechanic used in normal games:

https://user-images.githubusercontent.com/3179271/102984736-500fbf00-450e-11eb-9e67-f48b497a7809.mp4

since this is the alternative and its just horrendous to even look at: 

![Screen Shot 2020-12-23 at 11 03 06](https://user-images.githubusercontent.com/3179271/102984914-99600e80-450e-11eb-9f61-fc22d0c78d05.png)

> see the linked discord message and below it for some showcases, my video here just shows the one bug being fixed 🚭 
