### PR TITLE
Display unit cap modifier for core blocks

### DIFF
--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -376,7 +376,7 @@ public class Block extends UnlockableContent{
             bars.add("items", entity -> new Bar(() -> Core.bundle.format("bar.items", entity.items.total()), () -> Pal.items, () -> (float)entity.items.total() / itemCapacity));
         }
         
-        if(flags.contains(BlockFlag.unitModifier)) stats.add(Stat.maxUnits, Strings.format("@ @", unitCapModifier < 0 ? '-' : '+', Math.abs(unitCapModifier)));
+        if(flags.contains(BlockFlag.unitModifier)) stats.add(Stat.maxUnits, (unitCapModifier < 0 ? "-" : "+") + Math.abs(unitCapModifier));
     }
 
     public boolean canReplace(Block other){

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -375,6 +375,8 @@ public class Block extends UnlockableContent{
         if(hasItems && configurable){
             bars.add("items", entity -> new Bar(() -> Core.bundle.format("bar.items", entity.items.total()), () -> Pal.items, () -> (float)entity.items.total() / itemCapacity));
         }
+        
+        if(flags.contains(BlockFlag.unitModifier)) stats.add(Stat.maxUnits, Strings.format("@ @", unitCapModifier < 0 ? '-' : '+', Math.abs(unitCapModifier)));
     }
 
     public boolean canReplace(Block other){

--- a/core/src/mindustry/world/meta/Stat.java
+++ b/core/src/mindustry/world/meta/Stat.java
@@ -30,6 +30,7 @@ public enum Stat{
     lightningDamage,
     abilities,
     canBoost,
+    maxUnits,
 
     itemCapacity(StatCat.items),
     itemsMoved(StatCat.items),
@@ -51,7 +52,6 @@ public enum Stat{
     productionTime(StatCat.crafting),
     drillTier(StatCat.crafting),
     drillSpeed(StatCat.crafting),
-    maxUnits(StatCat.crafting),
     linkRange(StatCat.crafting),
     instructions(StatCat.crafting),
 


### PR DESCRIPTION
> core shard set to negative just for the screenshot*

- not sure if a new category like "special" is needed, housing it under general for now
- there is probably a shortcut for `< 0 ? '-' : '+'` somewhere that i haven't found yet
- maybe a slight bundle change is needed, not sure if the current value reflects it

![Screen Shot 2020-12-29 at 10 22 56](https://user-images.githubusercontent.com/3179271/103273620-0c123380-49c0-11eb-89c8-4f8b531a6abb.png)
![Screen Shot 2020-12-29 at 10 23 02](https://user-images.githubusercontent.com/3179271/103273624-0e748d80-49c0-11eb-8e80-a08ec2c02fa1.png)
![Screen Shot 2020-12-29 at 10 23 08](https://user-images.githubusercontent.com/3179271/103273625-0f0d2400-49c0-11eb-807d-0c83eedf1220.png)
