### PR TITLE
Processors should have priority

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -2067,6 +2067,8 @@ public class Blocks implements ContentList{
             instructionsPerTick = 2;
 
             size = 1;
+            
+            schematicPriority = 10;
         }};
 
         logicProcessor = new LogicBlock("logic-processor"){{
@@ -2077,6 +2079,8 @@ public class Blocks implements ContentList{
             range = 8 * 22;
 
             size = 2;
+            
+            schematicPriority = 10;
         }};
 
         hyperProcessor = new LogicBlock("hyper-processor"){{
@@ -2090,6 +2094,8 @@ public class Blocks implements ContentList{
             range = 8 * 42;
 
             size = 3;
+            
+            schematicPriority = 10;
         }};
 
         memoryCell = new MemoryBlock("memory-cell"){{


### PR DESCRIPTION
Example: You place a reactor schem that uses logic to shut itself off. Unfortunately, the reactor is placed before the processor then the entire thing blows up.
If processors are placed before the reactor they can disable the reactor pretty much as soon as it's placed.