### PR TITLE
mass driver player transport

### DIFF
--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -876,7 +876,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         boolean consumed = false, showedInventory = false;
 
         //check if tapped block is configurable
-        if(build.block.configurable && build.interactable(player.team())){
+        if(build.block.configurable && build.interactable(player.team()) && !Core.input.keyDown(Binding.control)){
             consumed = true;
             if(((!frag.config.isShown() && build.shouldShowConfigure(player)) //if the config fragment is hidden, show
             //alternatively, the current selected block can 'agree' to switch config tiles


### PR DESCRIPTION
> prototype

getting around on large maps is a chore, it would be nice if some sort of highways can be established for players.

this draft uses mass drivers for it, which will just send you to the next driver in the chain instead of allowing you to vent to any in range.

mass drivers just for player transport may be a bit overkill, so other methods like traversing power nodes somehow could/should also be considered. (to avoid unused mass drivers everywhere, and power poles are already abundant)

aside from figuring that out, this thing would probably also have to rotate or something to make it feel a bit more smooth, currently it just teleports you to the next whenever the previous soul particle has expired.

https://user-images.githubusercontent.com/3179271/104901041-2450ef00-597d-11eb-8a61-baaff1adadb3.mp4



