### PR TITLE
Remove dead servers from v5 server list

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -1,35 +1,5 @@
 [
   {
-    "address": "mindustry.indielm.com:1101"
-  },
-  {
-    "address": "mindustry.indielm.com"
-  },
-  {
-    "address": "v5.mindustry.nydus.app:6565"
-  },
-  {
-    "address": "mindustry.ru"
-  },
-  {
-    "address": "mindustry.ru:7000"
-  },
-  {
-    "address": "Mindustry.pl"
-  },
-  {
-    "address": "aamindustry.play.ai"
-  },
-  {
-    "address": "aamindustry.play.ai:6568"
-  },
-  {
-    "address": "aamindustry.play.ai:6569"
-  },
-  {
-    "address": "aamindustry.play.ai:6570"
-  },
-  {
     "address": "mindustry.atannergaming.com"
   },
   {
@@ -40,23 +10,5 @@
   },
   {
     "address": "mindustry.atannergaming.com:6800"
-  },
-  {
-    "address": "mindustry.kbni.net.au:6567"
-  },
-  {
-    "address": "mindustry.kbni.net.au:6568"
-  },
-  {
-    "address": "twsmindustry.24x7.hk"
-  },
-  {
-    "address": "twsmindustry.24x7.hk:6568"
-  },
-  {
-    "address": "mindustryranked.ddns.net"
-  },
-  {
-    "address": "attack.pearkin.net"
   }
 ]


### PR DESCRIPTION
From what I can see, atnanner is the only network that still hosts any v5 servers, all the others are either on v6 or are offline.