### PR TITLE
Fix block status of repair point and battery

### DIFF
--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -358,6 +358,10 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
         return power != null && (block.consumes.has(ConsumeType.power) && !block.consumes.getPower().buffered) ? power.status : 1f;
     }
 
+    public BlockStatus status(){
+        return cons.status();
+    }
+
     /** Call when nothing is happening to the entity. This increments the internal sleep timer. */
     public void sleep(){
         sleepTime += Time.delta;
@@ -812,7 +816,7 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
             Draw.z(Layer.power + 1);
             Draw.color(Pal.gray);
             Fill.square(brcx, brcy, 2.5f, 45);
-            Draw.color(cons.status().color);
+            Draw.color(status().color);
             Fill.square(brcx, brcy, 1.5f, 45);
             Draw.color();
         }

--- a/core/src/mindustry/world/blocks/power/Battery.java
+++ b/core/src/mindustry/world/blocks/power/Battery.java
@@ -45,8 +45,8 @@ public class Battery extends PowerDistributor{
 
         @Override
         public BlockStatus status(){
-            if(power.status == 0f) return BlockStatus.noInput;
-            if(power.status == 1f) return BlockStatus.active;
+            if(Mathf.equal(power.status, 0f, 0.01f)) return BlockStatus.noInput;
+            if(Mathf.equal(power.status, 1f, 0.01f)) return BlockStatus.active;
             return BlockStatus.noOutput;
         }
     }

--- a/core/src/mindustry/world/blocks/power/Battery.java
+++ b/core/src/mindustry/world/blocks/power/Battery.java
@@ -42,5 +42,12 @@ public class Battery extends PowerDistributor{
                 }
             }
         }
+
+        @Override
+        public BlockStatus status(){
+            if(power.status == 0f) return BlockStatus.noInput;
+            if(power.status == 1f) return BlockStatus.active;
+            return BlockStatus.noOutput;
+        }
     }
 }

--- a/core/src/mindustry/world/blocks/units/RepairPoint.java
+++ b/core/src/mindustry/world/blocks/units/RepairPoint.java
@@ -118,5 +118,10 @@ public class RepairPoint extends Block{
         public boolean shouldConsume(){
             return target != null && enabled;
         }
+
+        @Override
+        public BlockStatus status(){
+            return efficiency() == 0f ? BlockStatus.noInput : cons.status();
+        }
     }
 }

--- a/core/src/mindustry/world/blocks/units/RepairPoint.java
+++ b/core/src/mindustry/world/blocks/units/RepairPoint.java
@@ -121,7 +121,7 @@ public class RepairPoint extends Block{
 
         @Override
         public BlockStatus status(){
-            return efficiency() == 0f ? BlockStatus.noInput : cons.status();
+            return Mathf.equal(efficiency(), 0f, 0.01f) ? BlockStatus.noInput : cons.status();
         }
     }
 }


### PR DESCRIPTION
previously the repair point was always orange, this makes it red while it has no power:

![Screen Shot 2020-12-30 at 18 24 33](https://user-images.githubusercontent.com/3179271/103370536-592ffb80-4acd-11eb-8e56-e48dd7f14438.png)
![Screen Shot 2020-12-30 at 18 24 36](https://user-images.githubusercontent.com/3179271/103370540-5af9bf00-4acd-11eb-9d9d-150b1417b97a.png)

previously batteries always showed a green status, now its green when full, red when empty & orange anywhere in between:
![Screen Shot 2020-12-30 at 18 31 58](https://user-images.githubusercontent.com/3179271/103370541-5b925580-4acd-11eb-81ef-af7e369854ec.png)
