### PR TITLE
Prevents plastanium conveyor unload exploit

### DIFF
--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -63,7 +63,6 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
     transient boolean enabled = true;
     transient float enabledControlTime;
     transient String lastAccessed;
-    transient boolean unloadable = true;
 
     PowerModule power;
     ItemModule items;
@@ -384,6 +383,10 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
 
     //endregion
     //region handler methods
+
+    public boolean unloadable(){
+        return block.unloadable;
+    }
 
     /** Called when an unloader takes an item. */
     public void itemTaken(Item item){

--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -384,7 +384,7 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
     //endregion
     //region handler methods
 
-    public boolean unloadable(){
+    public boolean canUnload(){
         return block.unloadable;
     }
 

--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -63,6 +63,7 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
     transient boolean enabled = true;
     transient float enabledControlTime;
     transient String lastAccessed;
+    transient boolean unloadable = true;
 
     PowerModule power;
     ItemModule items;

--- a/core/src/mindustry/world/blocks/distribution/StackConveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/StackConveyor.java
@@ -177,6 +177,8 @@ public class StackConveyor extends Block implements Autotiler{
                 }
                 proxUpdating = false;
             }
+
+            unloadable = state != stateLoad;
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/distribution/StackConveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/StackConveyor.java
@@ -180,7 +180,7 @@ public class StackConveyor extends Block implements Autotiler{
         }
 
         @Override
-        public boolean unloadable(){
+        public boolean canUnload(){
             return state != stateLoad;
         }
 

--- a/core/src/mindustry/world/blocks/distribution/StackConveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/StackConveyor.java
@@ -177,8 +177,11 @@ public class StackConveyor extends Block implements Autotiler{
                 }
                 proxUpdating = false;
             }
+        }
 
-            unloadable = state != stateLoad;
+        @Override
+        public boolean unloadable(){
+            return state != stateLoad;
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/storage/Unloader.java
+++ b/core/src/mindustry/world/blocks/storage/Unloader.java
@@ -61,7 +61,7 @@ public class Unloader extends Block{
                     int pos = (offset + i) % proximity.size;
                     var other = proximity.get(pos);
 
-                    if(other.interactable(team) && other.block.unloadable && other.unloadable && other.block.hasItems
+                    if(other.interactable(team) && other.block.unloadable && other.unloadable() && other.block.hasItems
                     && ((sortItem == null && other.items.total() > 0) || (sortItem != null && other.items.has(sortItem)))){
                         //make sure the item can't be dumped back into this block
                         dumpingTo = other;

--- a/core/src/mindustry/world/blocks/storage/Unloader.java
+++ b/core/src/mindustry/world/blocks/storage/Unloader.java
@@ -61,7 +61,7 @@ public class Unloader extends Block{
                     int pos = (offset + i) % proximity.size;
                     var other = proximity.get(pos);
 
-                    if(other.interactable(team) && other.block.unloadable && other.unloadable() && other.block.hasItems
+                    if(other.interactable(team) && other.block.unloadable && other.canUnload() && other.block.hasItems
                     && ((sortItem == null && other.items.total() > 0) || (sortItem != null && other.items.has(sortItem)))){
                         //make sure the item can't be dumped back into this block
                         dumpingTo = other;

--- a/core/src/mindustry/world/blocks/storage/Unloader.java
+++ b/core/src/mindustry/world/blocks/storage/Unloader.java
@@ -61,7 +61,7 @@ public class Unloader extends Block{
                     int pos = (offset + i) % proximity.size;
                     var other = proximity.get(pos);
 
-                    if(other.interactable(team) && other.block.unloadable && other.block.hasItems
+                    if(other.interactable(team) && other.block.unloadable && other.unloadable && other.block.hasItems
                     && ((sortItem == null && other.items.total() > 0) || (sortItem != null && other.items.has(sortItem)))){
                         //make sure the item can't be dumped back into this block
                         dumpingTo = other;


### PR DESCRIPTION
a strange instachain design popped up on the discord overnight:
(unloading straight from the loading dock itself / very fast / bad)

![](https://cdn.discordapp.com/attachments/422855426242248725/791459574523756554/unknown.png)

this pull adds an additional low performance (boolean instead of a function) check on the building entity itself.

currently that value is always true since the block itself needs to be unloadable anyways, and i wasn't sure about whether or not to add it to the create, init, or both (of buildingcomp), but that would be a mirrored redundant check, dunno about it 🤔 