### PR TITLE
If a building and unit are found within the line, target the closer one.

### DIFF
--- a/core/src/mindustry/entities/Damage.java
+++ b/core/src/mindustry/entities/Damage.java
@@ -214,10 +214,10 @@ public class Damage{
      */
     public static Healthc linecast(Bullet hitter, float x, float y, float angle, float length){
         tr.trns(angle, length);
+        
+        tmpBuilding = null;
 
         if(hitter.type.collidesGround){
-            tmpBuilding = null;
-
             world.raycastEachWorld(x, y, x + tr.x, y + tr.y, (cx, cy) -> {
                 Building tile = world.build(cx, cy);
                 if(tile != null && tile.team != hitter.team){
@@ -226,8 +226,6 @@ public class Damage{
                 }
                 return false;
             });
-
-            if(tmpBuilding != null) return tmpBuilding;
         }
 
         rect.setPosition(x, y).setSize(tr.x, tr.y);
@@ -271,6 +269,14 @@ public class Damage{
 
         Units.nearbyEnemies(hitter.team, rect, cons);
 
+        if(tmpBuilding != null && tmpUnit != null){
+            float bDst = Mathf.dst2(x, y, tmpBuilding.getX(), tmpBuilding.getY());
+            float uDst = Mathf.dst2(x, y, tmpUnit.getX(), tmpUnit.getY());
+            if(uDst <= bDst) return tmpUnit;
+            if(bDst > uDst) return tmpBuilding;
+        }else if(tmpBuilding != null && tmpUnit == null){
+            return tmpBuilding;
+        }
         return tmpUnit;
     }
 


### PR DESCRIPTION
Currently, if a building and unit are in the line it always goes for the building regardless of distance. This adds a distance check to it. I feel like the code could be more optimized but it works.

Before:
![before](https://user-images.githubusercontent.com/54301439/107485352-8514b700-6b38-11eb-81de-fd47e69647a3.png)

After:
![after](https://user-images.githubusercontent.com/54301439/107485418-9958b400-6b38-11eb-88ed-03e0394b4a80.png)