### PR TITLE
Draw reconstructor in region during placement & unconnected

### DIFF
--- a/core/src/mindustry/world/blocks/experimental/BlockLoader.java
+++ b/core/src/mindustry/world/blocks/experimental/BlockLoader.java
@@ -52,6 +52,7 @@ public class BlockLoader extends PayloadAcceptor{
     @Override
     public void drawRequestRegion(BuildPlan req, Eachable<BuildPlan> list){
         Draw.rect(region, req.drawx(), req.drawy());
+        Draw.rect(inRegion, req.drawx(), req.drawy(), req.rotation * 90);
         Draw.rect(outRegion, req.drawx(), req.drawy(), req.rotation * 90);
         Draw.rect(topRegion, req.drawx(), req.drawy());
     }
@@ -76,11 +77,14 @@ public class BlockLoader extends PayloadAcceptor{
             Draw.rect(region, x, y);
 
             //draw input
+            boolean fallback = true;
             for(int i = 0; i < 4; i++){
                 if(blends(i) && i != rotation){
                     Draw.rect(inRegion, x, y, (i * 90) - 180);
+                    fallback = false;
                 }
             }
+            if(fallback) Draw.rect(inRegion, x, y, rotation * 90);
 
             Draw.rect(outRegion, x, y, rotdeg());
 

--- a/core/src/mindustry/world/blocks/units/Reconstructor.java
+++ b/core/src/mindustry/world/blocks/units/Reconstructor.java
@@ -33,6 +33,7 @@ public class Reconstructor extends UnitBlock{
     @Override
     public void drawRequestRegion(BuildPlan req, Eachable<BuildPlan> list){
         Draw.rect(region, req.drawx(), req.drawy());
+        Draw.rect(inRegion, req.drawx(), req.drawy(), req.rotation * 90);
         Draw.rect(outRegion, req.drawx(), req.drawy(), req.rotation * 90);
         Draw.rect(topRegion, req.drawx(), req.drawy());
     }
@@ -127,11 +128,14 @@ public class Reconstructor extends UnitBlock{
             Draw.rect(region, x, y);
 
             //draw input
+            boolean fallback = true;
             for(int i = 0; i < 4; i++){
                 if(blends(i) && i != rotation){
                     Draw.rect(inRegion, x, y, (i * 90) - 180);
+                    fallback = false;
                 }
             }
+            if(fallback) Draw.rect(inRegion, x, y, rotation * 90);
 
             Draw.rect(outRegion, x, y, rotdeg());
 


### PR DESCRIPTION
if no input side is connected it defaults to back input during placement & existing:

![Screen Shot 2020-12-27 at 19 20 14](https://user-images.githubusercontent.com/3179271/103177201-93ed2600-4878-11eb-8679-59262aab0454.png)

