### PR TITLE
Don't heal target's that don't need healing.

### DIFF
--- a/core/src/mindustry/entities/abilities/RepairFieldAbility.java
+++ b/core/src/mindustry/entities/abilities/RepairFieldAbility.java
@@ -31,9 +31,9 @@ public class RepairFieldAbility extends Ability{
             Units.nearby(unit.team, unit.x, unit.y, range, other -> {
                 if(other.damaged()){
                     healEffect.at(other);
+                    other.heal(amount);
                     wasHealed = true;
                 }
-                other.heal(amount);
             });
 
             if(wasHealed){


### PR DESCRIPTION
Why is the heal outside of the check for if the unit is damaged?