### PR TITLE
Don't terminate socket server on connection reset

### DIFF
--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -1045,7 +1045,7 @@ public class ServerControl implements ApplicationListener{
                 }catch(BindException b){
                     err("Command input socket already in use. Is another instance of the server running?");
                 }catch(IOException e){
-                    if(!e.getMessage().equals("Socket closed")){
+                    if(!e.getMessage().equals("Socket closed") && !e.getMessage().equals("Connection reset")){
                         err("Terminating socket server.");
                         err(e);
                     }


### PR DESCRIPTION
It would be useful for server applications to have the client socket switch between servers without destroying the socket itself.