### PR TITLE
Remove duplicates and mild formatting.

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -647,10 +647,10 @@ public class Blocks implements ContentList{
         separator = new Separator("separator"){{
             requirements(Category.crafting, with(Items.copper, 30, Items.titanium, 25));
             results = with(
-            Items.copper, 5,
-            Items.lead, 3,
-            Items.graphite, 2,
-            Items.titanium, 2
+                Items.copper, 5,
+                Items.lead, 3,
+                Items.graphite, 2,
+                Items.titanium, 2
             );
             hasPower = true;
             craftTime = 35f;
@@ -663,10 +663,10 @@ public class Blocks implements ContentList{
         disassembler = new Separator("disassembler"){{
             requirements(Category.crafting, with(Items.graphite, 140, Items.titanium, 100, Items.silicon, 150, Items.surgeAlloy, 70));
             results = with(
-            Items.sand, 4,
-            Items.graphite, 2,
-            Items.titanium, 2,
-            Items.thorium, 1
+                Items.sand, 4,
+                Items.graphite, 2,
+                Items.titanium, 2,
+                Items.thorium, 1
             );
             hasPower = true;
             craftTime = 15f;
@@ -1394,10 +1394,10 @@ public class Blocks implements ContentList{
         duo = new ItemTurret("duo"){{
             requirements(Category.turret, with(Items.copper, 35), true);
             ammo(
-            Items.copper, Bullets.standardCopper,
-            Items.graphite, Bullets.standardDense,
-            Items.pyratite, Bullets.standardIncendiary,
-            Items.silicon, Bullets.standardHoming
+                Items.copper, Bullets.standardCopper,
+                Items.graphite, Bullets.standardDense,
+                Items.pyratite, Bullets.standardIncendiary,
+                Items.silicon, Bullets.standardHoming
             );
 
             spread = 4f;
@@ -1416,9 +1416,9 @@ public class Blocks implements ContentList{
         scatter = new ItemTurret("scatter"){{
             requirements(Category.turret, with(Items.copper, 85, Items.lead, 45));
             ammo(
-            Items.scrap, Bullets.flakScrap,
-            Items.lead, Bullets.flakLead,
-            Items.metaglass, Bullets.flakGlass
+                Items.scrap, Bullets.flakScrap,
+                Items.lead, Bullets.flakLead,
+                Items.metaglass, Bullets.flakGlass
             );
             reloadTime = 18f;
             range = 160f;
@@ -1439,8 +1439,8 @@ public class Blocks implements ContentList{
         scorch = new ItemTurret("scorch"){{
             requirements(Category.turret, with(Items.copper, 25, Items.graphite, 22));
             ammo(
-            Items.coal, Bullets.basicFlame,
-            Items.pyratite, Bullets.pyraFlame
+                Items.coal, Bullets.basicFlame,
+                Items.pyratite, Bullets.pyraFlame
             );
             recoilAmount = 0f;
             reloadTime = 6f;
@@ -1456,9 +1456,9 @@ public class Blocks implements ContentList{
         hail = new ItemTurret("hail"){{
             requirements(Category.turret, with(Items.copper, 40, Items.graphite, 17));
             ammo(
-            Items.graphite, Bullets.artilleryDense,
-            Items.silicon, Bullets.artilleryHoming,
-            Items.pyratite, Bullets.artilleryIncendiary
+                Items.graphite, Bullets.artilleryDense,
+                Items.silicon, Bullets.artilleryHoming,
+                Items.pyratite, Bullets.artilleryIncendiary
             );
             targetAir = false;
             reloadTime = 60f;
@@ -1473,10 +1473,10 @@ public class Blocks implements ContentList{
         wave = new LiquidTurret("wave"){{
             requirements(Category.turret, with(Items.metaglass, 45, Items.lead, 75));
             ammo(
-            Liquids.water, Bullets.waterShot,
-            Liquids.slag, Bullets.slagShot,
-            Liquids.cryofluid, Bullets.cryoShot,
-            Liquids.oil, Bullets.oilShot
+                Liquids.water, Bullets.waterShot,
+                Liquids.slag, Bullets.slagShot,
+                Liquids.cryofluid, Bullets.cryoShot,
+                Liquids.oil, Bullets.oilShot
             );
             size = 2;
             recoilAmount = 0f;
@@ -1562,9 +1562,9 @@ public class Blocks implements ContentList{
         swarmer = new ItemTurret("swarmer"){{
             requirements(Category.turret, with(Items.graphite, 35, Items.titanium, 35, Items.plastanium, 45, Items.silicon, 30));
             ammo(
-            Items.blastCompound, Bullets.missileExplosive,
-            Items.pyratite, Bullets.missileIncendiary,
-            Items.surgeAlloy, Bullets.missileSurge
+                Items.blastCompound, Bullets.missileExplosive,
+                Items.pyratite, Bullets.missileIncendiary,
+                Items.surgeAlloy, Bullets.missileSurge
             );
             reloadTime = 30f;
             shots = 4;
@@ -1580,11 +1580,11 @@ public class Blocks implements ContentList{
         salvo = new ItemTurret("salvo"){{
             requirements(Category.turret, with(Items.copper, 100, Items.graphite, 90, Items.titanium, 60));
             ammo(
-            Items.copper, Bullets.standardCopper,
-            Items.graphite, Bullets.standardDense,
-            Items.pyratite, Bullets.standardIncendiary,
-            Items.silicon, Bullets.standardHoming,
-            Items.thorium, Bullets.standardThorium
+                Items.copper, Bullets.standardCopper,
+                Items.graphite, Bullets.standardDense,
+                Items.pyratite, Bullets.standardIncendiary,
+                Items.silicon, Bullets.standardHoming,
+                Items.thorium, Bullets.standardThorium
             );
 
             size = 2;
@@ -1624,7 +1624,6 @@ public class Blocks implements ContentList{
                 Liquids.oil, Bullets.heavyOilShot
             );
             size = 3;
-            recoilAmount = 0f;
             reloadTime = 2f;
             shots = 2;
             velocityInaccuracy = 0.1f;
@@ -1658,31 +1657,31 @@ public class Blocks implements ContentList{
             float brange = range + 10f;
 
             ammo(
-            Items.titanium, new ShrapnelBulletType(){{
-                length = brange;
-                damage = 66f;
-                ammoMultiplier = 4f;
-                width = 17f;
-                reloadMultiplier = 1.3f;
-            }},
-            Items.thorium, new ShrapnelBulletType(){{
-                length = brange;
-                damage = 105f;
-                ammoMultiplier = 5f;
-                toColor = Pal.thoriumPink;
-                shootEffect = smokeEffect = Fx.thoriumShoot;
-            }}
+                Items.titanium, new ShrapnelBulletType(){{
+                    length = brange;
+                    damage = 66f;
+                    ammoMultiplier = 4f;
+                    width = 17f;
+                    reloadMultiplier = 1.3f;
+                }},
+                Items.thorium, new ShrapnelBulletType(){{
+                    length = brange;
+                    damage = 105f;
+                    ammoMultiplier = 5f;
+                    toColor = Pal.thoriumPink;
+                    shootEffect = smokeEffect = Fx.thoriumShoot;
+                }}
             );
         }};
 
         ripple = new ItemTurret("ripple"){{
             requirements(Category.turret, with(Items.copper, 150, Items.graphite, 135, Items.titanium, 60));
             ammo(
-            Items.graphite, Bullets.artilleryDense,
-            Items.silicon, Bullets.artilleryHoming,
-            Items.pyratite, Bullets.artilleryIncendiary,
-            Items.blastCompound, Bullets.artilleryExplosive,
-            Items.plastanium, Bullets.artilleryPlastic
+                Items.graphite, Bullets.artilleryDense,
+                Items.silicon, Bullets.artilleryHoming,
+                Items.pyratite, Bullets.artilleryIncendiary,
+                Items.blastCompound, Bullets.artilleryExplosive,
+                Items.plastanium, Bullets.artilleryPlastic
             );
 
             targetAir = false;
@@ -1708,10 +1707,10 @@ public class Blocks implements ContentList{
         cyclone = new ItemTurret("cyclone"){{
             requirements(Category.turret, with(Items.copper, 200, Items.titanium, 125, Items.plastanium, 80));
             ammo(
-            Items.metaglass, Bullets.fragGlass,
-            Items.blastCompound, Bullets.fragExplosive,
-            Items.plastanium, Bullets.fragPlastic,
-            Items.surgeAlloy, Bullets.fragSurge
+                Items.metaglass, Bullets.fragGlass,
+                Items.blastCompound, Bullets.fragExplosive,
+                Items.plastanium, Bullets.fragPlastic,
+                Items.surgeAlloy, Bullets.fragSurge
             );
             xRand = 4f;
             reloadTime = 8f;
@@ -1731,19 +1730,19 @@ public class Blocks implements ContentList{
 
             requirements(Category.turret, with(Items.copper, 1000, Items.metaglass, 600, Items.surgeAlloy, 300, Items.plastanium, 200, Items.silicon, 600));
             ammo(
-            Items.surgeAlloy, new PointBulletType(){{
-                shootEffect = Fx.instShoot;
-                hitEffect = Fx.instHit;
-                smokeEffect = Fx.smokeCloud;
-                trailEffect = Fx.instTrail;
-                despawnEffect = Fx.instBomb;
-                trailSpacing = 20f;
-                damage = 1350;
-                buildingDamageMultiplier = 0.3f;
-                speed = brange;
-                hitShake = 6f;
-                ammoMultiplier = 1f;
-            }}
+                Items.surgeAlloy, new PointBulletType(){{
+                    shootEffect = Fx.instShoot;
+                    hitEffect = Fx.instHit;
+                    smokeEffect = Fx.smokeCloud;
+                    trailEffect = Fx.instTrail;
+                    despawnEffect = Fx.instBomb;
+                    trailSpacing = 20f;
+                    damage = 1350;
+                    buildingDamageMultiplier = 0.3f;
+                    speed = brange;
+                    hitShake = 6f;
+                    ammoMultiplier = 1f;
+                }}
             );
 
             maxAmmo = 40;
@@ -1772,9 +1771,9 @@ public class Blocks implements ContentList{
         spectre = new ItemTurret("spectre"){{
             requirements(Category.turret, with(Items.copper, 900, Items.graphite, 300, Items.surgeAlloy, 250, Items.plastanium, 175, Items.thorium, 250));
             ammo(
-            Items.graphite, Bullets.standardDenseBig,
-            Items.pyratite, Bullets.standardIncendiaryBig,
-            Items.thorium, Bullets.standardThoriumBig
+                Items.graphite, Bullets.standardDenseBig,
+                Items.pyratite, Bullets.standardIncendiaryBig,
+                Items.thorium, Bullets.standardThoriumBig
             );
             reloadTime = 6f;
             coolantMultiplier = 0.5f;

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -322,9 +322,8 @@ public class UnitTypes implements ContentList{
                 x = 5f;
                 shake = 2.2f;
                 y = 0.5f;
-                shootY = 5f;
-
                 shootY = 2.5f;
+
                 reload = 38f;
                 shots = 3;
                 inaccuracy = 35;
@@ -359,7 +358,6 @@ public class UnitTypes implements ContentList{
 
         quasar = new UnitType("quasar"){{
             mineTier = 3;
-            hitSize = 12f;
             boostMultiplier = 2f;
             health = 650f;
             buildSpeed = 1.7f;
@@ -471,7 +469,6 @@ public class UnitTypes implements ContentList{
         }};
 
         corvus = new UnitType("corvus"){{
-            mineTier = 1;
             hitSize = 29f;
             health = 18000f;
             armor = 9f;


### PR DESCRIPTION
Removes duplicate definitions
- Pulsar `shootY`
- Quasar `hitSize`
- Corvus `mineTier`
- Tsunami `recoilAmount`

Indent `ammo` on `ItemTurret`s and `results` on `Separator`s
Looks nicer, and matches with Tsunami.