### PR TITLE
Make schematics build insulated blocks first, power nodes last

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -788,6 +788,7 @@ public class Blocks implements ContentList{
             health = 130 * wallHealthMultiplier;
             insulated = true;
             absorbLasers = true;
+            schematicPriority = 10;
         }};
 
         plastaniumWallLarge = new Wall("plastanium-wall-large"){{

--- a/core/src/mindustry/game/Schematics.java
+++ b/core/src/mindustry/game/Schematics.java
@@ -285,7 +285,8 @@ public class Schematics implements Loadable{
     /** Creates an array of build requests from a schematic's data, centered on the provided x+y coordinates. */
     public Seq<BuildPlan> toRequests(Schematic schem, int x, int y){
         return schem.tiles.map(t -> new BuildPlan(t.x + x - schem.width/2, t.y + y - schem.height/2, t.rotation, t.block, t.config).original(t.x, t.y, schem.width, schem.height))
-            .removeAll(s -> (!s.block.isVisible() && !(s.block instanceof CoreBlock)) || !s.block.unlockedNow());
+            .removeAll(s -> (!s.block.isVisible() && !(s.block instanceof CoreBlock)) || !s.block.unlockedNow())
+            .sort(Structs.comps(Structs.comparing(s -> !s.block.insulated), Structs.comparing(s -> s.block instanceof PowerNode)));
     }
 
     /** @return all the valid loadouts for a specific core type. */

--- a/core/src/mindustry/game/Schematics.java
+++ b/core/src/mindustry/game/Schematics.java
@@ -285,8 +285,7 @@ public class Schematics implements Loadable{
     /** Creates an array of build requests from a schematic's data, centered on the provided x+y coordinates. */
     public Seq<BuildPlan> toRequests(Schematic schem, int x, int y){
         return schem.tiles.map(t -> new BuildPlan(t.x + x - schem.width/2, t.y + y - schem.height/2, t.rotation, t.block, t.config).original(t.x, t.y, schem.width, schem.height))
-            .removeAll(s -> (!s.block.isVisible() && !(s.block instanceof CoreBlock)) || !s.block.unlockedNow())
-            .sort(Structs.comps(Structs.comparing(s -> !s.block.insulated), Structs.comparing(s -> s.block instanceof PowerNode)));
+            .removeAll(s -> (!s.block.isVisible() && !(s.block instanceof CoreBlock)) || !s.block.unlockedNow()).sort(Structs.comparingInt(s -> -s.block.schematicPriority));
     }
 
     /** @return all the valid loadouts for a specific core type. */

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -145,6 +145,8 @@ public class Block extends UnlockableContent{
     public boolean conveyorPlacement;
     /** Whether to swap the diagonal placement modes. */
     public boolean swapDiagonalPlacement;
+    /** Build queue priority in schematics. */
+    public int schematicPriority = 0;
     /**
      * The color of this block when displayed on the minimap or map preview.
      * Do not set manually! This is overridden when loading for most blocks.

--- a/core/src/mindustry/world/blocks/power/PowerDiode.java
+++ b/core/src/mindustry/world/blocks/power/PowerDiode.java
@@ -22,6 +22,7 @@ public class PowerDiode extends Block{
         insulated = true;
         group = BlockGroup.power;
         noUpdateDisabled = true;
+        schematicPriority = 10;
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/power/PowerNode.java
+++ b/core/src/mindustry/world/blocks/power/PowerNode.java
@@ -43,6 +43,7 @@ public class PowerNode extends PowerBlock{
         outputsPower = false;
         canOverdrive = false;
         swapDiagonalPlacement = true;
+        schematicPriority = -10;
         drawDisabled = false;
 
         config(Integer.class, (entity, value) -> {


### PR DESCRIPTION
This PR sorts the build order of schematics when placed, so that small plastanium walls will be pushed to the beginning of the build queue, and all power nodes to the end.

This change fixes the following issues:
* Even though schematics in 6.0 remember power connections, that didn't matter at all as power nodes built halfway through the build order would often max themselves out with automatic connections before they could connect to their saved connections.
* For schematics surrounded by plastanium walls, power nodes outside the schematic could still make automatic connections to blocks inside the schematic during construction because some blocks would be built before the insulator walls were.
* Likewise, power nodes inside could make automatic connections out.
* Blocks outside a schematic would often steal power nodes' automatic connections so that by the time a schematic finished building, no connections would be left and some blocks in the schematic would be left unpowered.
* Schematics that used batteries to reduce the number of power connections needed would find some blocks left unpowered due to power nodes being constructed before some batteries, causing multiple automatic connections to be wasted on blocks that could have shared 1 connection via batteries.

Thus, schematics' power connections will look much neater after being built, and players will no longer have to waste time manually fixing bad automatic power connections.

As with anything involving build order, this PR does not address build order not being respected due to the player unit being out of build range. It also doesn't alter the build order of manually built designs.

Forgive these unrealistic, contrived examples.

![Schematic Build Order 1](https://user-images.githubusercontent.com/15149002/105571770-902db180-5d07-11eb-8afc-8f0a0a773a53.png)

![Schematic Build Order 2](https://user-images.githubusercontent.com/15149002/105569285-623f7180-5cf5-11eb-8466-5828bf9e4930.png)
