### PR TITLE
Makes timescale accessible to logic

### DIFF
--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -1311,6 +1311,7 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
             case health -> health;
             case maxHealth -> maxHealth;
             case efficiency -> efficiency();
+            case timescale -> timeScale;
             case range -> this instanceof Ranged r ? r.range() / tilesize : 0;
             case rotation -> rotation;
             case totalItems -> items == null ? 0 : items.total();

--- a/core/src/mindustry/logic/LAccess.java
+++ b/core/src/mindustry/logic/LAccess.java
@@ -21,6 +21,7 @@ public enum LAccess{
     maxHealth,
     heat,
     efficiency,
+    timescale,
     rotation,
     x,
     y,


### PR DESCRIPTION
running into a situation where i'd like to be able to sense if certain blocks are currently being boosted externally: 
(basically in situations where a build is unintentionally or partially boosted, e.g. a different nearby schematic)

![Screen Shot 2021-02-02 at 21 07 16](https://user-images.githubusercontent.com/3179271/106656382-e833a600-659a-11eb-8e85-207a8a5eb3dc.png)
![Screen Shot 2021-02-02 at 21 08 43](https://user-images.githubusercontent.com/3179271/106656375-e7027900-659a-11eb-9c5b-84d643222c9b.png)
![Screen Shot 2021-02-02 at 21 07 22](https://user-images.githubusercontent.com/3179271/106656377-e79b0f80-659a-11eb-8569-10f7d3167275.png)

