### PR TITLE
Units should not be able to shoot when reloadMultiplier = 0

### DIFF
--- a/core/src/mindustry/entities/comp/WeaponsComp.java
+++ b/core/src/mindustry/entities/comp/WeaponsComp.java
@@ -81,7 +81,7 @@ abstract class WeaponsComp implements Teamc, Posc, Rotc, Velc, Statusc{
     }
 
     boolean canShoot(){
-        return true;
+        return reloadMultiplier > 0f;
     }
 
     @Override


### PR DESCRIPTION
If a unit is fully reloaded, then it hit with a reloadMultiplier = 0 status effect, you can still shoot once, which doesn't really make much sense.