### PR TITLE
Removes double indentation of the io server group

### DIFF
--- a/servers_v6.json
+++ b/servers_v6.json
@@ -24,8 +24,8 @@
     "address": ["be6.run", "mindustrycn.top"]
   },
   {
-	"name": "io",
-	"address": ["mindustry.io", "mindustry.io:1000", "mindustry.io:2000", "mindustry.io:3000", "mindustry.io:4000"]
+    "name": "io",
+    "address": ["mindustry.io", "mindustry.io:1000", "mindustry.io:2000", "mindustry.io:3000", "mindustry.io:4000"]
   },
   {
     "name": "ECAN",


### PR DESCRIPTION
keeps the indentation identical to the other servers in the list.