### PR TITLE
Make engine trails a variable.

### DIFF
--- a/core/src/mindustry/entities/comp/TrailComp.java
+++ b/core/src/mindustry/entities/comp/TrailComp.java
@@ -7,20 +7,22 @@ import mindustry.graphics.*;
 import mindustry.type.*;
 
 @Component
-abstract class TrailComp implements Unitc{
+abstract class TrailComp implements Posc, Rotc{
     @Import UnitType type;
-    @Import float x, y, rotation;
+    @Import float x, y, rotation, elevation;
 
     transient Trail trail = new Trail(6);
 
     @Override
     public void update(){
-        trail.length = type.trailLength;
+        if(type.engineTrail){
+            trail.length = type.trailLength;
 
-        float scale = elevation();
-        float offset = type.engineOffset/2f + type.engineOffset/2f*scale;
+            float scale = elevation;
+            float offset = type.engineOffset/2f + type.engineOffset/2f*scale;
 
-        float cx = x + Angles.trnsx(rotation + 180, offset), cy = y + Angles.trnsy(rotation + 180, offset);
-        trail.update(cx, cy);
+            float cx = x + Angles.trnsx(rotation + 180, offset), cy = y + Angles.trnsy(rotation + 180, offset);
+            trail.update(cx, cy);
+        }
     }
 }

--- a/core/src/mindustry/entities/comp/UnitComp.java
+++ b/core/src/mindustry/entities/comp/UnitComp.java
@@ -30,7 +30,7 @@ import mindustry.world.blocks.payloads.*;
 import static mindustry.Vars.*;
 
 @Component(base = true)
-abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, Itemsc, Rotc, Unitc, Weaponsc, Drawc, Boundedc, Syncc, Shieldc, Commanderc, Displayable, Senseable, Ranged, Minerc, Builderc{
+abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, Itemsc, Rotc, Unitc, Weaponsc, Drawc, Boundedc, Syncc, Shieldc, Commanderc, Displayable, Senseable, Ranged, Minerc, Builderc, Trailc{
 
     @Import boolean hovering, dead;
     @Import float x, y, rotation, elevation, maxHealth, drag, armor, hitSize, health, ammo, minFormationSpeed;

--- a/core/src/mindustry/type/UnitType.java
+++ b/core/src/mindustry/type/UnitType.java
@@ -90,6 +90,7 @@ public class UnitType extends UnlockableContent{
     public float clipSize = -1;
     public boolean canDrown = true;
     public float engineOffset = 5f, engineSize = 2.5f;
+    public boolean engineTrail = false;
     public float strafePenalty = 0.5f;
     public float hitSize = 6f;
     public float itemOffsetY = 3f;
@@ -566,8 +567,8 @@ public class UnitType extends UnlockableContent{
         float scale = unit.elevation;
         float offset = engineOffset/2f + engineOffset/2f*scale;
 
-        if(unit instanceof Trailc){
-            Trail trail = ((Trailc)unit).trail();
+        if(engineTrail){
+            Trail trail = ((Unitc)unit).trail();
             trail.draw(unit.team.color, (engineSize + Mathf.absin(Time.time, 2f, engineSize / 4f) * scale) * trailScl);
         }
 


### PR DESCRIPTION

https://user-images.githubusercontent.com/54301439/103712432-abaa6580-4f6e-11eb-8614-d31017f20b7d.mp4

Simple true or false. False by default.
Uses the same `trailLength` as water units, though maybe that should be separated in case your water unit can boost. Wait can water units even boost if `canBoost = true`?