### PR TITLE
MassDriverBolt shouldn't collide with ground

### DIFF
--- a/core/src/mindustry/entities/bullet/MassDriverBolt.java
+++ b/core/src/mindustry/entities/bullet/MassDriverBolt.java
@@ -15,6 +15,7 @@ public class MassDriverBolt extends BulletType{
     public MassDriverBolt(){
         super(1f, 50);
         collidesTiles = false;
+        collidesGround = false;
         lifetime = 1f;
         despawnEffect = Fx.smeltsmoke;
         hitEffect = Fx.hitBulletBig;


### PR DESCRIPTION
It seems odd to me that it is able to go over buildings but can be intercepted by ground units