### PR TITLE
`maxRange` overriding on laser bullets

### DIFF
--- a/core/src/mindustry/entities/bullet/ContinuousLaserBulletType.java
+++ b/core/src/mindustry/entities/bullet/ContinuousLaserBulletType.java
@@ -55,7 +55,7 @@ public class ContinuousLaserBulletType extends BulletType{
 
     @Override
     public float range(){
-        return length;
+        return Math.max(length, maxRange);
     }
 
     @Override

--- a/core/src/mindustry/entities/bullet/LaserBulletType.java
+++ b/core/src/mindustry/entities/bullet/LaserBulletType.java
@@ -56,7 +56,7 @@ public class LaserBulletType extends BulletType{
 
     @Override
     public float range(){
-        return length;
+        return Math.max(length, maxRange);
     }
 
     @Override

--- a/core/src/mindustry/entities/bullet/SapBulletType.java
+++ b/core/src/mindustry/entities/bullet/SapBulletType.java
@@ -50,7 +50,7 @@ public class SapBulletType extends BulletType{
 
     @Override
     public float range(){
-        return length;
+        return Math.max(length, maxRange);
     }
 
     @Override

--- a/core/src/mindustry/entities/bullet/ShrapnelBulletType.java
+++ b/core/src/mindustry/entities/bullet/ShrapnelBulletType.java
@@ -47,7 +47,7 @@ public class ShrapnelBulletType extends BulletType{
 
     @Override
     public float range(){
-        return length;
+        return Math.max(length, maxRange);
     }
 
     @Override


### PR DESCRIPTION
I figured that since normal bullets have range increases with `maxRange`, the same should go for laser bullets.