### PR TITLE
Fix null == 0

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -780,7 +780,7 @@ public class LExecutor{
                 Var va = exec.var(a);
                 Var vb = exec.var(b);
 
-                if(op.objFunction2 != null && va.isobj && vb.isobj){
+                if(op.objFunction2 != null && (va.isobj || vb.isobj)){
                     //use object function if provided, and one of the variables is an object
                     exec.setnum(dest, op.objFunction2.get(exec.obj(a), exec.obj(b)));
                 }else{
@@ -951,7 +951,7 @@ public class LExecutor{
                 Var vb = exec.var(compare);
                 boolean cmp;
 
-                if(op.objFunction != null && va.isobj && vb.isobj){
+                if(op.objFunction != null && (va.isobj || vb.isobj)){
                     //use object function if provided, and one of the variables is an object
                     cmp = op.objFunction.get(exec.obj(value), exec.obj(compare));
                 }else{


### PR DESCRIPTION
`//use object function if provided, and`*`one of the variables is an object`*

Surely not both?