### PR TITLE
Stop buttons from wrapping when no players found

### DIFF
--- a/core/src/mindustry/ui/fragments/PlayerListFragment.java
+++ b/core/src/mindustry/ui/fragments/PlayerListFragment.java
@@ -62,9 +62,9 @@ public class PlayerListFragment extends Fragment{
                     menu.defaults().growX().height(50f).fillY();
                     menu.name = "menu";
 
-                    menu.button("@server.bans", ui.bans::show).disabled(b -> net.client());
-                    menu.button("@server.admins", ui.admins::show).disabled(b -> net.client());
-                    menu.button("@close", this::toggle);
+                    menu.button("@server.bans", ui.bans::show).disabled(b -> net.client()).get().getLabel().setWrap(false);
+                    menu.button("@server.admins", ui.admins::show).disabled(b -> net.client()).get().getLabel().setWrap(false);
+                    menu.button("@close", this::toggle).get().getLabel().setWrap(false);
                 }).margin(0f).pad(10f).growX();
 
             }).touchable(Touchable.enabled).margin(14f);


### PR DESCRIPTION
This has bothered me for ages and my solution to the problem is scuffed but at least it doesn't look terrible now I guess?
Before:
![](https://discord-cdn.is-terrible.com/fWaT7A.png)

After:
![](https://vexera.is-ne.at/STH1gY.png)