### PR TITLE
Block Ammo Multiplier

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -956,6 +956,7 @@ rules.buildai = AI Building
 rules.enemyCheat = Infinite AI (Red Team) Resources
 rules.blockhealthmultiplier = Block Health Multiplier
 rules.blockdamagemultiplier = Block Damage Multiplier
+rules.blockammomultiplier = Block Ammo Multiplier
 rules.unitbuildspeedmultiplier = Unit Production Speed Multiplier
 rules.unithealthmultiplier = Unit Health Multiplier
 rules.unitdamagemultiplier = Unit Damage Multiplier

--- a/core/src/mindustry/game/Rules.java
+++ b/core/src/mindustry/game/Rules.java
@@ -56,6 +56,8 @@ public class Rules{
     public float blockHealthMultiplier = 1f;
     /** How much damage blocks (turrets) deal. */
     public float blockDamageMultiplier = 1f;
+    /** Multiplier for block ammo. */
+    public float blockAmmoMultiplier = 1f;
     /** Multiplier for buildings resource cost. */
     public float buildCostMultiplier = 1f;
     /** Multiplier for building speed. */

--- a/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
+++ b/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
@@ -147,6 +147,7 @@ public class CustomRulesDialog extends BaseDialog{
         number("@rules.deconstructrefundmultiplier", false, f -> rules.deconstructRefundMultiplier = f, () -> rules.deconstructRefundMultiplier, () -> !rules.infiniteResources);
         number("@rules.blockhealthmultiplier", f -> rules.blockHealthMultiplier = f, () -> rules.blockHealthMultiplier);
         number("@rules.blockdamagemultiplier", f -> rules.blockDamageMultiplier = f, () -> rules.blockDamageMultiplier);
+        number("@rules.blockammomultiplier", f -> rules.blockAmmoMultiplier = f, () -> rules.blockAmmoMultiplier, 1, 100);
 
         main.button("@configure",
             () -> loadoutDialog.show(Blocks.coreShard.itemCapacity, rules.loadout,

--- a/core/src/mindustry/world/blocks/defense/turrets/ItemTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/ItemTurret.java
@@ -99,7 +99,9 @@ public class ItemTurret extends Turret{
 
             if(type == null) return 0;
 
-            return Math.min((int)((maxAmmo - totalAmmo) / ammoTypes.get(item).ammoMultiplier), amount);
+            //should always accept ammo if it has none
+            int acceptAmount = Math.min((int)((maxAmmo - totalAmmo) / ammoMultiplier(ammoTypes.get(item))), amount);
+            return !hasAmmo() && acceptAmount == 0 ? 1 : acceptAmount;
         }
 
         @Override
@@ -123,7 +125,8 @@ public class ItemTurret extends Turret{
             }
 
             BulletType type = ammoTypes.get(item);
-            totalAmmo += type.ammoMultiplier;
+            float amountAdded = Math.min(maxAmmo - totalAmmo, ammoMultiplier(type));
+            totalAmmo += amountAdded;
 
             //find ammo entry by type
             for(int i = 0; i < ammo.size; i++){
@@ -131,19 +134,19 @@ public class ItemTurret extends Turret{
 
                 //if found, put it to the right
                 if(entry.item == item){
-                    entry.amount += type.ammoMultiplier;
+                    entry.amount += amountAdded;
                     ammo.swap(i, ammo.size - 1);
                     return;
                 }
             }
 
             //must not be found
-            ammo.add(new ItemEntry(item, (int)type.ammoMultiplier));
+            ammo.add(new ItemEntry(item, (int)amountAdded));
         }
 
         @Override
         public boolean acceptItem(Building source, Item item){
-            return ammoTypes.get(item) != null && totalAmmo + ammoTypes.get(item).ammoMultiplier <= maxAmmo;
+            return ammoTypes.get(item) != null && (!hasAmmo() || totalAmmo + ammoMultiplier(ammoTypes.get(item)) <= maxAmmo);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/defense/turrets/LiquidTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/LiquidTurret.java
@@ -131,7 +131,7 @@ public class LiquidTurret extends Turret{
         public BulletType useAmmo(){
             if(cheating()) return ammoTypes.get(liquids.current());
             BulletType type = ammoTypes.get(liquids.current());
-            liquids.remove(liquids.current(), 1f / type.ammoMultiplier);
+            liquids.remove(liquids.current(), 1f / ammoMultiplier(type));
             return type;
         }
 
@@ -142,7 +142,7 @@ public class LiquidTurret extends Turret{
 
         @Override
         public boolean hasAmmo(){
-            return ammoTypes.get(liquids.current()) != null && liquids.total() >= 1f / ammoTypes.get(liquids.current()).ammoMultiplier;
+            return ammoTypes.get(liquids.current()) != null && liquids.total() >= 1f / ammoMultiplier(ammoTypes.get(liquids.current()));
         }
 
         @Override
@@ -154,7 +154,7 @@ public class LiquidTurret extends Turret{
         public boolean acceptLiquid(Building source, Liquid liquid){
             return ammoTypes.get(liquid) != null
                 && (liquids.current() == liquid || (ammoTypes.containsKey(liquid)
-                && (!ammoTypes.containsKey(liquids.current()) || liquids.get(liquids.current()) <= 1f / ammoTypes.get(liquids.current()).ammoMultiplier + 0.001f)));
+                && (!ammoTypes.containsKey(liquids.current()) || liquids.get(liquids.current()) <= 1f / ammoMultiplier(ammoTypes.get(liquids.current())) + 0.001f)));
         }
     }
 }

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -331,6 +331,10 @@ public class Turret extends ReloadTurret{
             return !charging;
         }
 
+        public float ammoMultiplier(BulletType type){
+            return type.ammoMultiplier * state.rules.blockAmmoMultiplier;
+        }
+
         /** Consume ammo and return a type. */
         public BulletType useAmmo(){
             if(cheating()) return peekAmmo();


### PR DESCRIPTION
This PR adds a Block Ammo Multiplier map rule; The higher the multiplier, the more a item fills up a turret's ammo bar
![BlockAmmoMultiplier](https://user-images.githubusercontent.com/68400583/109451892-656c0280-7a03-11eb-9078-3a0a07e792fc.jpg)

Why?

When you have a tiny map with limited resources, to help balance things, you would want to make items more effective.
You can make blocks cost less items with `BuildCostMultiplier`
But the only way you can make ammo's more effective is with `BlockDamageMultiplier`, and sometimes more damage per item isn't what's wanted, it is more shots per item. 

Notes:
  -  Does not allow values under 1 (due to problems with how ammo amount is stored with an `int`)
  -  Only works with item/liquid turrets; Does not decrease power usage of power turrets (Power is not an ammo, and it would be 
      a pain to implement)
  -  Does not affect coolant values (Coolant != Ammo)
  -  If ammo multiplier is too high, the item will just automatically fill up the turret's ammo bar (At 100, all turrets will be filled by 
      1 item)