### PR TITLE
Add kr server

### DIFF
--- a/servers_v6.json
+++ b/servers_v6.json
@@ -58,5 +58,9 @@
   {
     "name": "Minigames",
     "address": ["shizashizashiza.ml"]
+  },
+  {
+    "name": "Korea"
+    "address": ["mindustry.kr"]
   }
 ]

--- a/servers_v6.json
+++ b/servers_v6.json
@@ -60,7 +60,7 @@
     "address": ["shizashizashiza.ml"]
   },
   {
-    "name": "Korea"
+    "name": "Korea",
     "address": ["mindustry.kr"]
   }
 ]


### PR DESCRIPTION
There're many steam servers that ban and kick users who still enter even though warnings popup have been added. https://github.com/Anuken/Mindustry/pull/4042

I looked for other measures, change warning texts and it was https://github.com/Anuken/Mindustry/pull/4131.
but didn't work!

I recently found out that most of them are Koreans.
kr server is still under development, but it may be able to solve this problem.

The server check/maintence every Saturday/Sunday.
At the time of writing, the server was not opened because the CPU was being upgraded.