### PR TITLE
Add controlling count to logic processors

### DIFF
--- a/core/src/mindustry/logic/LAccess.java
+++ b/core/src/mindustry/logic/LAccess.java
@@ -33,6 +33,7 @@ public enum LAccess{
     team,
     type,
     flag,
+    controlling,
     controlled,
     commanded,
     name,

--- a/core/src/mindustry/world/blocks/logic/LogicBlock.java
+++ b/core/src/mindustry/world/blocks/logic/LogicBlock.java
@@ -486,6 +486,12 @@ public class LogicBlock extends Block{
         }
 
         @Override
+        public double sense(LAccess sensor){
+            if(sensor == LAccess.controlling) return Groups.unit.count(u -> u.controller() instanceof LogicAI ai && ai.controller == this);
+            return super.sense(sensor);
+        }
+
+        @Override
         public byte version(){
             return 1;
         }


### PR DESCRIPTION
after asking around in the #logic channel on discord it seems to be quite an overhead/chore to check for when an unit dies / gets commanded / playered / etc, personally it seems a bit messy to me and it would just be easier to have the logic block itself gain access to the count of units under its control. (basically what you get when hovering over it with your cursor)

maybe i'm overreacting and this isn't needed and there's a really simple solution i'm not seeing, but being able to jump over an unit binder block if the controlled count is above a certain amount would seemingly make it way cleaner to scale stuff, as well as easily stock the controlled units if an unit gets ripped from its grasp in any way shape or form.

i'd like to invite "pro logic users" to give their reaction to this, whether it would be useful or not / etc, imo it is. 🤔 

![Screen Shot 2021-01-22 at 16 36 04](https://user-images.githubusercontent.com/3179271/105511663-6efd9e80-5cd0-11eb-90ca-6e793337bf47.png)
![Screen Shot 2021-01-22 at 16 36 08](https://user-images.githubusercontent.com/3179271/105511673-715ff880-5cd0-11eb-9f3c-945bebc983dd.png)
![Screen Shot 2021-01-22 at 16 36 13](https://user-images.githubusercontent.com/3179271/105511676-71f88f00-5cd0-11eb-8d98-e91effe1fe85.png)
![Screen Shot 2021-01-22 at 16 36 23](https://user-images.githubusercontent.com/3179271/105511677-72912580-5cd0-11eb-835a-2a79bfab6255.png)
