### PR TITLE
Saves rotation of repair points

### DIFF
--- a/core/src/mindustry/world/blocks/units/RepairPoint.java
+++ b/core/src/mindustry/world/blocks/units/RepairPoint.java
@@ -6,6 +6,7 @@ import arc.math.*;
 import arc.math.geom.*;
 import arc.struct.*;
 import arc.util.*;
+import arc.util.io.*;
 import mindustry.annotations.Annotations.*;
 import mindustry.entities.*;
 import mindustry.gen.*;
@@ -122,6 +123,27 @@ public class RepairPoint extends Block{
         @Override
         public BlockStatus status(){
             return Mathf.equal(efficiency(), 0f, 0.01f) ? BlockStatus.noInput : cons.status();
+        }
+
+        @Override
+        public void write(Writes write){
+            super.write(write);
+            
+            write.f(rotation);
+        }
+
+        @Override
+        public void read(Reads read, byte revision){
+            super.read(read, revision);
+
+            if(revision >= 1){
+                rotation = read.f();
+            }
+        }
+
+        @Override
+        public byte version(){
+            return 1;
         }
     }
 }


### PR DESCRIPTION
> resolves https://github.com/Anuken/Mindustry-Suggestions/issues/1920

storing the rotation of repair points seems to be welcomed, this pr hopefully does that correctly.

in terms of backwards compatibility it should probably be merged before 124 since it would break 123.2 (right?)
(but then again, the block sync thing has already broken compatibility, so it doesn't really make much difference)

![Screen Shot 2021-02-04 at 16 06 18](https://user-images.githubusercontent.com/3179271/106912038-f3094a80-6702-11eb-9c50-6f825a70f9dc.png)

> originally made this a suggestion instead of a pull since i had some vague memories about the version/revision stuff being changed/removed like long ago or something, wasn't sure if my own attempt would/will break it or not*
