### PR TITLE
Make `BuildPlan.placeable` ignore rotation

### DIFF
--- a/core/src/mindustry/entities/units/BuildPlan.java
+++ b/core/src/mindustry/entities/units/BuildPlan.java
@@ -63,7 +63,7 @@ public class BuildPlan implements Position{
     }
 
     public boolean placeable(Team team){
-        return Build.validPlace(block, team, x, y, rotation);
+        return Build.validPlace(block, team, x, y, -1);
     }
 
     public boolean isRotation(Team team){


### PR DESCRIPTION
Currently, there's this problem with auto-bridging conveyors, which is caused because `Build.validPlace` does not allow conveyors to replace itself if the rotation is the same. 
![](https://user-images.githubusercontent.com/57631841/108997996-974a3580-76a0-11eb-83f4-dc9f412c6d97.png)

This PR makes `BuildPlan.placeable` use the rotation of -1, which seems to be the simplest solution to this problem at the moment (Nothing other than the autobridging algorithm uses this function at the moment, so it shouldn't break anything)