### PR TITLE
Log who skipped the wave to the console

### DIFF
--- a/core/src/mindustry/core/NetServer.java
+++ b/core/src/mindustry/core/NetServer.java
@@ -725,6 +725,7 @@ public class NetServer implements ApplicationListener{
             //no verification is done, so admins can hypothetically spam waves
             //not a real issue, because server owners may want to do just that
             logic.skipWave();
+            info("&lc@ has skipped the wave.", player.name);
         }else if(action == AdminAction.ban){
             netServer.admins.banPlayerIP(other.con.address);
             netServer.admins.banPlayerID(other.con.uuid);


### PR DESCRIPTION
i've had this in the nydus codebase for quite a while, makes it easier to find out which admin has skip (spammed) wave(s) and thus making it easier to address the admin directly instead of just guessing or asking around, came in helpful a few times 😗 