### PR TITLE
fix votekick button becoming unfocused 3x a second

### DIFF
--- a/core/src/mindustry/ui/fragments/PlayerListFragment.java
+++ b/core/src/mindustry/ui/fragments/PlayerListFragment.java
@@ -2,7 +2,7 @@ package mindustry.ui.fragments;
 
 import arc.*;
 import arc.graphics.g2d.*;
-import arc.input.KeyCode;
+import arc.input.*;
 import arc.scene.*;
 import arc.scene.event.*;
 import arc.scene.ui.*;

--- a/core/src/mindustry/ui/fragments/PlayerListFragment.java
+++ b/core/src/mindustry/ui/fragments/PlayerListFragment.java
@@ -2,6 +2,7 @@ package mindustry.ui.fragments;
 
 import arc.*;
 import arc.graphics.g2d.*;
+import arc.input.KeyCode;
 import arc.scene.*;
 import arc.scene.event.*;
 import arc.scene.ui.*;
@@ -35,7 +36,7 @@ public class PlayerListFragment extends Fragment{
                     return;
                 }
 
-                if(visible && timer.get(20)){
+                if(visible && timer.get(20) && !Core.input.keyDown(KeyCode.mouseLeft)){
                     rebuild();
                     content.pack();
                     content.act(Core.graphics.getDeltaTime());


### PR DESCRIPTION
The votekick button will unclick itself every time the player list rebuilds, this is a janky way to stop it from doing so.