### PR TITLE
Logic: Fix radar from value bug

### DIFF
--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -387,15 +387,13 @@ public class LStatements{
     public static class RadarStatement extends LStatement{
         public RadarTarget target1 = RadarTarget.enemy, target2 = RadarTarget.any, target3 = RadarTarget.any;
         public RadarSort sort = RadarSort.distance;
-        public String radar = "0", sortOrder = "1", output = "result";
+        public String radar = "turret1", sortOrder = "1", output = "result";
 
         @Override
         public void build(Table table){
             table.defaults().left();
 
             if(buildFrom()){
-                radar = "turret1";
-
                 table.add(" from ");
 
                 fields(table, radar, v -> radar = v);
@@ -820,6 +818,7 @@ public class LStatements{
 
     @RegisterStatement("uradar")
     public static class UnitRadarStatement extends RadarStatement{
+        public String radar = "0";
 
         @Override
         public boolean buildFrom(){

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -818,7 +818,10 @@ public class LStatements{
 
     @RegisterStatement("uradar")
     public static class UnitRadarStatement extends RadarStatement{
-        public String radar = "0";
+
+        public UnitRadarStatement(){
+            radar = "0";
+        }
 
         @Override
         public boolean buildFrom(){


### PR DESCRIPTION
This PR fixes a bug I created in #4207.

Currently, the `from` field of `radar` instantly resets to its default value of `turret1` whenever the edit panel of a processor is opened, because the variable is being reinitialized every time the panel is rendered.