### PR TITLE
outputSize stat for Block Forge

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -706,6 +706,7 @@ stat.abilities = Abilities
 stat.canboost = Can Boost
 stat.flying = Flying
 stat.ammouse = Ammo Use
+stat.outputblocksize = Output Size
 
 ability.forcefield = Force Field
 ability.repairfield = Repair Field

--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -644,6 +644,7 @@ block.unknown = [lightgray]???
 stat.description = Purpose
 stat.input = Input
 stat.output = Output
+stat.outputsize = Output Size
 stat.booster = Booster
 stat.tiles = Required Tiles
 stat.affinities = Affinities
@@ -706,7 +707,6 @@ stat.abilities = Abilities
 stat.canboost = Can Boost
 stat.flying = Flying
 stat.ammouse = Ammo Use
-stat.outputblocksize = Output Size
 
 ability.forcefield = Force Field
 ability.repairfield = Repair Field

--- a/core/assets/bundles/bundle_ko.properties
+++ b/core/assets/bundles/bundle_ko.properties
@@ -644,6 +644,7 @@ block.unknown = [lightgray]???
 stat.description = 특성
 stat.input = 입력
 stat.output = 출력
+stat.outputsize = 출력 크기
 stat.booster = 가속
 stat.tiles = 필요한 타일
 stat.affinities = 친화력

--- a/core/src/mindustry/world/blocks/experimental/BlockForge.java
+++ b/core/src/mindustry/world/blocks/experimental/BlockForge.java
@@ -18,6 +18,7 @@ import mindustry.world.blocks.*;
 import mindustry.world.blocks.payloads.*;
 import mindustry.world.blocks.production.*;
 import mindustry.world.consumers.*;
+import mindustry.world.meta.*
 
 import static mindustry.Vars.*;
 

--- a/core/src/mindustry/world/blocks/experimental/BlockForge.java
+++ b/core/src/mindustry/world/blocks/experimental/BlockForge.java
@@ -18,7 +18,7 @@ import mindustry.world.blocks.*;
 import mindustry.world.blocks.payloads.*;
 import mindustry.world.blocks.production.*;
 import mindustry.world.consumers.*;
-import mindustry.world.meta.*
+import mindustry.world.meta.*;
 
 import static mindustry.Vars.*;
 

--- a/core/src/mindustry/world/blocks/experimental/BlockForge.java
+++ b/core/src/mindustry/world/blocks/experimental/BlockForge.java
@@ -48,6 +48,13 @@ public class BlockForge extends PayloadAcceptor{
     public TextureRegion[] icons(){
         return new TextureRegion[]{region, outRegion};
     }
+    
+    @Override
+    public void setStats(){
+        super.setStats();
+
+        stats.add(Stat.outputSize, "@x@ ~ @x@", minBlockSize, minBlockSize, maxBlockSize, maxBlockSize);
+    }
 
     @Override
     public void setBars(){

--- a/core/src/mindustry/world/meta/Stat.java
+++ b/core/src/mindustry/world/meta/Stat.java
@@ -54,7 +54,7 @@ public enum Stat{
     maxUnits(StatCat.crafting),
     linkRange(StatCat.crafting),
     instructions(StatCat.crafting),
-    outputBlockSize(StatCat.crafting),
+    outputSize(StatCat.crafting),
 
     weapons(StatCat.function),
     bullet(StatCat.function),

--- a/core/src/mindustry/world/meta/Stat.java
+++ b/core/src/mindustry/world/meta/Stat.java
@@ -54,6 +54,7 @@ public enum Stat{
     maxUnits(StatCat.crafting),
     linkRange(StatCat.crafting),
     instructions(StatCat.crafting),
+    outputBlockSize(StatCat.crafting),
 
     weapons(StatCat.function),
     bullet(StatCat.function),

--- a/core/src/mindustry/world/meta/StatUnit.java
+++ b/core/src/mindustry/world/meta/StatUnit.java
@@ -10,7 +10,7 @@ import java.util.*;
 public enum StatUnit{
     blocks,
     blocksSquared,
-    minMaxBlocksSquared,
+    blocksSquaredRange,
     powerSecond,
     liquidSecond,
     itemsSecond,

--- a/core/src/mindustry/world/meta/StatUnit.java
+++ b/core/src/mindustry/world/meta/StatUnit.java
@@ -10,7 +10,6 @@ import java.util.*;
 public enum StatUnit{
     blocks,
     blocksSquared,
-    blocksSquaredRange,
     powerSecond,
     liquidSecond,
     itemsSecond,

--- a/core/src/mindustry/world/meta/StatUnit.java
+++ b/core/src/mindustry/world/meta/StatUnit.java
@@ -10,6 +10,7 @@ import java.util.*;
 public enum StatUnit{
     blocks,
     blocksSquared,
+    minMaxBlocksSquared,
     powerSecond,
     liquidSecond,
     itemsSecond,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/58885089/103256965-9499cf80-49d2-11eb-9564-2dd6b61e11bd.png)
*( This but .replace("Output", "Output Size"); )*
+ Adds stat.outputSize and used it for Block Forge.
+ Name is not *too* specific (outputSize and not outputBlockSize) so it can be utilized by mods, or later with a different purpose, such as payload size or unit size.
+ Comes with ~~brazil~~ korean.