### PR TITLE
Make tests fail if any server json is invalid

### DIFF
--- a/tests/src/test/java/ApplicationTests.java
+++ b/tests/src/test/java/ApplicationTests.java
@@ -19,6 +19,11 @@ import mindustry.net.Net;
 import mindustry.type.*;
 import mindustry.world.*;
 import org.junit.jupiter.api.*;
+import rhino.*;
+import rhino.json.*;
+import rhino.json.JsonParser.*;
+
+import java.io.*;
 
 import static mindustry.Vars.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -635,5 +640,18 @@ public class ApplicationTests{
 
         tile.build.handleStack(item, 1, unit);
         assertEquals(capacity, tile.build.items.get(item));
+    }
+
+    @Test
+    void serverListJson(){
+        String[] files = {"servers.json", "servers_be.json", "servers_v6.json"};
+
+        for(String file : files){
+            try{
+                new JsonParser(Context.enter(), new TopLevel()).parseValue(Core.files.absolute(new File("./../../" + file).getAbsolutePath()).readString("UTF-8"));
+            }catch(ParseException e){
+                assertEquals("no exception", e.toString());
+            }
+        }
     }
 }


### PR DESCRIPTION
its happening a little more often than never that a server pull request contains invalid json, but the tests still pass.

this pull validates the 3 server json files, and fails the test if there's an issue:

<img width="1046" alt="Screen Shot 2021-01-19 at 16 30 52" src="https://user-images.githubusercontent.com/3179271/105055959-f00c2a00-5a73-11eb-807c-7db26d2631df.png">

![Screen Shot 2021-01-19 at 16 31 03](https://user-images.githubusercontent.com/3179271/105055999-fbf7ec00-5a73-11eb-835f-b02a18622217.png)

keeping this in draft mode because:
- the way i accessed the files is probably a weird workaround (landing in the core assets and .. ing up)
- using the rhino json parser because i could not find another (built in) thing that could throw a json exception
- probably not the right way to catch an exception within a test, but this is unfamiliar terrain for me
- doesn't use a commandline call or something to validate json externally since that relies on the os its built on
