### PR TITLE
Block loader/unloader progress bar changes

### DIFF
--- a/core/src/mindustry/world/blocks/experimental/BlockLoader.java
+++ b/core/src/mindustry/world/blocks/experimental/BlockLoader.java
@@ -1,5 +1,6 @@
 package mindustry.world.blocks.experimental;
 
+import arc.*;
 import arc.graphics.g2d.*;
 import arc.util.*;
 import mindustry.entities.units.*;
@@ -46,7 +47,7 @@ public class BlockLoader extends PayloadAcceptor{
     public void setBars(){
         super.setBars();
 
-        bars.add("progress", entity -> new Bar("bar.progress", Pal.ammo, ((BlockLoaderBuild)entity)::fraction));
+        bars.add("progress", (BlockLoaderBuild entity) -> new Bar(() -> Core.bundle.format("bar.items", entity.payload == null ? 0 : entity.payload.build.items.total()), () -> Pal.items, entity::fraction));
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/experimental/BlockUnloader.java
+++ b/core/src/mindustry/world/blocks/experimental/BlockUnloader.java
@@ -55,11 +55,6 @@ public class BlockUnloader extends BlockLoader{
         }
 
         @Override
-        public float fraction(){
-            return payload == null ? 0f : 1f - payload.build.items.total() / (float)payload.build.block.itemCapacity;
-        }
-
-        @Override
         public boolean shouldExport(){
             return payload != null && (payload.block().hasItems && payload.build.items.empty());
         }


### PR DESCRIPTION
ammo colored `Build progress` bar didn't make much sense in this block, so i changed it to the item colored `Items: {0}` one.
(also reverses the unloader bar since it goes up as items went down, now both bars do the same)

![Screen Shot 2020-12-27 at 11 31 50](https://user-images.githubusercontent.com/3179271/103168989-62546a80-4838-11eb-9e5b-7bfed0fcc71f.png)
![Screen Shot 2020-12-27 at 11 32 02](https://user-images.githubusercontent.com/3179271/103168991-62ed0100-4838-11eb-8c19-639e20986f70.png)
