### PR TITLE
Highlight all linked inventories on core selection

### DIFF
--- a/core/src/mindustry/world/blocks/storage/CoreBlock.java
+++ b/core/src/mindustry/world/blocks/storage/CoreBlock.java
@@ -48,7 +48,7 @@ public class CoreBlock extends StorageBlock{
         update = true;
         hasItems = true;
         priority = TargetPriority.core;
-        flags = EnumSet.of(BlockFlag.core, BlockFlag.unitModifier);
+        flags = EnumSet.of(BlockFlag.core, BlockFlag.unitModifier, BlockFlag.storage);
         unitCapModifier = 10;
         loopSound = Sounds.respawning;
         loopSoundVolume = 1f;
@@ -296,17 +296,16 @@ public class CoreBlock extends StorageBlock{
         @Override
         public void drawSelect(){
             Lines.stroke(1f, Pal.accent);
-            Cons<Building> outline = t -> {
+            Cons<Building> outline = b -> {
                 for(int i = 0; i < 4; i++){
                     Point2 p = Geometry.d8edge[i];
-                    float offset = -Math.max(t.block.size - 1, 0) / 2f * tilesize;
-                    Draw.rect("block-select", t.x + offset * p.x, t.y + offset * p.y, i * 90);
+                    float offset = -Math.max(b.block.size - 1, 0) / 2f * tilesize;
+                    Draw.rect("block-select", b.x + offset * p.x, b.y + offset * p.y, i * 90);
                 }
             };
-            if(proximity.contains(e -> owns(e) && e.items == items)){
-                outline.get(this);
+            for(Tile other : indexer.getAllied(team, BlockFlag.storage)){
+                if(other.build != null && other.build.items == items) outline.get(other.build);
             }
-            proximity.each(e -> owns(e) && e.items == items, outline);
             Draw.reset();
         }
 

--- a/core/src/mindustry/world/blocks/storage/CoreBlock.java
+++ b/core/src/mindustry/world/blocks/storage/CoreBlock.java
@@ -48,7 +48,7 @@ public class CoreBlock extends StorageBlock{
         update = true;
         hasItems = true;
         priority = TargetPriority.core;
-        flags = EnumSet.of(BlockFlag.core, BlockFlag.unitModifier, BlockFlag.storage);
+        flags = EnumSet.of(BlockFlag.core, BlockFlag.unitModifier);
         unitCapModifier = 10;
         loopSound = Sounds.respawning;
         loopSoundVolume = 1f;
@@ -303,9 +303,10 @@ public class CoreBlock extends StorageBlock{
                     Draw.rect("block-select", b.x + offset * p.x, b.y + offset * p.y, i * 90);
                 }
             };
-            for(Tile other : indexer.getAllied(team, BlockFlag.storage)){
-                if(other.build != null && other.build.items == items) outline.get(other.build);
-            }
+            team.cores().each(core -> {
+                outline.get(core);
+                core.proximity.each(storage -> storage.items == items, outline);
+            });
             Draw.reset();
         }
 


### PR DESCRIPTION
maps with several cores (placed any distance apart) mess up core highlighting, this pull tries to remedy that:
(in both pics the center core block was hovered over)

> before

![Screen Shot 2021-01-04 at 11 55 45](https://user-images.githubusercontent.com/3179271/103530081-1ed8ac80-4e87-11eb-8f6c-41afa14d06ef.png)

> after

![Screen Shot 2021-01-04 at 12 18 34](https://user-images.githubusercontent.com/3179271/103530103-2435f700-4e87-11eb-9df1-bb7b03c8b003.png)

to make the code look clean i've added the storage flag to the core blocks as well, not sure if this has side effects 🤔 