### PR TITLE
Make rotation via construction emit effect & sound

### DIFF
--- a/core/src/mindustry/world/Build.java
+++ b/core/src/mindustry/world/Build.java
@@ -69,6 +69,7 @@ public class Build{
         if(tile.team() == team && tile.block == result && tile.build != null && tile.block.quickRotate){
             if(unit != null && unit.getControllerName() != null) tile.build.lastAccessed = unit.getControllerName();
             tile.build.rotation = Mathf.mod(rotation, 4);
+            ConstructBlock.rotateFinish(tile);
             tile.build.updateProximity();
             tile.build.noSleep();
             return;

--- a/core/src/mindustry/world/blocks/ConstructBlock.java
+++ b/core/src/mindustry/world/blocks/ConstructBlock.java
@@ -92,6 +92,11 @@ public class ConstructBlock extends Block{
         if(shouldPlay()) Sounds.place.at(tile, calcPitch(true));
     }
 
+    public static void rotateFinish(Tile tile){
+        Fx.placeBlock.at(tile.drawx(), tile.drawy(), tile.block().size);
+        if(shouldPlay()) Sounds.place.at(tile, calcPitch(true));
+    }
+
     static boolean shouldPlay(){
         if(Time.timeSinceMillis(lastPlayed) >= 32){
             lastPlayed = Time.millis();


### PR DESCRIPTION
currently when you build over something with a different rotation it just shows the beams and it happening, but no visual ques.

this pull makes it so that when its being rotated via construction that it shows the construction effect & sound.
(rotation via the mouse wheel is exempt)

this was the cleanest place to add the sound hooks in (due to shouldplay and pitch being private), instead of moving the entire function over here, and on first glance it might look as though scroll wheel rotate triggers this too, which it does not.

in short, this will make it feel better when you rotate lots of stuff like a bunch of conveyors in bulk.