### PR TITLE
Prevent visual plastanium conveyor glitch when disabled 🚥

### DIFF
--- a/core/src/mindustry/world/blocks/distribution/StackConveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/StackConveyor.java
@@ -180,13 +180,17 @@ public class StackConveyor extends Block implements Autotiler{
         }
 
         @Override
+        public float efficiency(){
+            return 1f;
+        }
+
+        @Override
         public void updateTile(){
             // reel in crater
             if(cooldown > 0f) cooldown = Mathf.clamp(cooldown - speed * edelta(), 0f, recharge);
 
-            if(link == -1){
-                return;
-            }
+            // indicates empty state
+            if(link == -1) return;
 
             // crater needs to be centered
             if(cooldown > 0f) return;
@@ -195,6 +199,9 @@ public class StackConveyor extends Block implements Autotiler{
             if(lastItem == null){
                 lastItem = items.first();
             }
+
+            // do not continue if disabled, will still allow one to be reeled in to prevent visual stacking
+            if(!enabled) return;
 
             if(state == stateUnload){ //unload
                 while(lastItem != null && (!splitOut ? moveForward(lastItem) : dump(lastItem))){


### PR DESCRIPTION
currently when you disable a `plastanium conveyor` it will stop moving in the roomba while the active ones behind still do.

this pull request hardcodes efficiency at `1f` (since it doesn't use power anyways) so the `edelta` can use it properly.

now when its `!enabled` it will simply prevent it from moving forward or unloading by itself, it will still allow them to park.

![Screen Shot 2020-12-24 at 11 46 41](https://user-images.githubusercontent.com/3179271/103084825-4191d800-45e0-11eb-8301-b7b71cdc2316.png)
![Screen Shot 2020-12-24 at 12 03 46](https://user-images.githubusercontent.com/3179271/103084826-422a6e80-45e0-11eb-9c09-3fc6de696708.png)
