### PR TITLE
Allow negative drag to accelerate objects.

### DIFF
--- a/core/src/mindustry/entities/comp/VelComp.java
+++ b/core/src/mindustry/entities/comp/VelComp.java
@@ -22,7 +22,7 @@ abstract class VelComp implements Posc{
     @Override
     public void update(){
         move(vel.x * Time.delta, vel.y * Time.delta);
-        vel.scl(Mathf.clamp(1f - drag * Time.delta));
+        vel.scl(Mathf.clamp(1f - drag * Time.delta, -1f, 1f));
     }
 
     /** @return function to use for check solid state. if null, no checking is done. */


### PR DESCRIPTION
Built-in bullets have negative drag, but that does nothing. This allows drag calculation to go from -1 to 1 instead of 0 to 1.