### PR TITLE
Avoid drawing potential links for contacting blocks

### DIFF
--- a/core/src/mindustry/world/Tile.java
+++ b/core/src/mindustry/world/Tile.java
@@ -58,7 +58,7 @@ public class Tile implements Position, QuadTreeObject, Displayable{
         return Point2.pack(x, y);
     }
 
-    /** Returns true if these tiles touch on any axis. */
+    /** Returns true if these tiles are right next to eachother. */
     public boolean adjacentTo(Tile tile){
         return relativeTo(tile) != -1;
     }

--- a/core/src/mindustry/world/Tile.java
+++ b/core/src/mindustry/world/Tile.java
@@ -58,6 +58,11 @@ public class Tile implements Position, QuadTreeObject, Displayable{
         return Point2.pack(x, y);
     }
 
+    /** Returns true if these tiles touch on any axis. */
+    public boolean adjacentTo(Tile tile){
+        return relativeTo(tile) != -1;
+    }
+
     public byte relativeTo(Tile tile){
         return relativeTo(tile.x, tile.y);
     }

--- a/core/src/mindustry/world/blocks/power/PowerNode.java
+++ b/core/src/mindustry/world/blocks/power/PowerNode.java
@@ -144,9 +144,10 @@ public class PowerNode extends PowerBlock{
         Drawf.circles(x * tilesize + offset, y * tilesize + offset, laserRange * tilesize);
 
         getPotentialLinks(tile, other -> {
-            if(tile.adjacentTo(other.tile)) return; //power gets transferred via direct contact
-            Draw.color(laserColor1, Renderer.laserOpacity * 0.5f);
-            drawLaser(tile.team(), x * tilesize + offset, y * tilesize + offset, other.x, other.y, size, other.block.size);
+            if(!tile.adjacentTo(other.tile)){ //power gets transferred via direct contact
+                Draw.color(laserColor1, Renderer.laserOpacity * 0.5f);
+                drawLaser(tile.team(), x * tilesize + offset, y * tilesize + offset, other.x, other.y, size, other.block.size);
+            }
 
             Drawf.square(other.x, other.y, other.block.size * tilesize / 2f + 2f, Pal.place);
 

--- a/core/src/mindustry/world/blocks/power/PowerNode.java
+++ b/core/src/mindustry/world/blocks/power/PowerNode.java
@@ -144,7 +144,7 @@ public class PowerNode extends PowerBlock{
         Drawf.circles(x * tilesize + offset, y * tilesize + offset, laserRange * tilesize);
 
         getPotentialLinks(tile, other -> {
-            if(!tile.adjacentTo(other.tile)) return; //power gets transferred via direct contact
+            if(tile.adjacentTo(other.tile)) return; //power gets transferred via direct contact
             Draw.color(laserColor1, Renderer.laserOpacity * 0.5f);
             drawLaser(tile.team(), x * tilesize + offset, y * tilesize + offset, other.x, other.y, size, other.block.size);
 

--- a/core/src/mindustry/world/blocks/power/PowerNode.java
+++ b/core/src/mindustry/world/blocks/power/PowerNode.java
@@ -144,10 +144,9 @@ public class PowerNode extends PowerBlock{
         Drawf.circles(x * tilesize + offset, y * tilesize + offset, laserRange * tilesize);
 
         getPotentialLinks(tile, other -> {
-            if(!tile.adjacentTo(other.tile)){ //power gets transferred via direct contact
-                Draw.color(laserColor1, Renderer.laserOpacity * 0.5f);
-                drawLaser(tile.team(), x * tilesize + offset, y * tilesize + offset, other.x, other.y, size, other.block.size);
-            }
+            if(tile.adjacentTo(other.tile)) return; //power gets transferred via direct contact
+            Draw.color(laserColor1, Renderer.laserOpacity * 0.5f);
+            drawLaser(tile.team(), x * tilesize + offset, y * tilesize + offset, other.x, other.y, size, other.block.size);
 
             Drawf.square(other.x, other.y, other.block.size * tilesize / 2f + 2f, Pal.place);
 

--- a/core/src/mindustry/world/blocks/power/PowerNode.java
+++ b/core/src/mindustry/world/blocks/power/PowerNode.java
@@ -144,7 +144,7 @@ public class PowerNode extends PowerBlock{
         Drawf.circles(x * tilesize + offset, y * tilesize + offset, laserRange * tilesize);
 
         getPotentialLinks(tile, other -> {
-            if(tile.relativeTo(other.tile) > -1) return; //power transferred via direct contact, no visual indicators needed here
+            if(!tile.adjacentTo(other.tile)) return; //power gets transferred via direct contact
             Draw.color(laserColor1, Renderer.laserOpacity * 0.5f);
             drawLaser(tile.team(), x * tilesize + offset, y * tilesize + offset, other.x, other.y, size, other.block.size);
 

--- a/core/src/mindustry/world/blocks/power/PowerNode.java
+++ b/core/src/mindustry/world/blocks/power/PowerNode.java
@@ -144,6 +144,7 @@ public class PowerNode extends PowerBlock{
         Drawf.circles(x * tilesize + offset, y * tilesize + offset, laserRange * tilesize);
 
         getPotentialLinks(tile, other -> {
+            if(tile.relativeTo(other.tile) > -1) return; //power transferred via direct contact, no visual indicators needed here
             Draw.color(laserColor1, Renderer.laserOpacity * 0.5f);
             drawLaser(tile.team(), x * tilesize + offset, y * tilesize + offset, other.x, other.y, size, other.block.size);
 


### PR DESCRIPTION
something that has become a little more noticeable with the ghost cables is that it also previews in places where it transfers via proximity, this adds a small check that prevents drawing any visuals if it on direct contact on any of the 4 axis:
(doesn't draw the purple thing either, but why should it? no wire would spawn there anyways)

![Screen Shot 2021-02-27 at 14 45 03](https://user-images.githubusercontent.com/3179271/109389273-36269a00-790c-11eb-81ff-c84ebdc4f0af.png)
![Screen Shot 2021-02-27 at 14 56 13](https://user-images.githubusercontent.com/3179271/109389275-37f05d80-790c-11eb-836d-eda2ef6f7d65.png)

> though maybe this has to go in the potentiallinks part of the code (that i don't fully understand) since it could take up 1 of the drawn links that could have happened if one wasn't reserved just for the adjecency ones*
