### PR TITLE
Make fillitems fill the core to the brim

### DIFF
--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -502,7 +502,7 @@ public class ServerControl implements ApplicationListener{
             }
 
             for(Item item : content.items()){
-                state.teams.cores(team).first().items.set(item, state.teams.cores(team).first().block.itemCapacity);
+                state.teams.cores(team).first().items.set(item, state.teams.cores(team).first().storageCapacity);
             }
 
             info("Core filled.");


### PR DESCRIPTION
Instead of just setting all items to the capacity of the first found core.
(which excluded any linked storage blocks, and possibly lowering)