### PR TITLE
Allow for core incineration via rules

### DIFF
--- a/core/src/mindustry/game/Rules.java
+++ b/core/src/mindustry/game/Rules.java
@@ -97,6 +97,8 @@ public class Rules{
     public Team waveTeam = Team.crux;
     /** name of the custom mode that this ruleset describes, or null. */
     public @Nullable String modeName;
+    /** Whether cores incinerate items when full, just like in the campaign. */
+    public boolean coreIncinerates = false;
     /** special tags for additional info. */
     public StringMap tags = new StringMap();
 

--- a/core/src/mindustry/world/blocks/storage/CoreBlock.java
+++ b/core/src/mindustry/world/blocks/storage/CoreBlock.java
@@ -319,7 +319,7 @@ public class CoreBlock extends StorageBlock{
         }
 
         public boolean incinerate(){
-            return state.isCampaign();
+            return state.isCampaign() || state.rules.coreIncinerates;
         }
 
         @Override


### PR DESCRIPTION
i would like to be able to play with core incineration on the nydus bleeding edge server:

- once the core is full of something that production chain turns off, possibly causing power issues when some turn back on.
- makes mixed conveyors (e.g. lead with glass) less of a problem when the core eventually fills up with something.
- adds a nice challenge of having to balance production: not to little but also not too much
- possibly brings some more logic into play, like disabling a conveyor once the core is full
- no more need for impractical overflow + incinerator setups near the core
- makes it more in like with what is expected through playing the campaign
- maybe a few unforseen meta changes due to sideeffects, will be interesting
- currently a base level rule instead of team rule, maybe some map makers would like it overridable per team though?
- generally just interesting to experiment with, would be nice to have this for the time being on bleeding edge
- yes, i could have just written a plugin that constantly sets it back to like 100 below the cap and spawn particles, but spamming all those packets is just not very efficient while a relatively harmful rule addition is objectively better

(false by default of course, its an opt-in)

![Screen Shot 2021-01-03 at 11 44 36](https://user-images.githubusercontent.com/3179271/103476809-16b23b80-4db9-11eb-9a07-00b41a78b9f9.png)

> naming might not be the best, could imply on whether or not the core is susceptible or not to catching fire 🔥 