### PR TITLE
Critical BlockForge bugfix

### DIFF
--- a/core/src/mindustry/world/blocks/experimental/BlockForge.java
+++ b/core/src/mindustry/world/blocks/experimental/BlockForge.java
@@ -36,7 +36,10 @@ public class BlockForge extends PayloadAcceptor{
         hasPower = true;
         rotate = true;
 
-        config(Block.class, (BlockForgeBuild tile, Block block) -> tile.recipe = block);
+        config(Block.class, (BlockForgeBuild tile, Block block) -> {
+            if(tile.recipe != block) tile.progress = 0f;
+            tile.recipe = block;
+        });
 
         consumes.add(new ConsumeItemDynamic((BlockForgeBuild e) -> e.recipe != null ? e.recipe.requirements : ItemStack.empty));
     }
@@ -95,8 +98,6 @@ public class BlockForge extends PayloadAcceptor{
                     payVector.setZero();
                     progress = 0f;
                 }
-            }else{
-                progress = 0;
             }
 
             heat = Mathf.lerpDelta(heat, Mathf.num(produce), 0.3f);


### PR DESCRIPTION
Be amazed as you see 4 lines of code fix 4 bugs at once!
+ fixes the bug when you swap at the last moment, you get a free block.
+ fixes the bug that progress is reset when you minimize the window if the block has a liquidConsumer.
+ fixes the bug of progress not resetting in certain recipe swaps.
+ fixes the bug when a slight interruption causes a whole progress reset, which is abnormal behavior compared to other crafters.