### PR TITLE
Disable publichost on every startup

### DIFF
--- a/desktop/src/mindustry/desktop/DesktopLauncher.java
+++ b/desktop/src/mindustry/desktop/DesktopLauncher.java
@@ -103,10 +103,8 @@ public class DesktopLauncher extends ClientLauncher{
                 logSteamError(e);
             }
             
-            // Reset previous version settings
-            if(Version.build < 123){
-                Core.settings.put("publichost", false);
-            }
+            // Reset public host settings
+            Core.settings.put("publichost", false);
         }
     }
 

--- a/desktop/src/mindustry/desktop/DesktopLauncher.java
+++ b/desktop/src/mindustry/desktop/DesktopLauncher.java
@@ -104,7 +104,7 @@ public class DesktopLauncher extends ClientLauncher{
             }
             
             // Reset public host settings
-            Core.settings.put("publichost", false);
+            Core.settings.put("steampublic3", false);
         }
     }
 

--- a/desktop/src/mindustry/desktop/DesktopLauncher.java
+++ b/desktop/src/mindustry/desktop/DesktopLauncher.java
@@ -102,6 +102,11 @@ public class DesktopLauncher extends ClientLauncher{
                 Log.err("Failed to load Steam native libraries.");
                 logSteamError(e);
             }
+            
+            // Reset previous version settings
+            if(Version.build < 123){
+                Core.settings.put("publichost", false);
+            }
         }
     }
 


### PR DESCRIPTION
Updated the public server description, but to no avail if players don't see the message.
This resets the settings from the previous build and lets you see the popup again.