### PR TITLE
fix "exit confirmation when saved"

### DIFF
--- a/core/src/mindustry/editor/MapEditorDialog.java
+++ b/core/src/mindustry/editor/MapEditorDialog.java
@@ -665,7 +665,7 @@ public class MapEditorDialog extends Dialog implements Disposable{
 
     private void tryExit(){
         if(saved){
-            this::hide.run();
+            hide.run();
         }else{
             ui.showConfirm("@confirm", "@editor.unsaved", this::hide);
         }

--- a/core/src/mindustry/editor/MapEditorDialog.java
+++ b/core/src/mindustry/editor/MapEditorDialog.java
@@ -664,7 +664,11 @@ public class MapEditorDialog extends Dialog implements Disposable{
     }
 
     private void tryExit(){
-        ui.showConfirm("@confirm", "@editor.unsaved", this::hide);
+        if(saved){
+            this::hide.run();
+        }else{
+            ui.showConfirm("@confirm", "@editor.unsaved", this::hide);
+        }
     }
 
     private void addBlockSelection(Table cont){


### PR DESCRIPTION
If it's intended, should we change the text to `please comfirm` but not `not saved`?