### PR TITLE
conductsTo() returning whether to conduct itself to adjacent builds

### DIFF
--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -789,8 +789,8 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
 
         for(Building other : proximity){
             if(other != null && other.power != null
-            && !block.insulated && !(block.consumesPower && other.block.consumesPower && !block.outputsPower && !other.block.outputsPower)
-            && other.conductsTo(self()) && !power.links.contains(other.pos())){
+            && !(block.consumesPower && other.block.consumesPower && !block.outputsPower && !other.block.outputsPower)
+            && conductsTo(other) && other.conductsTo(self()) && !power.links.contains(other.pos())){
                 out.add(other);
             }
         }

--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -778,6 +778,10 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
         }
         power.links.clear();
     }
+    
+    public boolean conductsTo(Building other){
+        return true;
+    }
 
     public Seq<Building> getPowerConnections(Seq<Building> out){
         out.clear();
@@ -786,7 +790,7 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
         for(Building other : proximity){
             if(other != null && other.power != null
             && !(block.consumesPower && other.block.consumesPower && !block.outputsPower && !other.block.outputsPower)
-            && !power.links.contains(other.pos())){
+            && other.conductsTo(self()) && !power.links.contains(other.pos())){
                 out.add(other);
             }
         }

--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -780,7 +780,7 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
     }
     
     public boolean conductsTo(Building other){
-        return true;
+        return !block.insulated;
     }
 
     public Seq<Building> getPowerConnections(Seq<Building> out){
@@ -789,7 +789,7 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
 
         for(Building other : proximity){
             if(other != null && other.power != null
-            && !(block.consumesPower && other.block.consumesPower && !block.outputsPower && !other.block.outputsPower)
+            && !block.insulated && !(block.consumesPower && other.block.consumesPower && !block.outputsPower && !other.block.outputsPower)
             && other.conductsTo(self()) && !power.links.contains(other.pos())){
                 out.add(other);
             }


### PR DESCRIPTION
+ Allows certain blocks to only conduct on 1 or 2 sides, serving as an insulated wire
+ Allows modded blocks to use adjacent blocks as both inputs and outputs(ex. a logic gate, comparator etc.)
+ Insulated blocks will no longer conduct even if it hasPower; you need to manually connect it via nodes too!

![image](https://user-images.githubusercontent.com/58885089/104829366-606d4c80-58b6-11eb-9e8c-fbef817ae7a2.png)
+ Practical, real modded use example: make piston not take(accept) power from its "arm" side
