### PR TITLE
1mil source output

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -1992,7 +1992,7 @@ public class Blocks implements ContentList{
 
         powerSource = new PowerSource("power-source"){{
             requirements(Category.power, BuildVisibility.sandboxOnly, with());
-            powerProduction = 100000f / 60f;
+            powerProduction = 1000000f / 60f;
             alwaysUnlocked = true;
         }};
 


### PR DESCRIPTION
Just gave the power source an extra zero cause right now i can generate more power than it outputs super easily in campaign. And honestly the last thing the source needed was a nerf.