### PR TITLE
Fix a few issues w/ double tap mining

### DIFF
--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -491,12 +491,10 @@ public class DesktopInput extends InputHandler{
                 sreq = req;
             }else if(req != null && req.breaking){
                 deleting = true;
-            }else if(Core.settings.getBool("doubletapmine") && selected == prevSelected && Time.timeSinceMillis(selectMillis) < 500){
-                tryBeginMine(selected);
             }else if(selected != null){
                 //only begin shooting if there's no cursor event
                 if(!tryTapPlayer(Core.input.mouseWorld().x, Core.input.mouseWorld().y) && !tileTapped(selected.build) && !player.unit().activelyBuilding() && !droppingItem
-                    && (Core.settings.getBool("doubletapmine") ? !tryStopMine(selected) : !tryBeginMine(selected)) && !Core.scene.hasKeyboard()){
+                    && !((!settings.getBool("doubletapmine") || selected == prevSelected && Time.timeSinceMillis(selectMillis) < 500) && tryBeginMine(selected)) && !Core.scene.hasKeyboard()){
                     player.shooting = shouldShoot;
                 }
             }else if(!Core.scene.hasKeyboard()){ //if it's out of bounds, shooting is just fine


### PR DESCRIPTION
Currently, double tap mining consumes clicks so it prevents the player from configuring any block if they click twice within 500ms. The double tap mining was also using the `selected` var which could have been null causing a crash. This is a very messy solution but it gets the job done and achieves the intended functionality,