### PR TITLE
Fixes BuilderAI & RepairAI retreat nullpointers

### DIFF
--- a/core/src/mindustry/ai/types/BuilderAI.java
+++ b/core/src/mindustry/ai/types/BuilderAI.java
@@ -53,7 +53,7 @@ public class BuilderAI extends AIController{
             if((retreatTimer += Time.delta) >= retreatDelay){
                 if(enemy != null){
                     var core = unit.closestCore();
-                    if(!unit.within(core, retreatDst)){
+                    if(core != null && !unit.within(core, retreatDst)){
                         moveTo(core, retreatDst);
                     }
                 }

--- a/core/src/mindustry/ai/types/RepairAI.java
+++ b/core/src/mindustry/ai/types/RepairAI.java
@@ -45,7 +45,7 @@ public class RepairAI extends AIController{
                 //fly away from enemy when not doing anything
                 if(avoid != null){
                     var core = unit.closestCore();
-                    if(!unit.within(core, retreatDst)){
+                    if(core != null && !unit.within(core, retreatDst)){
                         moveTo(core, retreatDst);
                     }
                 }


### PR DESCRIPTION
fixes a crash caused by the recent addition of the retreat mechanic:

```
[02-15-2021 07:53:47] [E] java.lang.NullPointerException
    at arc.math.geom.Position.within(Position.java:41)
    at mindustry.ai.types.BuilderAI.updateMovement(BuilderAI.java:56)
    at mindustry.entities.units.AIController.updateUnit(AIController.java:45)
    at mindustry.gen.PayloadUnit.update(PayloadUnit.java:1396)
    at mindustry.entities.EntityGroup.each(EntityGroup.java:68)
    at mindustry.entities.EntityGroup.update(EntityGroup.java:58)
    at mindustry.gen.Groups.update(Groups.java:71)
    at mindustry.core.Logic.update(Logic.java:411)
    at arc.backend.headless.HeadlessApplication.mainLoop(HeadlessApplication.java:89)
    at arc.backend.headless.HeadlessApplication$1.run(HeadlessApplication.java:54)
```