### PR TITLE
targetable() for Units

### DIFF
--- a/core/src/mindustry/entities/Units.java
+++ b/core/src/mindustry/entities/Units.java
@@ -93,7 +93,7 @@ public class Units{
      * @return whether the target is invalid
      */
     public static boolean invalidateTarget(Posc target, Team team, float x, float y, float range){
-        return target == null || (range != Float.MAX_VALUE && !target.within(x, y, range)) || (target instanceof Teamc && ((Teamc)target).team() == team) || (target instanceof Healthc && !((Healthc)target).isValid());
+        return target == null || (range != Float.MAX_VALUE && !target.within(x, y, range)) || (target instanceof Teamc && ((Teamc)target).team() == team) || (target instanceof Healthc && !((Healthc)target).isValid()) || ((target instanceof Unitc u) && !u.targetable(team));
     }
 
     /** See {@link #invalidateTarget(Posc, Team, float, float, float)} */
@@ -197,7 +197,7 @@ public class Units{
         cdist = 0f;
 
         nearbyEnemies(team, x - range, y - range, range*2f, range*2f, e -> {
-            if(e.dead() || !predicate.get(e) || e.team == Team.derelict) return;
+            if(e.dead() || !predicate.get(e) || e.team == Team.derelict || !e.targetable(team)) return;
 
             float dst2 = e.dst2(x, y);
             if(dst2 < range*range && (result == null || dst2 < cdist)){
@@ -217,7 +217,7 @@ public class Units{
         cdist = 0f;
 
         nearbyEnemies(team, x - range, y - range, range*2f, range*2f, e -> {
-            if(e.dead() || !predicate.get(e) || !e.within(x, y, range)) return;
+            if(e.dead() || !predicate.get(e) || !e.within(x, y, range) || !e.targetable(team)) return;
 
             float cost = sort.cost(e, x, y);
             if(result == null || cost < cdist){
@@ -235,7 +235,7 @@ public class Units{
         cdist = 0f;
 
         for(Unit e : Groups.unit){
-            if(!predicate.get(e) || e.team() != team) continue;
+            if(!predicate.get(e) || e.team() != team || !e.targetable(team)) continue;
 
             float dist = e.dst2(x, y);
             if(result == null || dist < cdist){
@@ -253,7 +253,7 @@ public class Units{
         cdist = 0f;
 
         nearby(team, x, y, range, e -> {
-            if(!predicate.get(e)) return;
+            if(!predicate.get(e) || !e.targetable(team)) return;
 
             float dist = e.dst2(x, y);
             if(result == null || dist < cdist){
@@ -272,7 +272,7 @@ public class Units{
         cdist = 0f;
 
         nearby(team, x - range, y - range, range*2f, range*2f, e -> {
-            if(!predicate.get(e)) return;
+            if(!predicate.get(e) || !e.targetable(team)) return;
 
             float dist = e.dst2(x, y);
             if(result == null || dist < cdist){

--- a/core/src/mindustry/entities/comp/UnitComp.java
+++ b/core/src/mindustry/entities/comp/UnitComp.java
@@ -177,6 +177,10 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
         //cannot shoot while boosting
         return !(type.canBoost && isFlying());
     }
+    
+    public boolean targetable(Team targeter){
+        return type.targetable(self(), targeter);
+    }
 
     @Override
     public int itemCapacity(){

--- a/core/src/mindustry/type/UnitType.java
+++ b/core/src/mindustry/type/UnitType.java
@@ -153,7 +153,7 @@ public class UnitType extends UnlockableContent{
 
     public void landed(Unit unit){}
     
-    public boolean targetable(Unit unit){
+    public boolean targetable(Unit unit, Team targeter){
         return true;
     }
 

--- a/core/src/mindustry/type/UnitType.java
+++ b/core/src/mindustry/type/UnitType.java
@@ -152,6 +152,10 @@ public class UnitType extends UnlockableContent{
     }
 
     public void landed(Unit unit){}
+    
+    public boolean targetable(Unit unit){
+        return true;
+    }
 
     public void display(Unit unit, Table table){
         table.table(t -> {


### PR DESCRIPTION
+ Main targetable() is placed in UnitType so it is not necessary to create a new constructor
+ targetable() is also in Unit so other future features can be implemented; such as an "Untargetable core units" rule, currently it just calls the targetable() of the type
+ nearby() and the similar functions in Units.java are intentionally unchanged, meaning that it does not consider targetable(), since not being targetable does not always imply invincibility

- [x] UnitType targetable(Unit unit, Team team)
- [x] Unit targetable(Team team)
- [x] Units.java