### PR TITLE
Colored construct

### DIFF
--- a/core/src/mindustry/graphics/Drawf.java
+++ b/core/src/mindustry/graphics/Drawf.java
@@ -221,9 +221,13 @@ public class Drawf{
     }
 
     public static void construct(float x, float y, TextureRegion region, float rotation, float progress, float speed, float time){
+        construct(x, y, region, Pal.accent, rotation, progress, speed, time);
+    }
+    
+    public static void construct(float x, float y, TextureRegion region, Color color, float rotation, float progress, float speed, float time){
         Shaders.build.region = region;
         Shaders.build.progress = progress;
-        Shaders.build.color.set(Pal.accent);
+        Shaders.build.color.set(color);
         Shaders.build.color.a = speed;
         Shaders.build.time = -time / 20f;
 
@@ -235,9 +239,13 @@ public class Drawf{
     }
 
     public static void construct(Building t, TextureRegion region, float rotation, float progress, float speed, float time){
+        construct(t, region, Pal.accent, rotation, progress, speed, time);
+    }
+        
+    public static void construct(Building t, TextureRegion region, Color color, float rotation, float progress, float speed, float time){
         Shaders.build.region = region;
         Shaders.build.progress = progress;
-        Shaders.build.color.set(Pal.accent);
+        Shaders.build.color.set(color);
         Shaders.build.color.a = speed;
         Shaders.build.time = -time / 20f;
 


### PR DESCRIPTION
Adds `Drawf.construct` but with custom colors. Useful for script modders who want to construct something in a specific color without having to do the whole shader thing themself.