### PR TITLE
Knockback Integration with Splash Damage

### DIFF
--- a/core/src/mindustry/entities/Damage.java
+++ b/core/src/mindustry/entities/Damage.java
@@ -314,6 +314,25 @@ public class Damage{
         damage(team, x, y, radius, damage, false, air, ground);
     }
 
+    /** Knockback all enemy units in a range. */
+    public static void knockback(Team team, float x, float y, float radius, float knockback, boolean air, boolean ground){
+        Cons<Unit> cons = entity -> {
+            if(entity.team == team || !entity.within(x, y, radius) || (entity.isFlying() && !air) || (entity.isGrounded() && !ground)){
+                return;
+            }
+
+            float dst = tr.set(entity).sub(x, y).len();
+            entity.impulse(tr.nor().scl((1f - dst / radius) * knockback * 80f));
+        };
+
+        rect.setSize(radius * 2).setCenter(x, y);
+        if(team != null){
+            Units.nearbyEnemies(team, rect, cons);
+        }else{
+            Units.nearby(rect, cons);
+        }
+    }
+
     /** Applies a status effect to all enemy units in a range. */
     public static void status(Team team, float x, float y, float radius, StatusEffect effect, float duration, boolean air, boolean ground){
         Cons<Unit> cons = entity -> {

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -215,11 +215,7 @@ public abstract class BulletType extends Content{
         }
 
         if(splashDamageRadius > 0 && !b.absorbed){
-            Damage.damage(b.team, x, y, splashDamageRadius, splashDamage * b.damageMultiplier(), collidesAir, collidesGround);
-
-            if(knockback > 0f){
-                Damage.knockback(b.team, x, y, splashDamageRadius, knockback, collidesAir, collidesGround);
-            }
+            Damage.damage(b.team, x, y, splashDamageRadius, splashDamage * b.damageMultiplier(), knockback, false, collidesAir, collidesGround);
 
             if(status != StatusEffects.none){
                 Damage.status(b.team, x, y, splashDamageRadius, status, statusDuration, collidesAir, collidesGround);

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -217,6 +217,10 @@ public abstract class BulletType extends Content{
         if(splashDamageRadius > 0 && !b.absorbed){
             Damage.damage(b.team, x, y, splashDamageRadius, splashDamage * b.damageMultiplier(), collidesAir, collidesGround);
 
+            if(knockback > 0f){
+                Damage.knockback(b.team, x, y, splashDamageRadius, knockback, collidesAir, collidesGround);
+            }
+
             if(status != StatusEffects.none){
                 Damage.status(b.team, x, y, splashDamageRadius, status, statusDuration, collidesAir, collidesGround);
             }


### PR DESCRIPTION
This PR allows bullets with allow knockback to be applied to all enemies in their splash damage radius.
![Dagger Being Knocked Around](https://user-images.githubusercontent.com/68400583/109923867-445e1880-7c74-11eb-9040-5a92181b1ed8.gif)

As you can see, the dagger is being knocked around. 

Partially relevant:  This TODO right here: https://github.com/Anuken/Mindustry/blob/d73cf9fcff026a581b06c0aaab89a9c3231d3310/core/src/mindustry/entities/Damage.java#L348