### PR TITLE
Draw Top on BlockForge

### DIFF
--- a/core/src/mindustry/world/blocks/experimental/BlockForge.java
+++ b/core/src/mindustry/world/blocks/experimental/BlockForge.java
@@ -47,7 +47,7 @@ public class BlockForge extends PayloadAcceptor{
 
     @Override
     public TextureRegion[] icons(){
-        return new TextureRegion[]{region, outRegion};
+        return new TextureRegion[]{region, outRegion, topRegion};
     }
 
     @Override
@@ -69,6 +69,7 @@ public class BlockForge extends PayloadAcceptor{
     public void drawRequestRegion(BuildPlan req, Eachable<BuildPlan> list){
         Draw.rect(region, req.drawx(), req.drawy());
         Draw.rect(outRegion, req.drawx(), req.drawy(), req.rotation * 90);
+        Draw.rect(topRegion, req.drawx(), req.drawy());
     }
     
     public class BlockForgeBuild extends PayloadAcceptorBuild<BuildPayload>{
@@ -136,7 +137,11 @@ public class BlockForge extends PayloadAcceptor{
                 Draw.draw(Layer.blockOver, () -> Drawf.construct(this, recipe, 0, progress / recipe.buildCost, heat, time));
             }
 
+            Draw.z(Layer.blockOver);
             drawPayload();
+
+            Draw.z(Layer.blockOver + 0.1f);
+            Draw.rect(topRegion, x, y);
         }
         
         @Override


### PR DESCRIPTION
Yes I do realize the BlockForge is experimental, but still, I think this:
![icon](https://user-images.githubusercontent.com/68400583/106844456-73757000-665d-11eb-8d4e-ab13c0d161e1.png)

is closer to the style of the other payload blocks than this: 
![this-looks-ugly](https://user-images.githubusercontent.com/68400583/106844581-c3eccd80-665d-11eb-99e5-8ea9650305ac.png)


Plus it looks better (in my opinion). 