### PR TITLE
add resolveDependencies gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -410,3 +410,13 @@ task deployAll{
     dependsOn "server:deploy"
     dependsOn "android:deploy"
 }
+
+task resolveDependencies{
+    doLast{
+        rootProject.allprojects{project ->
+            Set<Configuration> configurations = project.buildscript.configurations + project.configurations
+            configurations.findAll{c -> c.canBeResolved}
+                .forEach{c -> c.resolve()}
+        }
+    }
+}


### PR DESCRIPTION
This task will download all dependecies, including transitive dependencies. This is very useful when packaging Mindustry for a distribution, as we can first download the dependencies in a seperate step, archive them, and then disable network access to have a more reproducible build.
I added this in https://github.com/NixOS/nixpkgs/pull/108274, and someone suggested it could be useful for others.