### PR TITLE
`collidesGround` check in `GroundAI`

### DIFF
--- a/core/src/mindustry/ai/types/GroundAI.java
+++ b/core/src/mindustry/ai/types/GroundAI.java
@@ -21,7 +21,11 @@ public class GroundAI extends AIController{
 
         if(core != null && unit.within(core, unit.range() / 1.1f + core.block.size * tilesize / 2f)){
             target = core;
-            Arrays.fill(targets, core);
+            for(int i = 0; i < targets.length; i++){
+                if(unit.mounts[i].weapon.bullet.collidesGround){
+                    targets[i] = core;
+                }
+            }
         }
 
         if((core == null || !unit.within(core, unit.range() * 0.5f)) && command() == UnitCommand.attack){


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/54301439/110565601-9636f080-8103-11eb-8237-8833d4924a57.mp4

The Urodela is attempting to shoot the core with bullets that have `collidesGround = false`.

---
After:

https://user-images.githubusercontent.com/54301439/110565627-9d5dfe80-8103-11eb-8ebc-7635b0574890.mp4

Added `collidesGround` check to fix that.