### PR TITLE
Adds Call#clearItems

### DIFF
--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -100,6 +100,12 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         if(build == null || build.items == null) return;
         build.items.set(item, amount);
     }
+    
+    @Remote(called = Loc.server, unreliable = true)
+    public static void clearItems(Building build){
+        if(build == null || build.items == null) return;
+        build.items.clear();
+    }
 
     @Remote(called = Loc.server, unreliable = true)
     public static void transferItemTo(@Nullable Unit unit, Item item, int amount, float x, float y, Building build){


### PR DESCRIPTION
https://github.com/Anuken/Mindustry/commit/6b3919e8f73bd1224356a954277f4a21d20e3b1d is great for when you need to modify one item, but not in bulk.

exhibit 1:

on nydus bleeding edge the launchpads can send items to the core, but the launchpad inherently allows for mixed items:
```
                items.each((item, amount) -> {
                    core.items.add(item, amount);
                    Call.setItem(this, item, 0);
                });
```
this results in multiple calls to get the intended result, which is a bit of a packet waste.

exhibit 2:

lets say for example you want to clear out a seperator for whatever reason, those items aren't sinced with the server so you can't do 1 call for each item present in it serverside, but you have to run it for each possible item.

a workaround for this could be the `send block snapshot` function (which i have modified on nydus v5 & v6 so it can run every tick if something is pushed to its queue), but that sends the entirety of the stream again while you just want to clear the items.

so:

this call will just be a performance shortcut, i can live without it just perfectly but it would be nice to have on board ⛵ 