### PR TITLE
Make drag calculation no longer clamped

### DIFF
--- a/core/src/mindustry/entities/comp/VelComp.java
+++ b/core/src/mindustry/entities/comp/VelComp.java
@@ -22,7 +22,7 @@ abstract class VelComp implements Posc{
     @Override
     public void update(){
         move(vel.x * Time.delta, vel.y * Time.delta);
-        vel.scl(Mathf.clamp(1f - drag * Time.delta));
+        vel.scl(1f - drag * Time.delta);
     }
 
     /** @return function to use for check solid state. if null, no checking is done. */


### PR DESCRIPTION
Reason: Some built-in bullets have negative `drag`, but due to the clamp they don't actually accelerate.
Also allows `drag` to be above 1 if you want your object to move backward for some weird reason. Who knows what modders will do with this.