### PR TITLE
Replace logic to clipboard icon with export

### DIFF
--- a/core/src/mindustry/logic/LogicDialog.java
+++ b/core/src/mindustry/logic/LogicDialog.java
@@ -45,7 +45,7 @@ public class LogicDialog extends BaseDialog{
                         }
                     }).marginLeft(12f).disabled(b -> Core.app.getClipboardText() == null);
                     t.row();
-                    t.button("@schematic.copy", Icon.copy, style, () -> {
+                    t.button("@schematic.copy", Icon.export, style, () -> {
                         dialog.hide();
                         Core.app.setClipboardText(canvas.save());
                     }).marginLeft(12f);


### PR DESCRIPTION
haven't played around with logic all to much, but initially i couldn't really find the export button on first glance, both buttons only interact with the clipboard yet for one the import icon is used, and for the other the copy/clipboard one, would be nice if both icons matched (since usually the export button is the one you press before you select any of a few methods)

"Copy to clipboard" may have to change to "Export to clipboard" to be more in line with the message above it 🤔 

schematic export:
![Screen Shot 2021-01-21 at 15 44 45](https://user-images.githubusercontent.com/3179271/105366771-ff1fe300-5bff-11eb-93a7-49f732d064a4.png)

logic export:
![Screen Shot 2021-01-21 at 15 44 57](https://user-images.githubusercontent.com/3179271/105366774-ffb87980-5bff-11eb-80e4-ea0d319f3baf.png)

schematic import:
![Screen Shot 2021-01-21 at 15 47 26](https://user-images.githubusercontent.com/3179271/105366776-00511000-5c00-11eb-9b32-a4e055b31429.png)
