### PR TITLE
Create FileTreeInitEvent

### DIFF
--- a/core/src/mindustry/game/EventType.java
+++ b/core/src/mindustry/game/EventType.java
@@ -68,6 +68,8 @@ public class EventType{
     public static class ContentInitEvent{}
     /** Called when the client game is first loaded. */
     public static class ClientLoadEvent{}
+    /** Called *after* all the modded files have been added into Vars.tree */
+    public static class FileTreeInitEvent{}
     /** Called when a game begins and the world is loaded. */
     public static class WorldLoadEvent{}
 

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -347,6 +347,7 @@ public class Mods implements Loadable{
                 }
             }
         }
+        Events.fire(new FileTreeInitEvent());
 
         //add new keys to each bundle
         I18NBundle bundle = Core.bundle;


### PR DESCRIPTION
`FileTreeInitEvent` is thrown after the modded files are added into `Vars.tree`. Useful for mods that loads assets with `Vars.tree` as it's file handle resolver