### PR TITLE
Update servers_be.json

### DIFF
--- a/servers_be.json
+++ b/servers_be.json
@@ -6,9 +6,6 @@
     "address": "nydustry.nydus.app:6060"
   },
   {
-    "address": "routerchain.ddns.net:6568"
-  },
-  {
     "address": "mindustry.pl:6660"
   }
 ]


### PR DESCRIPTION
similar to #4081 this server is no longer running a bleeding edge version:

![Screen Shot 2021-02-06 at 13 34 31](https://user-images.githubusercontent.com/3179271/107118269-3b01ac00-6880-11eb-8cdc-7e9dbbf85de1.png)

(hasn't appeared in the list for months, they've probably shut it down long ago and reused the ip/port for another server)
