### PR TITLE
Secondary bloom layers.

### DIFF
--- a/core/src/mindustry/content/Fx.java
+++ b/core/src/mindustry/content/Fx.java
@@ -752,7 +752,7 @@ public class Fx{
         randLenVectors(e.id, 3, 2f + e.fin() * 7f, (x, y) -> {
             Fill.circle(e.x + x, e.y + y, 0.1f + e.fout() * 1.4f);
         });
-    }),
+    }).layer(Layer.highEffect),
 
     fire = new Effect(50f, e -> {
         color(Pal.lightFlame, Pal.darkFlame, e.fin());
@@ -804,7 +804,7 @@ public class Fx{
         randLenVectors(e.id, 2, 1f + e.fin() * 2f, (x, y) -> {
             Fill.circle(e.x + x, e.y + y, e.fout() * 1.2f);
         });
-    }),
+    }).layer(Layer.highEffect),
 
     melting = new Effect(40f, e -> {
         color(Liquids.slag.color, Color.white, e.fout() / 5f + Mathf.randomSeedRange(e.id, 0.12f));
@@ -812,21 +812,21 @@ public class Fx{
         randLenVectors(e.id, 2, 1f + e.fin() * 3f, (x, y) -> {
             Fill.circle(e.x + x, e.y + y, .2f + e.fout() * 1.2f);
         });
-    }),
+    }).layer(Layer.highEffect),
 
     wet = new Effect(80f, e -> {
         color(Liquids.water.color);
         alpha(Mathf.clamp(e.fin() * 2f));
 
         Fill.circle(e.x, e.y, e.fout());
-    }),
+    }).layer(Layer.highEffect),
 
     muddy = new Effect(80f, e -> {
         color(Color.valueOf("432722"));
         alpha(Mathf.clamp(e.fin() * 2f));
 
         Fill.circle(e.x, e.y, e.fout());
-    }),
+    }).layer(Layer.highEffect),
 
     sapped = new Effect(40f, e -> {
         color(Pal.sap);
@@ -834,7 +834,7 @@ public class Fx{
         randLenVectors(e.id, 2, 1f + e.fin() * 2f, (x, y) -> {
             Fill.square(e.x + x, e.y + y, e.fslope() * 1.1f, 45f);
         });
-    }),
+    }).layer(Layer.highEffect),
 
     sporeSlowed = new Effect(40f, e -> {
         color(Pal.spore);
@@ -856,13 +856,13 @@ public class Fx{
         randLenVectors(e.id, 2, 1f + e.fin() * 2f, (x, y) -> {
             Fill.square(e.x + x, e.y + y, e.fout() * 2.3f + 0.5f);
         });
-    }),
+    }).layer(Layer.highEffect),
 
     overclocked = new Effect(50f, e -> {
         color(Pal.accent);
 
         Fill.square(e.x, e.y, e.fslope() * 2f, 45f);
-    }),
+    }).layer(Layer.highEffect),
 
     dropItem = new Effect(20f, e -> {
         float length = 20f * e.finpow();

--- a/core/src/mindustry/core/Renderer.java
+++ b/core/src/mindustry/core/Renderer.java
@@ -256,6 +256,8 @@ public class Renderer implements ApplicationListener{
             bloom.resize(graphics.getWidth() / 4, graphics.getHeight() / 4);
             Draw.draw(Layer.bullet - 0.01f, bloom::capture);
             Draw.draw(Layer.effect + 0.01f, bloom::render);
+            Draw.draw(Layer.air - 0.01f, bloom::capture);
+            Draw.draw(Layer.sky + 0.01f, bloom::render);
         }
 
         Draw.draw(Layer.plans, overlays::drawBottom);

--- a/core/src/mindustry/core/Renderer.java
+++ b/core/src/mindustry/core/Renderer.java
@@ -256,8 +256,8 @@ public class Renderer implements ApplicationListener{
             bloom.resize(graphics.getWidth() / 4, graphics.getHeight() / 4);
             Draw.draw(Layer.bullet - 0.01f, bloom::capture);
             Draw.draw(Layer.effect + 0.01f, bloom::render);
-            Draw.draw(Layer.air - 0.01f, bloom::capture);
-            Draw.draw(Layer.sky + 0.01f, bloom::render);
+            Draw.draw(Layer.highBullet - 0.01f, bloom::capture);
+            Draw.draw(Layer.highEffect + 0.01f, bloom::render);
         }
 
         Draw.draw(Layer.plans, overlays::drawBottom);

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -23,6 +23,7 @@ public abstract class BulletType extends Content{
     public float damage;
     public float hitSize = 4;
     public float drawSize = 40f;
+    public float drawLayer = Layer.bullet;
     public float drag = 0f;
     public boolean pierce, pierceBuilding;
     public int pierceCap = -1;

--- a/core/src/mindustry/entities/comp/BulletComp.java
+++ b/core/src/mindustry/entities/comp/BulletComp.java
@@ -158,7 +158,7 @@ abstract class BulletComp implements Timedc, Damagec, Hitboxc, Teamc, Posc, Draw
 
     @Override
     public void draw(){
-        Draw.z(Layer.bullet);
+        Draw.z(type.drawLayer);
 
         type.draw(self());
         type.drawLight(self());

--- a/core/src/mindustry/graphics/Layer.java
+++ b/core/src/mindustry/graphics/Layer.java
@@ -72,10 +72,10 @@ public class Layer{
     shields = 125,
 
     //high bloom *bloom begin*
-    air = 130,
+    highBullet = 130,
 
     //high bloom *bloom end*
-    sky = 140,
+    highEffect = 140,
 
     //weather effects, e.g. rain and snow TODO draw before overlay UI?
     weather = 145,

--- a/core/src/mindustry/graphics/Layer.java
+++ b/core/src/mindustry/graphics/Layer.java
@@ -71,17 +71,23 @@ public class Layer{
     //shield effects
     shields = 125,
 
+    //high bloom *bloom begin*
+    air = 130,
+
+    //high bloom *bloom end*
+    sky = 140,
+
     //weather effects, e.g. rain and snow TODO draw before overlay UI?
-    weather = 130,
+    weather = 145,
 
     //light rendering *shaders used*
-    light = 140,
+    light = 150,
 
     //names of players in the game
-    playerName = 150,
+    playerName = 160,
 
     //space effects, currently only the land and launch effects
-    space = 160,
+    space = 170,
 
     //the end of all layers
     end = 200,

--- a/core/src/mindustry/world/blocks/campaign/LaunchPad.java
+++ b/core/src/mindustry/world/blocks/campaign/LaunchPad.java
@@ -188,7 +188,7 @@ public class LaunchPad extends Block{
             float cx = cx(), cy = cy();
             float rotation = fin() * (130f + Mathf.randomSeedRange(id(), 50f));
 
-            Draw.z(Layer.effect + 0.001f);
+            Draw.z(Layer.sky - 0.001f);
 
             Draw.color(Pal.engine);
 

--- a/core/src/mindustry/world/blocks/campaign/LaunchPad.java
+++ b/core/src/mindustry/world/blocks/campaign/LaunchPad.java
@@ -188,7 +188,7 @@ public class LaunchPad extends Block{
             float cx = cx(), cy = cy();
             float rotation = fin() * (130f + Mathf.randomSeedRange(id(), 50f));
 
-            Draw.z(Layer.sky - 0.001f);
+            Draw.z(Layer.highEffect + 0.001f);
 
             Draw.color(Pal.engine);
 


### PR DESCRIPTION
Some layers that bloom above flying units, allowing for bullets and effects that bloom above them, as well as making launchpad engine draw over flying units while still blooming.

https://user-images.githubusercontent.com/54301439/105931969-06c8f880-6001-11eb-80cd-32095cd5f033.mp4

(Note: I have no idea what performance issues, if any, this'll cause.)