### PR TITLE
Draw to-be affected blocks when placing projectors

### DIFF
--- a/core/src/mindustry/world/blocks/defense/MendProjector.java
+++ b/core/src/mindustry/world/blocks/defense/MendProjector.java
@@ -54,7 +54,9 @@ public class MendProjector extends Block{
 
     @Override
     public void drawPlace(int x, int y, int rotation, boolean valid){
-        Drawf.dashCircle(x * tilesize + offset, y * tilesize + offset, range, Pal.accent);
+        Drawf.dashCircle(x * tilesize + offset, y * tilesize + offset, range, baseColor);
+
+        indexer.eachBlock(player.team(), x * tilesize + offset, y * tilesize + offset, range, other -> true, other -> Drawf.selected(other, Tmp.c1.set(baseColor).a(Mathf.absin(4f, 1f))));
     }
 
     public class MendBuild extends Building implements Ranged{

--- a/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
+++ b/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
@@ -47,7 +47,9 @@ public class OverdriveProjector extends Block{
 
     @Override
     public void drawPlace(int x, int y, int rotation, boolean valid){
-        Drawf.dashCircle(x * tilesize + offset, y * tilesize + offset, range, Pal.accent);
+        Drawf.dashCircle(x * tilesize + offset, y * tilesize + offset, range, baseColor);
+
+        indexer.eachBlock(player.team(), x * tilesize + offset, y * tilesize + offset, range, other -> other.block.canOverdrive, other -> Drawf.selected(other, Tmp.c1.set(baseColor).a(Mathf.absin(4f, 1f))));
     }
 
     @Override


### PR DESCRIPTION
previously overdrive & mend projectors did not display which blocks in range would be affected during placement mode, this pull request makes that happen, as well as change the placement mode circle color to the one you see when its selected:

![Screen Shot 2021-02-28 at 15 35 12](https://user-images.githubusercontent.com/3179271/109422159-a7348300-79da-11eb-86f5-93cdd3c8575a.png)
![Screen Shot 2021-02-28 at 15 35 19](https://user-images.githubusercontent.com/3179271/109422161-a8fe4680-79da-11eb-8a8c-e8536c214313.png)
