### PR TITLE
Scale impact reactor warmup time with boost

### DIFF
--- a/core/src/mindustry/world/blocks/power/ImpactReactor.java
+++ b/core/src/mindustry/world/blocks/power/ImpactReactor.java
@@ -72,7 +72,7 @@ public class ImpactReactor extends PowerGenerator{
             if(consValid() && power.status >= 0.99f){
                 boolean prevOut = getPowerProduction() <= consumes.getPower().requestedPower(this);
 
-                warmup = Mathf.lerpDelta(warmup, 1f, warmupSpeed);
+                warmup = Mathf.lerpDelta(warmup, 1f, warmupSpeed * timeScale());
                 if(Mathf.equal(warmup, 1f, 0.001f)){
                     warmup = 1f;
                 }


### PR DESCRIPTION
<img width="900" alt="Screen Shot 2021-01-13 at 08 17 53" src="https://user-images.githubusercontent.com/3179271/104418855-dcdef300-5577-11eb-870b-90e0a21bedae.png">

- uses `timeScale()` instead of `timeScale` to make it consistent with the rest of the file
- spin down time left unaffected, it would probably just not look good at all
