### PR TITLE
Make content parser's parsers public

### DIFF
--- a/core/src/mindustry/mod/ContentParser.java
+++ b/core/src/mindustry/mod/ContentParser.java
@@ -125,7 +125,7 @@ public class ContentParser{
     LoadedMod currentMod;
     private Content currentContent;
 
-    private Json parser = new Json(){
+    public Json parser = new Json(){
         @Override
         public <T> T readValue(Class<T> type, Class elementType, JsonValue jsonData, Class keyType){
             T t = internalRead(type, elementType, jsonData, keyType);
@@ -181,7 +181,7 @@ public class ContentParser{
         }
     };
 
-    private ObjectMap<ContentType, TypeParser<?>> parsers = ObjectMap.of(
+    public ObjectMap<ContentType, TypeParser<?>> parsers = ObjectMap.of(
         ContentType.block, (TypeParser<Block>)(mod, name, value) -> {
             readBundle(ContentType.block, name, value);
 


### PR DESCRIPTION
- This allows Java mods (or JS mods...somehow) to provide custom parsers, so other mods with content dependency to a Java mods will be parsed with the additional java classes.

- ...Wording is horrible, here is an example:

Java mod sk7725/BetaMindy has `PayloadTurret.java`
Json mod bluewolf/BetaBeta has
`routerpayturret.hjson`, with the following content:
```
type: PayloadTurret
size: 1
(and so on)
```
(BetaBeta has dependency set to BetaMindy of course)