### PR TITLE
Reshuffle nydus servers

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -6,7 +6,7 @@
     "address": "mindustry.indielm.com"
   },
   {
-    "address": "mindustry.nydus.app:1337"
+    "address": "v5.mindustry.nydus.app:6565"
   },
   {
     "address": "mindustry.ru"

--- a/servers_be.json
+++ b/servers_be.json
@@ -3,6 +3,6 @@
     "address": "mindustry.us.to"
   },
   {
-    "address": "nydustry.nydus.app:6060"
+    "address": "be.mindustry.nydus.app:6567"
   }
 ]

--- a/servers_v6.json
+++ b/servers_v6.json
@@ -82,5 +82,9 @@
   {
     "name": "Mindustry PLAY",
     "address": ["92.63.100.160"]
+  },
+  {
+    "name": "Nydus",
+    "address": ["v6.mindustry.nydus.app:6566"]
   }
 ]


### PR DESCRIPTION
> this pull request adds an entry to the v6 server list, as well as reorganize its existing entries for v6 & bleeding edge:

(own sub-sub domain and unique sequential port where coincidentally the last number relates to the version)
```
be.mindustry.nydus.app:6567
v6.mindustry.nydus.app:6566
v5.mindustry.nydus.app:6565
```

as some were aware the v5 server ip landed you in "silicon valley", a small iq test map where you had to place a silicon smelter in order to get redirected to the actual server, this immensely reduced the amount of griefers and generally bad players.  

for v6 i have come up with "disrepair", here the task for the player is to simply place down either mender to proceed:

the 3 hints the player gets:
- map name is disrepair
- mode name is puzzle
- core is damaged

one of the first instincts of players should be to repair a damaged core. (besides, nothing else can be done on that map)
the moment they place down either a mender or mend projector they get sent to the actual server to join their peers.
when the last connected player leaves the map it gets reset to the below screenshot again, ensuring a clean slate.

lastly i'd like to mention that this pull which basically contains instructions on how to solve it doesn't break the concept, the goal for the player is to figure out how to make it through, doing it entirely by yourself / reading this / asking others / being told by others / etc are all valid ways, that is basically the gate, only players who can't figure out any of those get stuck.

![Screen Shot 2021-02-17 at 10 24 17](https://user-images.githubusercontent.com/3179271/108186230-68b2e480-710d-11eb-8a64-91b1547f2ae9.png)

![](https://cdn.discordapp.com/attachments/683377001918497090/809054249534619658/Screen_Shot_2021-02-10_at_14.32.30.png)

> i will be keeping an eye on how well it goes, should be on-par with silicon valley, and that turned out well enough ❤️ 
