### PR TITLE
Add disarmed status effect that disarms

### DIFF
--- a/core/src/mindustry/content/StatusEffects.java
+++ b/core/src/mindustry/content/StatusEffects.java
@@ -12,7 +12,7 @@ import mindustry.graphics.*;
 import static mindustry.Vars.*;
 
 public class StatusEffects implements ContentList{
-    public static StatusEffect none, burning, freezing, unmoving, slow, wet, muddy, melting, sapped, tarred, overdrive, overclock, shielded, shocked, blasted, corroded, boss, sporeSlowed;
+    public static StatusEffect none, burning, freezing, unmoving, slow, wet, muddy, melting, sapped, tarred, overdrive, overclock, shielded, shocked, blasted, corroded, boss, sporeSlowed, disarmed;
 
     @Override
     public void load(){
@@ -172,6 +172,11 @@ public class StatusEffects implements ContentList{
         corroded = new StatusEffect("corroded"){{
             color = Pal.plastanium;
             damage = 0.1f;
+        }};
+
+        disarmed = new StatusEffect("disarmed"){{
+            color = Color.valueOf("e9ead3");
+            disarms = true;
         }};
     }
 }

--- a/core/src/mindustry/content/StatusEffects.java
+++ b/core/src/mindustry/content/StatusEffects.java
@@ -176,7 +176,7 @@ public class StatusEffects implements ContentList{
 
         disarmed = new StatusEffect("disarmed"){{
             color = Color.valueOf("e9ead3");
-            disarms = true;
+            disarm = true;
         }};
     }
 }

--- a/core/src/mindustry/entities/comp/StatusComp.java
+++ b/core/src/mindustry/entities/comp/StatusComp.java
@@ -20,6 +20,7 @@ abstract class StatusComp implements Posc, Flyingc{
     private transient Bits applied = new Bits(content.getBy(ContentType.status).size);
 
     @ReadOnly transient float speedMultiplier = 1, damageMultiplier = 1, healthMultiplier = 1, reloadMultiplier = 1;
+    @ReadOnly transient boolean disarmed = false;
 
     @Import UnitType type;
 
@@ -111,6 +112,7 @@ abstract class StatusComp implements Posc, Flyingc{
 
         applied.clear();
         speedMultiplier = damageMultiplier = healthMultiplier = reloadMultiplier = 1f;
+        disarmed = false;
 
         if(statuses.isEmpty()) return;
 
@@ -132,6 +134,9 @@ abstract class StatusComp implements Posc, Flyingc{
                 healthMultiplier *= entry.effect.healthMultiplier;
                 damageMultiplier *= entry.effect.damageMultiplier;
                 reloadMultiplier *= entry.effect.reloadMultiplier;
+
+                if(entry.effect.disarms) disarmed = true;
+
                 entry.effect.update(self(), entry.time);
             }
         }

--- a/core/src/mindustry/entities/comp/StatusComp.java
+++ b/core/src/mindustry/entities/comp/StatusComp.java
@@ -135,7 +135,7 @@ abstract class StatusComp implements Posc, Flyingc{
                 damageMultiplier *= entry.effect.damageMultiplier;
                 reloadMultiplier *= entry.effect.reloadMultiplier;
 
-                disarmed |= entry.effect.disarms;
+                disarmed |= entry.effect.disarm;
 
                 entry.effect.update(self(), entry.time);
             }

--- a/core/src/mindustry/entities/comp/StatusComp.java
+++ b/core/src/mindustry/entities/comp/StatusComp.java
@@ -135,7 +135,7 @@ abstract class StatusComp implements Posc, Flyingc{
                 damageMultiplier *= entry.effect.damageMultiplier;
                 reloadMultiplier *= entry.effect.reloadMultiplier;
 
-                if(entry.effect.disarms) disarmed = true;
+                disarmed |= entry.effect.disarms;
 
                 entry.effect.update(self(), entry.time);
             }

--- a/core/src/mindustry/entities/comp/UnitComp.java
+++ b/core/src/mindustry/entities/comp/UnitComp.java
@@ -32,7 +32,7 @@ import static mindustry.Vars.*;
 @Component(base = true)
 abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, Itemsc, Rotc, Unitc, Weaponsc, Drawc, Boundedc, Syncc, Shieldc, Commanderc, Displayable, Senseable, Ranged, Minerc, Builderc{
 
-    @Import boolean hovering, dead;
+    @Import boolean hovering, dead, disarmed;
     @Import float x, y, rotation, elevation, maxHealth, drag, armor, hitSize, health, ammo, minFormationSpeed;
     @Import Team team;
     @Import int id;
@@ -178,7 +178,7 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
     @Replace
     public boolean canShoot(){
         //cannot shoot while boosting
-        return !(type.canBoost && isFlying());
+        return !disarmed && !(type.canBoost && isFlying());
     }
 
     @Override

--- a/core/src/mindustry/entities/comp/WeaponsComp.java
+++ b/core/src/mindustry/entities/comp/WeaponsComp.java
@@ -16,6 +16,7 @@ import static mindustry.Vars.*;
 @Component
 abstract class WeaponsComp implements Teamc, Posc, Rotc, Velc, Statusc{
     @Import float x, y, rotation, reloadMultiplier;
+    @Import boolean disarmed;
     @Import Vec2 vel;
     @Import UnitType type;
 
@@ -81,7 +82,7 @@ abstract class WeaponsComp implements Teamc, Posc, Rotc, Velc, Statusc{
     }
 
     boolean canShoot(){
-        return true;
+        return !disarmed;
     }
 
     @Override

--- a/core/src/mindustry/type/StatusEffect.java
+++ b/core/src/mindustry/type/StatusEffect.java
@@ -17,8 +17,10 @@ public class StatusEffect extends MappableContent{
     public float healthMultiplier = 1f;
     /** Unit speed multiplier */
     public float speedMultiplier = 1f;
-    /** Unit speed multiplier */
+    /** Unit reload multiplier. */
     public float reloadMultiplier = 1f;
+    /** Unit weapon(s) disabled. */
+    public boolean disarms = false;
     /** Damage per frame. */
     public float damage;
     /** Chance of effect appearing. */

--- a/core/src/mindustry/type/StatusEffect.java
+++ b/core/src/mindustry/type/StatusEffect.java
@@ -20,7 +20,7 @@ public class StatusEffect extends MappableContent{
     /** Unit reload multiplier. */
     public float reloadMultiplier = 1f;
     /** Unit weapon(s) disabled. */
-    public boolean disarms = false;
+    public boolean disarm = false;
     /** Damage per frame. */
     public float damage;
     /** Chance of effect appearing. */


### PR DESCRIPTION
> resolves #4741 by adding a new status effect property (+ a status effect that uses it, though currently no particle effects)

ingame showcase with the parallax: (fire held down all the time)

<img width="614" alt="Screen Shot 2021-02-23 at 10 05 54" src="https://user-images.githubusercontent.com/3179271/108822146-f6d01480-75be-11eb-884c-021061ed8737.png">

https://user-images.githubusercontent.com/3179271/108822158-fafc3200-75be-11eb-84bf-f4e1584c8fce.mp4

> weapons stop rotating if you can't shoot, leaving that as-is for now, oh and the status color is Fx.plasticburn :)