### PR TITLE
Make other things use modulo

### DIFF
--- a/core/src/mindustry/world/blocks/experimental/BlockForge.java
+++ b/core/src/mindustry/world/blocks/experimental/BlockForge.java
@@ -105,7 +105,7 @@ public class BlockForge extends PayloadAcceptor{
                     consume();
                     payload = new BuildPayload(recipe, team);
                     payVector.setZero();
-                    progress = 0f;
+                    progress %= 1f;
                 }
             }
 

--- a/core/src/mindustry/world/blocks/power/ItemLiquidGenerator.java
+++ b/core/src/mindustry/world/blocks/power/ItemLiquidGenerator.java
@@ -134,7 +134,7 @@ public class ItemLiquidGenerator extends PowerGenerator{
                     Item item = items.take();
                     productionEfficiency = getItemEfficiency(item);
                     explosiveness = item.explosiveness;
-                    generateTime = 1f;
+                    generateTime %= 1f;
                 }
 
                 if(generateTime > 0f){

--- a/core/src/mindustry/world/blocks/units/Reconstructor.java
+++ b/core/src/mindustry/world/blocks/units/Reconstructor.java
@@ -175,7 +175,7 @@ public class Reconstructor extends UnitBlock{
                         //upgrade the unit
                         if(progress >= constructTime){
                             payload.unit = upgrade(payload.unit.type).create(payload.unit.team());
-                            progress = 0;
+                            progress %= 1f;
                             Effect.shake(2f, 3f, this);
                             Fx.producesmoke.at(this);
                             consume();

--- a/core/src/mindustry/world/blocks/units/UnitBlock.java
+++ b/core/src/mindustry/world/blocks/units/UnitBlock.java
@@ -35,7 +35,7 @@ public class UnitBlock extends PayloadAcceptor{
         public float progress, time, speedScl;
 
         public void spawned(){
-            progress = 0f;
+            progress %= 1f;
             payload = null;
         }
 

--- a/core/src/mindustry/world/blocks/units/UnitFactory.java
+++ b/core/src/mindustry/world/blocks/units/UnitFactory.java
@@ -225,7 +225,7 @@ public class UnitFactory extends UnitBlock{
                 UnitPlan plan = plans.get(currentPlan);
 
                 if(progress >= plan.time && consValid()){
-                    progress = 0f;
+                    progress %= 1f;
 
                     payload = new UnitPayload(plan.unit.create(team));
                     payVector.setZero();


### PR DESCRIPTION
Since genericCrafter now `%` instead of setting to 0, I figured other things should also do the same.