### PR TITLE
Add `setupRequirements`, which calls `requirements` so that it can be used in rhino js.

### DIFF
--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -625,6 +625,14 @@ public class Block extends UnlockableContent{
         return cacheLayer == CacheLayer.walls;
     }
 
+    public void setupRequirements(Category cat, ItemStack[] stacks){
+        requirements(cat, stacks);
+    }
+
+    public void setupRequirements(Category cat, BuildVisibility visible, ItemStack[] stacks){
+        requirements(cat, visible, stacks);
+    }
+
     public void requirements(Category cat, ItemStack[] stacks, boolean unlocked){
         requirements(cat, BuildVisibility.shown, stacks);
         this.alwaysUnlocked = unlocked;


### PR DESCRIPTION
This'll allow it to be used in rhino js without rhino having a stroke about it.

I chose to change the method instead of the property because changing the method only breaks Java mods while changing the property would break every non-java mods. Java mods would be easier to fix because you could just do a `ctrl + h` to replace every `requirements` with `setRequirements` (assuming all blocks are in one file like Mindustry source code) while in non-java mods you would have to go through every file individually and fix it.

(I'm sorry sk)