### PR TITLE
locator 2: electric boogaloo

### DIFF
--- a/core/src/mindustry/graphics/MinimapRenderer.java
+++ b/core/src/mindustry/graphics/MinimapRenderer.java
@@ -10,6 +10,7 @@ import arc.scene.ui.layout.*;
 import arc.struct.*;
 import arc.util.*;
 import arc.util.pooling.*;
+import mindustry.ai.*;
 import mindustry.entities.*;
 import mindustry.game.EventType.*;
 import mindustry.gen.*;
@@ -109,6 +110,16 @@ public class MinimapRenderer implements Disposable{
                     drawLabel(x + rx, y + ry, player.name, player.team().color);
                 }
             }
+        }
+
+        if(withLabels && control.input.block != null){
+            indexer.eachBlock(player.team(), player.x, player.y, Math.max(world.width(), world.height()) * tilesize * 2, b -> b.block == control.input.block, b -> {
+
+                float rx = b.x / (world.width() * tilesize) * w;
+                float ry = b.y / (world.height() * tilesize) * h;
+
+                drawLabel(x + rx, y + ry, Fonts.getUnicodeStr(b.block.name), Color.white);
+            });
         }
 
         Draw.reset();

--- a/core/src/mindustry/graphics/MinimapRenderer.java
+++ b/core/src/mindustry/graphics/MinimapRenderer.java
@@ -115,11 +115,13 @@ public class MinimapRenderer implements Disposable{
         if(withLabels && control.input.block != null){
             indexer.eachBlock(player.team(), player.x, player.y, Math.max(world.width(), world.height()) * tilesize * 2, b -> b.block == control.input.block, b -> {
 
-                float rx = b.x / (world.width() * tilesize) * w;
-                float ry = b.y / (world.height() * tilesize) * h;
+                float rx = (b.x + (tilesize / 2f)) / (world.width() * tilesize) * w;
+                float ry = (b.y + (tilesize / 2f)) / (world.height() * tilesize) * h;
 
-                float scale = b.block.size * tilesize * scaling / 1.5f;
+                float scale = b.block.size * tilesize * scaling / 1.6f; // for some reason 1.6 is the magic number?
+//                Draw.alpha(0.75f);
                 Draw.rect(b.block.icon(Cicon.full), x + rx, y + ry, scale, scale, 0);
+//                Draw.alpha(1.00f);
             });
         }
 

--- a/core/src/mindustry/graphics/MinimapRenderer.java
+++ b/core/src/mindustry/graphics/MinimapRenderer.java
@@ -118,7 +118,8 @@ public class MinimapRenderer implements Disposable{
                 float rx = b.x / (world.width() * tilesize) * w;
                 float ry = b.y / (world.height() * tilesize) * h;
 
-                drawLabel(x + rx, y + ry, Fonts.getUnicodeStr(b.block.name), Color.white);
+                float scale = b.block.size * tilesize * scaling / 1.5f;
+                Draw.rect(b.block.icon(Cicon.full), x + rx + (tilesize / 2f), y + ry + (tilesize / 2f), scale, scale, 0);
             });
         }
 

--- a/core/src/mindustry/graphics/MinimapRenderer.java
+++ b/core/src/mindustry/graphics/MinimapRenderer.java
@@ -119,7 +119,7 @@ public class MinimapRenderer implements Disposable{
                 float ry = b.y / (world.height() * tilesize) * h;
 
                 float scale = b.block.size * tilesize * scaling / 1.5f;
-                Draw.rect(b.block.icon(Cicon.full), x + rx + (tilesize / 2f), y + ry + (tilesize / 2f), scale, scale, 0);
+                Draw.rect(b.block.icon(Cicon.full), x + rx, y + ry, scale, scale, 0);
             });
         }
 


### PR DESCRIPTION
recreating #915, but this time it shows all the blocks on the minimap when you select any block to build with.

notable differences:
- works not just for mechpads
- minimap instead of arrows

todo:
- cache the results with an interval timer or just once each time you toggle open the minimap
- align the emojis better with the blocks since currently they are off
- maybe draw the actual texture over the exact pixels on the minimap?

currently leaving this in draft mode while i figure out what to do next, since minimap stuff & textures confuse me 🤔 
(discussion & suggestions more than welcome)

![Screen Shot 2020-12-27 at 17 04 47](https://user-images.githubusercontent.com/3179271/103174861-eb35cb00-4865-11eb-8cec-4c67a9fec0fd.png)
![Screen Shot 2020-12-27 at 17 04 51](https://user-images.githubusercontent.com/3179271/103174863-ee30bb80-4865-11eb-8d54-cc72d3913ddf.png)
