### PR TITLE
Color power lasers depending on battery drain

### DIFF
--- a/core/src/mindustry/world/blocks/power/PowerNode.java
+++ b/core/src/mindustry/world/blocks/power/PowerNode.java
@@ -35,6 +35,7 @@ public class PowerNode extends PowerBlock{
     public int maxNodes = 3;
     public Color laserColor1 = Color.white;
     public Color laserColor2 = Pal.powerLight;
+    public Color laserColor3 = Color.valueOf("fb9567");
 
     public PowerNode(String name){
         super(name);
@@ -162,8 +163,12 @@ public class PowerNode extends PowerBlock{
         Placement.calculateNodes(points, this, rotation, (point, other) -> overlaps(world.tile(point.x, point.y), world.tile(other.x, other.y)));
     }
 
-    protected void setupColor(float satisfaction){
-        Draw.color(laserColor1, laserColor2, (1f - satisfaction) * 0.86f + Mathf.absin(3f, 0.1f));
+    protected void setupColor(float satisfaction, float batteryUsed){
+        if(Mathf.zero(batteryUsed)){
+            Draw.color(laserColor1, laserColor2, (1f - satisfaction) * 0.86f + Mathf.absin(3f, 0.1f));
+        }else{
+            Draw.color(laserColor1, laserColor3, Mathf.clamp(batteryUsed * 500f + 0.5f) * 0.86f + Mathf.absin(3f, 0.1f));
+        }
         Draw.alpha(Renderer.laserOpacity);
     }
 
@@ -243,7 +248,7 @@ public class PowerNode extends PowerBlock{
     @Override
     public void drawRequestConfigTop(BuildPlan req, Eachable<BuildPlan> list){
         if(req.config instanceof Point2[] ps){
-            setupColor(1f);
+            setupColor(1f, 0f);
             for(Point2 point : ps){
                 int px = req.x + point.x, py = req.y + point.y;
                 otherReq = null;
@@ -419,7 +424,7 @@ public class PowerNode extends PowerBlock{
             if(Mathf.zero(Renderer.laserOpacity)) return;
 
             Draw.z(Layer.power);
-            setupColor(power.graph.getSatisfaction());
+            setupColor(power.graph.getSatisfaction(), power.graph.getBatteryUsedFraction());
 
             for(int i = 0; i < power.links.size; i++){
                 Building link = world.build(power.links.get(i));


### PR DESCRIPTION
This PR resolves [suggestion #2012](https://github.com/Anuken/Mindustry-Suggestions/issues/2012).

Currently, while batteries are being drained, power lasers remain full bright because battery power is fulfilling power needs. That means that when batteries are finally depleted, players are suddenly and rudely awakened to total power loss with no warning.

This PR colors power lasers according to the percent of total stored power being drained each tick. This solution should scale well to power grids both small and large, early game and late game. The color used is the same as [that used to indicate battery fullness](https://github.com/Anuken/Mindustry/blob/master/core/src/mindustry/world/blocks/power/Battery.java#L17).

The color change is designed to be sudden and immediately noticeable upon transitioning to negative power production. From there, as the total stored power depletes, the color becomes increasingly redder until total power loss, at which there is another sudden color change to indicate that.

These images show power laser color at 1%, 33%, 66%, and 99% battery depletion. Notice that the 1% laser color varies according to drain.

![Power laser battery color](https://user-images.githubusercontent.com/15149002/109433504-8150b380-79c5-11eb-9865-d963e17354ac.png)

How it looks at 50% power laser opacity:

![Power laser battery color 50%](https://user-images.githubusercontent.com/15149002/109433505-844ba400-79c5-11eb-8b79-ac1207c8d616.png)
