### PR TITLE
Nuclear reactor schem priority of -5

### DIFF
--- a/core/src/mindustry/world/blocks/power/NuclearReactor.java
+++ b/core/src/mindustry/world/blocks/power/NuclearReactor.java
@@ -54,7 +54,7 @@ public class NuclearReactor extends PowerGenerator{
         hasLiquids = true;
         rebuildable = false;
         flags = EnumSet.of(BlockFlag.reactor, BlockFlag.generator);
-        schematicPriority = -15;
+        schematicPriority = -5;
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/power/NuclearReactor.java
+++ b/core/src/mindustry/world/blocks/power/NuclearReactor.java
@@ -54,6 +54,7 @@ public class NuclearReactor extends PowerGenerator{
         hasLiquids = true;
         rebuildable = false;
         flags = EnumSet.of(BlockFlag.reactor, BlockFlag.generator);
+        schematicPriority = -15;
     }
 
     @Override


### PR DESCRIPTION
This will ensure that reactors are built after everything else (except nodes), this should reduce the likelihood of accidentally blowing them up due to lack of cryo (the change to logic block priority already fixes this in most cases but its better to be safe than sorry)