### PR TITLE
light block placement

### DIFF
--- a/core/src/mindustry/world/blocks/power/LightBlock.java
+++ b/core/src/mindustry/world/blocks/power/LightBlock.java
@@ -3,12 +3,15 @@ package mindustry.world.blocks.power;
 import arc.graphics.*;
 import arc.graphics.g2d.*;
 import arc.math.*;
+import arc.math.geom.*;
 import arc.scene.ui.layout.*;
+import arc.struct.*;
 import arc.util.*;
 import arc.util.io.*;
 import mindustry.annotations.Annotations.*;
 import mindustry.gen.*;
 import mindustry.graphics.*;
+import mindustry.input.*;
 import mindustry.logic.*;
 import mindustry.world.*;
 
@@ -25,8 +28,22 @@ public class LightBlock extends Block{
         update = true;
         configurable = true;
         saveConfig = true;
+        swapDiagonalPlacement = true;
 
         config(Integer.class, (LightBuild tile, Integer value) -> tile.color = value);
+    }
+
+    @Override
+    public void drawPlace(int x, int y, int rotation, boolean valid){
+        super.drawPlace(x, y, rotation, valid);
+
+        Drawf.dashCircle(x * tilesize + offset, y * tilesize + offset, radius * 0.8f, Pal.placing);
+    }
+
+    @Override
+    public void changePlacementPath(Seq<Point2> points, int rotation){
+        var placeRadius2 = Mathf.pow(radius * 0.8f / tilesize, 2f) * 3;
+        Placement.calculateNodes(points, this, rotation, (point, other) -> Mathf.dst2(point.x, point.y, other.x, other.y) <= placeRadius2);
     }
 
     public class LightBuild extends Building{
@@ -68,6 +85,11 @@ public class LightBlock extends Block{
         @Override
         public void drawLight(){
             Drawf.light(team, x, y, radius * Math.min(smoothTime, 2f), Tmp.c1.set(color), brightness * efficiency());
+        }
+
+        @Override
+        public void drawSelect(){
+            Drawf.dashCircle(x, y, radius * 0.8f, team.color);
         }
 
         @Override


### PR DESCRIPTION
https://github.com/Anuken/Mindustry-Suggestions/issues/1410

For the two magic numbers, I just place explanations here for now:
- I just measured "circle-shadow.png" in photoshop by my brightness recognizability and got 0.8.
- Multiplied 3 is the square of the distance between centers of overlapping regular-triangular tessellated unit circles, to have lights just contiguous.

x0.8:

![image](https://user-images.githubusercontent.com/53636947/110226529-34239300-7f2b-11eb-9e0c-e486e3581496.png)
![x0.8](https://user-images.githubusercontent.com/53636947/110207485-b7f36600-7ebe-11eb-9c6f-2701a8cbf972.png)

x0.75 (I wrongly multiplied `brightness` before):
![x0.75](https://user-images.githubusercontent.com/53636947/110207461-95614d00-7ebe-11eb-920e-f2a2b7f3bcaf.png)