### PR TITLE
Cursor should not change for other teams when hovering over doors and construction.

### DIFF
--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -1142,7 +1142,7 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
 
     /** Returns whether or not a hand cursor should be shown over this block. */
     public Cursor getCursor(){
-        return block.configurable && team == player.team() ? SystemCursor.hand : SystemCursor.arrow;
+        return block.configurable && interactable(player.team()) ? SystemCursor.hand : SystemCursor.arrow;
     }
 
     /**

--- a/core/src/mindustry/world/blocks/ConstructBlock.java
+++ b/core/src/mindustry/world/blocks/ConstructBlock.java
@@ -172,7 +172,7 @@ public class ConstructBlock extends Block{
 
         @Override
         public Cursor getCursor(){
-            return SystemCursor.hand;
+            return interactable(player.team()) ? SystemCursor.hand : SystemCursor.arrow;
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/defense/Door.java
+++ b/core/src/mindustry/world/blocks/defense/Door.java
@@ -126,7 +126,7 @@ public class Door extends Wall{
 
         @Override
         public Cursor getCursor(){
-            return player.team() == team ? SystemCursor.hand : SystemCursor.arrow;
+            return interactable(player.team()) ? SystemCursor.hand : SystemCursor.arrow;
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/defense/Door.java
+++ b/core/src/mindustry/world/blocks/defense/Door.java
@@ -126,7 +126,7 @@ public class Door extends Wall{
 
         @Override
         public Cursor getCursor(){
-            return SystemCursor.hand;
+            return player.team() == team ? SystemCursor.hand : SystemCursor.arrow;
         }
 
         @Override


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/54301439/109609374-1942c000-7ae0-11eb-83d4-1b25365abcd3.mp4

![Mindustry_exPb9xVUee](https://user-images.githubusercontent.com/54301439/109633372-df33e700-7afc-11eb-8e1a-9f8fa834f462.png)

After:

https://user-images.githubusercontent.com/54301439/109609388-1d6edd80-7ae0-11eb-89fa-57a7c100ce8a.mp4

![java_lVBIYnJCzn](https://user-images.githubusercontent.com/54301439/109633383-e22ed780-7afc-11eb-85a2-d3e62714199f.png)