### PR TITLE
Fix mirror being offset

### DIFF
--- a/core/src/mindustry/maps/filters/MirrorFilter.java
+++ b/core/src/mindustry/maps/filters/MirrorFilter.java
@@ -68,8 +68,8 @@ public class MirrorFilter extends GenerateFilter{
     void mirror(Vec2 p, float x0, float y0, float x1, float y1){
         //special case: uneven map mirrored at 45 degree angle
         if(in.width != in.height && angle % 90 != 0){
-            p.x = (p.x - in.width/2f) * -1 + in.width/2f;
-            p.y = (p.y - in.height/2f) * -1 + in.height/2f;
+            p.x = in.width - p.x - 1;
+            p.y = in.height - p.y - 1;
         }else{
             float dx = x1 - x0;
             float dy = y1 - y0;


### PR DESCRIPTION
Because apparently it isn't a valid map even though its been a known issue for months.
P.S. Notice how in the original code `in.width/2` is being added twice... and so is `in.height/2` what is the point of that?