### PR TITLE
Add enable building hint, combine building and respawn hints

### DIFF
--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -8,7 +8,6 @@ import arc.graphics.g2d.*;
 import arc.math.*;
 import arc.math.geom.*;
 import arc.scene.*;
-import arc.scene.event.*;
 import arc.scene.ui.*;
 import arc.scene.ui.layout.*;
 import arc.util.*;
@@ -42,38 +41,32 @@ public class DesktopInput extends InputHandler{
     /** Selected build request for movement. */
     public @Nullable BuildPlan sreq;
     /** Whether player is currently deleting removal requests. */
-    public boolean deleting = false, wasBuilding = true, shouldShoot = false, panning = false;
+    public boolean deleting = false, shouldShoot = false, panning = false;
     /** Mouse pan speed. */
     public float panScale = 0.005f, panSpeed = 4.5f, panBoostSpeed = 11f;
 
     @Override
     public void buildUI(Group group){
-        //respawn hints
+        //building and respawn hints
         group.fill(t -> {
-            t.visible(() -> Core.settings.getBool("hints") && ui.hudfrag.shown && !player.dead() && !player.unit().spawnedByCore() && !(Core.settings.getBool("hints") && lastSchematic != null && !selectRequests.isEmpty()));
+            t.visible(() -> ui.hudfrag.shown && Core.settings.getBool("hints") && selectRequests.isEmpty() && (!isBuilding && !Core.settings.getBool("buildautopause") || player.unit().isBuilding() || !player.dead() && !player.unit().spawnedByCore()));
             t.bottom();
             t.table(Styles.black6, b -> {
                 b.defaults().left();
-                b.label(() -> Core.bundle.format("respawn", Core.keybinds.get(Binding.respawn).key.toString())).style(Styles.outlineLabel);
-            }).margin(6f);
-        });
-
-        //building hints
-        group.fill(t -> {
-            t.bottom();
-            t.visible(() -> {
-                t.color.a = Mathf.lerpDelta(t.color.a, player.unit().isBuilding() ? 1f : 0f, 0.15f);
-
-                return ui.hudfrag.shown && Core.settings.getBool("hints") && selectRequests.isEmpty() && t.color.a > 0.01f;
-            });
-            t.touchable(() -> t.color.a < 0.1f ? Touchable.disabled : Touchable.childrenOnly);
-            t.table(Styles.black6, b -> {
-                b.defaults().left();
-                b.label(() -> Core.bundle.format(!isBuilding ?  "resumebuilding" : "pausebuilding", Core.keybinds.get(Binding.pause_building).key.toString())).style(Styles.outlineLabel);
-                b.row();
-                b.label(() -> Core.bundle.format("cancelbuilding", Core.keybinds.get(Binding.clear_building).key.toString())).style(Styles.outlineLabel);
-                b.row();
-                b.label(() -> Core.bundle.format("selectschematic", Core.keybinds.get(Binding.schematic_select).key.toString())).style(Styles.outlineLabel);
+                b.label(() -> {
+                    String str = "";
+                    if(!isBuilding && !Core.settings.getBool("buildautopause") && !player.unit().isBuilding()){
+                        str += Core.bundle.format("enablebuilding", Core.keybinds.get(Binding.pause_building).key.toString());
+                    }else if(player.unit().isBuilding()){
+                        str += Core.bundle.format(isBuilding ? "pausebuilding" : "resumebuilding", Core.keybinds.get(Binding.pause_building).key.toString()) +
+                            "\n" + Core.bundle.format("cancelbuilding", Core.keybinds.get(Binding.clear_building).key.toString()) +
+                            "\n" + Core.bundle.format("selectschematic", Core.keybinds.get(Binding.schematic_select).key.toString());
+                    }
+                    if(!player.dead() && !player.unit().spawnedByCore()){
+                        str += (!str.isEmpty() ? "\n" : "") + Core.bundle.format("respawn", Core.keybinds.get(Binding.respawn).key.toString());
+                    }
+                    return str;
+                }).style(Styles.outlineLabel);
             }).margin(10f);
         });
 
@@ -454,7 +447,6 @@ public class DesktopInput extends InputHandler{
             buildWasAutoPaused = false;
 
             if(isBuilding){
-                wasBuilding = player.unit().isBuilding();
                 player.shooting = false;
             }
         }
@@ -562,7 +554,6 @@ public class DesktopInput extends InputHandler{
             }
 
             mode = none;
-            wasBuilding = true;
         }
 
         if(Core.input.keyTap(Binding.toggle_block_status)){


### PR DESCRIPTION
This PR reimplements #3857, but merges the building and respawn hints together, fixing #4642 and another existing unreported bug.

Before:
![resume building + respawn](https://user-images.githubusercontent.com/15149002/107892430-e098c900-6ed9-11eb-9862-a4db44e1c0c2.png)

After:
![enable building](https://user-images.githubusercontent.com/15149002/107892439-f0b0a880-6ed9-11eb-92a1-5eaabb8f83e6.gif)

This hint is hidden whenever the "Save Schematic..." button is shown.

I removed the hint fade-in/out to keep the code simpler and more maintainable.