### PR TITLE
Override ModMeta#toString

### DIFF
--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -853,6 +853,18 @@ public class Mods implements Loadable{
             if(author != null) author = Strings.stripColors(author);
             if(description != null) description = Strings.stripColors(description);
         }
+        
+        @Override
+        public String toString() {
+            return "ModMeta{" +
+                    "name='" + name + '\'' +
+                    ", author='" + author + '\'' +
+                    ", version='" + version + '\'' +
+                    ", main='" + main + '\'' +
+                    ", minGameVersion='" + minGameVersion + '\'' +
+                    ", hidden=" + hidden +
+                    '}';
+        }
     }
 
     public enum ModState{


### PR DESCRIPTION
Just a useful thing for console output (plugin in preview):

![image](https://user-images.githubusercontent.com/55251897/104094287-05799b00-52a1-11eb-89e6-ef001e28449e.png)

I'm not sure which fields should be returned and which shouldn't. If I am wrong, please correct me.