### PR TITLE
Enable client to use a different data dir through env MINDUSTRY_DATA_DIR

### DIFF
--- a/core/src/mindustry/ClientLauncher.java
+++ b/core/src/mindustry/ClientLauncher.java
@@ -34,6 +34,11 @@ public abstract class ClientLauncher extends ApplicationCore implements Platform
 
     @Override
     public void setup(){
+        String dataDir = OS.env("MINDUSTRY_DATA_DIR");
+        if(dataDir != null){
+            Core.settings.setDataDirectory(files.absolute(dataDir));
+        }
+
         checkLaunch();
         loadLogger();
 


### PR DESCRIPTION
I tried to use as many `Core` calls as I could but didn't find anything in regards to absolute vs relative paths, so I enforced absolutes to avoid a bigger fingerprint of the code