### PR TITLE
Display map names with underscores

### DIFF
--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -339,7 +339,7 @@ public class ServerControl implements ApplicationListener{
             if(!maps.all().isEmpty()){
                 info("Maps:");
                 for(Map map : maps.all()){
-                    info("  @: &fi@ / @x@", map.name(), map.custom ? "Custom" : "Default", map.width, map.height);
+                    info("  @: &fi@ / @x@", map.name().replace(' ', '_'), map.custom ? "Custom" : "Default", map.width, map.height);
                 }
             }else{
                 info("No maps found.");


### PR DESCRIPTION
## Benefits
- It makes it obvious how to host maps with spaces (thus removing questions such as #1247)
- It allows to copy-paste a map name from the output of the `maps` command.

## Drawbacks
- It doesn't display the real name I guess?

## Workarounds
- Who cares for the real name. You can't use it in a command anyway.

## Other approaches
- It could be documented (ie. not just in an issue), but that would have to be discoverable and many people won't search for it.