### PR TITLE
Add boost bars to overdrive projectors

### DIFF
--- a/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
+++ b/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
@@ -1,14 +1,15 @@
 package mindustry.world.blocks.defense;
 
+import arc.*;
 import arc.graphics.*;
 import arc.graphics.g2d.*;
 import arc.math.*;
 import arc.util.*;
 import arc.util.io.*;
 import mindustry.annotations.Annotations.*;
-import mindustry.gen.*;
 import mindustry.graphics.*;
 import mindustry.logic.*;
+import mindustry.ui.*;
 import mindustry.world.*;
 import mindustry.world.meta.*;
 
@@ -62,6 +63,12 @@ public class OverdriveProjector extends Block{
         }
     }
 
+    @Override
+    public void setBars(){
+        super.setBars();
+        bars.add("boost", (OverdriveBuild entity) -> new Bar(() -> Core.bundle.format("bar.boost", (int)(entity.realBoost() * 100)), () -> Pal.accent, () -> entity.realBoost() / (hasBoost ? speedBoost + speedBoostPhase : speedBoost)));
+    }
+
     public class OverdriveBuild extends Building implements Ranged{
         float heat;
         float charge = Mathf.random(reload);
@@ -88,17 +95,20 @@ public class OverdriveProjector extends Block{
                 phaseHeat = Mathf.lerpDelta(phaseHeat, Mathf.num(cons.optionalValid()), 0.1f);
             }
 
+            if(charge >= reload){
+                float realRange = range + phaseHeat * phaseRangeBoost;
+
+                charge = 0f;
+                indexer.eachBlock(this, realRange, other -> true, other -> other.applyBoost(realBoost(), reload + 1f));
+            }
+
             if(timer(timerUse, useTime) && efficiency() > 0 && consValid()){
                 consume();
             }
+        }
 
-            if(charge >= reload){
-                float realRange = range + phaseHeat * phaseRangeBoost;
-                float realBoost = (speedBoost + phaseHeat * speedBoostPhase) * efficiency();
-
-                charge = 0f;
-                indexer.eachBlock(this, realRange, other -> true, other -> other.applyBoost(realBoost, reload + 1f));
-            }
+        public float realBoost(){
+            return consValid() ? (speedBoost + phaseHeat * speedBoostPhase) * efficiency() : 0f;
         }
 
         @Override


### PR DESCRIPTION
would be nice to see the current boost percentage of the overdrive projectors, since cross referencing the core database doesn't give you a clear enough picture:

![Screen Shot 2021-01-04 at 11 29 25](https://user-images.githubusercontent.com/3179271/103526610-74aa5600-4e81-11eb-80e8-b81b5349c2d9.png)
![Screen Shot 2021-01-04 at 11 29 33](https://user-images.githubusercontent.com/3179271/103526615-76741980-4e81-11eb-98d1-be7b3fa3826d.png)
![Screen Shot 2021-01-04 at 11 29 53](https://user-images.githubusercontent.com/3179271/103526616-77a54680-4e81-11eb-80e4-6bfc26849a20.png)
![Screen Shot 2021-01-04 at 11 30 03](https://user-images.githubusercontent.com/3179271/103526619-783ddd00-4e81-11eb-9a57-4cc9b22a780d.png)
![Screen Shot 2021-01-04 at 11 30 52](https://user-images.githubusercontent.com/3179271/103526621-78d67380-4e81-11eb-86bc-40ec9b840df4.png)
![Screen Shot 2021-01-04 at 11 36 24](https://user-images.githubusercontent.com/3179271/103526625-7aa03700-4e81-11eb-9e5c-d141c7456749.png)

> consume moved down due to a consvalid race condition with the overdrive dome*

![Screen Shot 2021-01-04 at 11 32 26](https://user-images.githubusercontent.com/3179271/103526584-6ceab180-4e81-11eb-8472-f9516f8f571d.png)
