### PR TITLE
Remove turret1 from uradar

### DIFF
--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -387,13 +387,15 @@ public class LStatements{
     public static class RadarStatement extends LStatement{
         public RadarTarget target1 = RadarTarget.enemy, target2 = RadarTarget.any, target3 = RadarTarget.any;
         public RadarSort sort = RadarSort.distance;
-        public String radar = "turret1", sortOrder = "1", output = "result";
+        public String radar = "0", sortOrder = "1", output = "result";
 
         @Override
         public void build(Table table){
             table.defaults().left();
 
             if(buildFrom()){
+                radar = "turret1";
+
                 table.add(" from ");
 
                 fields(table, radar, v -> radar = v);


### PR DESCRIPTION
This PR changes `uradar`'s disabled `from` parameter's default value from "turret1" to "0".

`uradar` extends `radar`, thus inheriting all its default parameters. The `from` parameter does nothing in `uradar`, yet it is still prefilled with "turret1", which misleads players into thinking that this is some kind of hidden or "easter egg" parameter, as seen [here](https://youtu.be/EDfv_oM_TbE?t=4469). It also bloats schematic files with unnecessary bytes. The leftover "turret1" can be seen when copying logic code to the clipboard.

Before:
```py
uradar enemy any any distance turret1 1 result
```

After:
```py
uradar enemy any any distance 0 1 result
```