### PR TITLE
Remove space in perShot

### DIFF
--- a/core/src/mindustry/world/meta/StatUnit.java
+++ b/core/src/mindustry/world/meta/StatUnit.java
@@ -20,7 +20,7 @@ public enum StatUnit{
     minutes,
     perSecond,
     perMinute,
-    perShot,
+    perShot(false),
     timesSpeed(false),
     percent(false),
     shieldHealth,


### PR DESCRIPTION
There should not be a space between the number and "/shot"
![Mindustry_uwCkXIf6u8](https://user-images.githubusercontent.com/54301439/107327834-a2775180-6a62-11eb-905b-b4abe3fb6bdb.png)
