### PR TITLE
Add sector icon picker back button

### DIFF
--- a/core/src/mindustry/ui/dialogs/ControlsDialog.java
+++ b/core/src/mindustry/ui/dialogs/ControlsDialog.java
@@ -17,7 +17,7 @@ public class ControlsDialog extends KeybindDialog{
 
     @Override
     public void addCloseButton(){
-        buttons.button("@back", Icon.left, this::hide).size(230f, 64f);
+        buttons.button("@back", Icon.left, this::hide).size(210f, 64f);
 
         keyDown(key -> {
             if(key == KeyCode.escape || key == KeyCode.back) hide();

--- a/core/src/mindustry/ui/dialogs/PlanetDialog.java
+++ b/core/src/mindustry/ui/dialogs/PlanetDialog.java
@@ -208,11 +208,11 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
     }
 
     void addBack(){
-        buttons.button("@back", Icon.left, this::hide).size(200, 54).pad(2).bottom();
+        buttons.button("@back", Icon.left, this::hide).size(200f, 54f).pad(2).bottom();
     }
 
     void addTech(){
-        buttons.button("@techtree", Icon.tree, () -> ui.research.show()).size(200, 54).pad(2).bottom();
+        buttons.button("@techtree", Icon.tree, () -> ui.research.show()).size(200f, 54f).pad(2).bottom();
     }
 
     public void showOverview(){
@@ -677,7 +677,7 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
                     setFillParent(true);
                     cont.pane(t -> {
                         t.marginRight(19f);
-                        t.defaults().size(48);
+                        t.defaults().size(48f);
 
                         t.button(Icon.none, Styles.clearTogglei, () -> {
                             sector.info.icon = null;
@@ -701,6 +701,7 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
                             if(++i % 8 == 0) t.row();
                         }
                     });
+                    buttons.button("@back", Icon.left, this::hide).size(210f, 64f);
                 }}.show();
             }).size(40f);
         }).row();

--- a/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
+++ b/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
@@ -146,7 +146,7 @@ public class SettingsMenuDialog extends SettingsDialog{
                             }
                         }
                     }
-                    
+
                     for(var slot : control.saves.getSaveSlots().copy()){
                         if(slot.isSector()){
                             slot.delete();
@@ -501,13 +501,13 @@ public class SettingsMenuDialog extends SettingsDialog{
 
     @Override
     public void addCloseButton(){
-        buttons.button("@back", Icon.leftOpen, () -> {
+        buttons.button("@back", Icon.left, () -> {
             if(prefs.getChildren().first() != menu){
                 back();
             }else{
                 hide();
             }
-        }).size(230f, 64f);
+        }).size(210f, 64f);
 
         keyDown(key -> {
             if(key == KeyCode.escape || key == KeyCode.back){


### PR DESCRIPTION
This PR adds a back button to the sector icon picker dialog, which is possibly the only dialog to lack a back button. For some reason, `addCloseButton()` didn't work.

Also, it makes all back buttons in the settings menu share a consistent icon and size.