### PR TITLE
Show schematic description in schematic info

### DIFF
--- a/core/src/mindustry/ui/dialogs/SchematicsDialog.java
+++ b/core/src/mindustry/ui/dialogs/SchematicsDialog.java
@@ -405,6 +405,10 @@ public class SchematicsDialog extends BaseDialog{
                     }
                 });
             }
+            if(!schem.description().isEmpty()){
+                cont.row();
+                cont.add("[lightgray]" + schem.description()).wrap().width(500f).padTop(20);
+            }
 
             show();
         }


### PR DESCRIPTION
Schematic descriptions typically contain usage instructions, so it makes sense to display it in the schematic's info dialog. Better than having to open the name edit panel to view the description.

Has the same 500px wrap width as [content descriptions](https://github.com/Anuken/Mindustry/blob/master/core/src/mindustry/ui/dialogs/ContentInfoDialog.java#L46).

How it looks on desktop:
![Schematic description desktop](https://user-images.githubusercontent.com/15149002/106652268-0a510800-654a-11eb-85dc-040cd9a3a55b.png)

Mobile:
![Schematic description mobile](https://user-images.githubusercontent.com/15149002/106652283-10df7f80-654a-11eb-903c-720df672a35e.png)