### PR TITLE
Charge Turrets should not be able to shoot while charging.

### DIFF
--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -353,7 +353,7 @@ public class Turret extends ReloadTurret{
         }
 
         protected void updateShooting(){
-            if(reload >= reloadTime){
+            if(reload >= reloadTime && !charging){
                 BulletType type = peekAmmo();
 
                 shoot(type);


### PR DESCRIPTION
Reasons
- Beginning charging while already charging doesn't make much sense.
- The first shot shooting sets `charging` to false, allowing the turret to rotate while charging

---

Before:

https://user-images.githubusercontent.com/54301439/110393910-4df2d200-8020-11eb-818f-1f53aa774f49.mp4

After:

https://user-images.githubusercontent.com/54301439/110393927-55b27680-8020-11eb-9b4d-963968424caa.mp4

