### PR TITLE
Draws team regions during schematic placement

### DIFF
--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -428,7 +428,7 @@ public class Block extends UnlockableContent{
         TextureRegion reg = getRequestRegion(req, list);
         Draw.rect(reg, req.drawx(), req.drawy(), !rotate ? 0 : req.rotation * 90);
 
-        if(teamRegion.found()){
+        if(req.worldContext && teamRegion.found()){
             Team team = player != null ? player.team() : Team.sharded;
             if(teamRegions[team.id] == teamRegion) Draw.color(team.color);
             Draw.rect(teamRegions[team.id], req.drawx(), req.drawy());

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -429,8 +429,9 @@ public class Block extends UnlockableContent{
         Draw.rect(reg, req.drawx(), req.drawy(), !rotate ? 0 : req.rotation * 90);
 
         if(teamRegion.found()){
-            if(teamRegions[player.team().id] == teamRegion) Draw.color(player.team().color);
-            Draw.rect(teamRegions[player.team().id], req.drawx(), req.drawy());
+            Team team = player != null ? player.team() : Team.sharded;
+            if(teamRegions[team.id] == teamRegion) Draw.color(team.color);
+            Draw.rect(teamRegions[team.id], req.drawx(), req.drawy());
             Draw.color();
         }
 

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -428,10 +428,9 @@ public class Block extends UnlockableContent{
         TextureRegion reg = getRequestRegion(req, list);
         Draw.rect(reg, req.drawx(), req.drawy(), !rotate ? 0 : req.rotation * 90);
 
-        if(req.worldContext && teamRegion.found()){
-            Team team = player != null ? player.team() : Team.sharded;
-            if(teamRegions[team.id] == teamRegion) Draw.color(team.color);
-            Draw.rect(teamRegions[team.id], req.drawx(), req.drawy());
+        if(req.worldContext && player != null && teamRegion.found()){
+            if(teamRegions[player.team().id] == teamRegion) Draw.color(player.team().color);
+            Draw.rect(teamRegions[player.team().id], req.drawx(), req.drawy());
             Draw.color();
         }
 

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -428,6 +428,12 @@ public class Block extends UnlockableContent{
         TextureRegion reg = getRequestRegion(req, list);
         Draw.rect(reg, req.drawx(), req.drawy(), !rotate ? 0 : req.rotation * 90);
 
+        if(teamRegion.found()){
+            if(teamRegions[player.team().id] == teamRegion) Draw.color(player.team().color);
+            Draw.rect(teamRegions[player.team().id], req.drawx(), req.drawy());
+            Draw.color();
+        }
+
         drawRequestConfig(req, list);
     }
 


### PR DESCRIPTION
found it a bit strange to see sharded previews while playing as another team, this pr tries to remedy that:
(looks like no team != null check is needed since the player's team defaults to sharded)

![Screen Shot 2021-02-04 at 21 17 40](https://user-images.githubusercontent.com/3179271/106950534-d4b94400-672e-11eb-9a78-65e8bf86b866.png)
![Screen Shot 2021-02-04 at 21 17 30](https://user-images.githubusercontent.com/3179271/106950529-d2ef8080-672e-11eb-9b9b-cd7e3170038e.png)
