### PR TITLE
Add buildSpeedMultiplier status effect

### DIFF
--- a/core/src/mindustry/entities/comp/BuilderComp.java
+++ b/core/src/mindustry/entities/comp/BuilderComp.java
@@ -29,8 +29,7 @@ import static mindustry.Vars.*;
 abstract class BuilderComp implements Posc, Statusc, Teamc, Rotc{
     static final Vec2[] vecs = new Vec2[]{new Vec2(), new Vec2(), new Vec2(), new Vec2()};
 
-    @Import float x, y, rotation;
-    @Import boolean disarmed;
+    @Import float x, y, rotation, buildSpeedMultiplier;
     @Import UnitType type;
     @Import Team team;
 
@@ -42,7 +41,7 @@ abstract class BuilderComp implements Posc, Statusc, Teamc, Rotc{
     private transient float buildAlpha = 0f;
 
     public boolean canBuild(){
-        return !disarmed && type.buildSpeed > 0;
+        return type.buildSpeed > 0 && buildSpeedMultiplier > 0;
     }
 
     @Override
@@ -127,9 +126,9 @@ abstract class BuilderComp implements Posc, Statusc, Teamc, Rotc{
 
         //otherwise, update it.
         if(current.breaking){
-            entity.deconstruct(self(), core, 1f / entity.buildCost * Time.delta * type.buildSpeed * state.rules.buildSpeedMultiplier);
+            entity.deconstruct(self(), core, 1f / entity.buildCost * Time.delta * type.buildSpeed * buildSpeedMultiplier * state.rules.buildSpeedMultiplier);
         }else{
-            entity.construct(self(), core, 1f / entity.buildCost * Time.delta * type.buildSpeed * state.rules.buildSpeedMultiplier, current.config);
+            entity.construct(self(), core, 1f / entity.buildCost * Time.delta * type.buildSpeed * buildSpeedMultiplier * state.rules.buildSpeedMultiplier, current.config);
         }
 
         current.stuck = Mathf.equal(current.progress, entity.progress);

--- a/core/src/mindustry/entities/comp/BuilderComp.java
+++ b/core/src/mindustry/entities/comp/BuilderComp.java
@@ -26,10 +26,11 @@ import java.util.*;
 import static mindustry.Vars.*;
 
 @Component
-abstract class BuilderComp implements Posc, Teamc, Rotc{
+abstract class BuilderComp implements Posc, Statusc, Teamc, Rotc{
     static final Vec2[] vecs = new Vec2[]{new Vec2(), new Vec2(), new Vec2(), new Vec2()};
 
     @Import float x, y, rotation;
+    @Import boolean disarmed;
     @Import UnitType type;
     @Import Team team;
 
@@ -41,7 +42,7 @@ abstract class BuilderComp implements Posc, Teamc, Rotc{
     private transient float buildAlpha = 0f;
 
     public boolean canBuild(){
-        return type.buildSpeed > 0;
+        return !disarmed && type.buildSpeed > 0;
     }
 
     @Override

--- a/core/src/mindustry/entities/comp/StatusComp.java
+++ b/core/src/mindustry/entities/comp/StatusComp.java
@@ -19,7 +19,7 @@ abstract class StatusComp implements Posc, Flyingc{
     private Seq<StatusEntry> statuses = new Seq<>();
     private transient Bits applied = new Bits(content.getBy(ContentType.status).size);
 
-    @ReadOnly transient float speedMultiplier = 1, damageMultiplier = 1, healthMultiplier = 1, reloadMultiplier = 1;
+    @ReadOnly transient float speedMultiplier = 1, damageMultiplier = 1, healthMultiplier = 1, reloadMultiplier = 1, buildSpeedMultiplier = 1;
     @ReadOnly transient boolean disarmed = false;
 
     @Import UnitType type;
@@ -111,7 +111,7 @@ abstract class StatusComp implements Posc, Flyingc{
         }
 
         applied.clear();
-        speedMultiplier = damageMultiplier = healthMultiplier = reloadMultiplier = 1f;
+        speedMultiplier = damageMultiplier = healthMultiplier = reloadMultiplier = buildSpeedMultiplier = 1f;
         disarmed = false;
 
         if(statuses.isEmpty()) return;
@@ -134,6 +134,7 @@ abstract class StatusComp implements Posc, Flyingc{
                 healthMultiplier *= entry.effect.healthMultiplier;
                 damageMultiplier *= entry.effect.damageMultiplier;
                 reloadMultiplier *= entry.effect.reloadMultiplier;
+                buildSpeedMultiplier *= entry.effect.buildSpeedMultiplier;
 
                 disarmed |= entry.effect.disarm;
 

--- a/core/src/mindustry/type/StatusEffect.java
+++ b/core/src/mindustry/type/StatusEffect.java
@@ -19,7 +19,9 @@ public class StatusEffect extends MappableContent{
     public float speedMultiplier = 1f;
     /** Unit reload multiplier. */
     public float reloadMultiplier = 1f;
-    /** Unit weapon(s) and building disabled. */
+    /** Unit build speed multiplier. */
+    public float buildSpeedMultiplier = 1f;
+    /** Unit weapon(s) disabled. */
     public boolean disarm = false;
     /** Damage per frame. */
     public float damage;

--- a/core/src/mindustry/type/StatusEffect.java
+++ b/core/src/mindustry/type/StatusEffect.java
@@ -15,11 +15,11 @@ public class StatusEffect extends MappableContent{
     public float damageMultiplier = 1f;
     /** Unit health multiplier. */
     public float healthMultiplier = 1f;
-    /** Unit speed multiplier */
+    /** Unit speed multiplier. */
     public float speedMultiplier = 1f;
     /** Unit reload multiplier. */
     public float reloadMultiplier = 1f;
-    /** Unit weapon(s) disabled. */
+    /** Unit weapon(s) and building disabled. */
     public boolean disarm = false;
     /** Damage per frame. */
     public float damage;


### PR DESCRIPTION
~~This PR makes the disarmed status effect into a general "stops units from doing things" effect, by also preventing building. This makes disarmed effective against builder units like polys and megas.~~

This PR adds the `buildSpeedMultiplier` status effect. `canBuild()` returns false when this effect is ≤ 0.

Related: #4762