### PR TITLE
Rally point knockback prototype

### DIFF
--- a/core/src/mindustry/entities/comp/UnitComp.java
+++ b/core/src/mindustry/entities/comp/UnitComp.java
@@ -26,6 +26,7 @@ import mindustry.ui.*;
 import mindustry.world.*;
 import mindustry.world.blocks.environment.*;
 import mindustry.world.blocks.payloads.*;
+import mindustry.world.meta.*;
 
 import static mindustry.Vars.*;
 import static mindustry.logic.GlobalConstants.*;
@@ -334,6 +335,14 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
                 if(within(spawn.worldx(), spawn.worldy(), relativeSize)){
                     vel().add(Tmp.v1.set(this).sub(spawn.worldx(), spawn.worldy()).setLength(0.1f + 1f - dst(spawn) / relativeSize).scl(0.45f * Time.delta));
                 }
+            }
+        }
+
+        //apply knockback near rally points
+        for(Tile rally : indexer.getAllied(team, BlockFlag.rally)){
+            float relativeSize = (tilesize * rally.block().size) + hitSize/2f + 1f;
+            if(within(rally.worldx(), rally.worldy(), relativeSize)){
+                vel().add(Tmp.v1.set(this).sub(rally.worldx(), rally.worldy()).setLength(0.1f + 1f - dst(rally) / relativeSize).scl(0.45f * Time.delta));
             }
         }
 


### PR DESCRIPTION
currently a "major" issue with having lots of (air) units near a rally point is that you cannot see the rally point anymore, the only way to find it is by moving the cursor around the center hoping it would change into a pointer, or place a second rally point nearby and set that one to attack while you deal with the existing one:

![Screen Shot 2021-03-11 at 12 35 20](https://user-images.githubusercontent.com/3179271/110781878-b7fcb880-8266-11eb-96b8-db0295ff6f2f.png)

i've tried some other method to keep it clickable, but in this draft pull i gave rally points the same effect (only to its own team) as enemy dropzones that push units away from it, here's an example of how it would look with the code from this pull:

![Screen Shot 2021-03-11 at 12 35 29](https://user-images.githubusercontent.com/3179271/110782047-eda1a180-8266-11eb-99b4-2eff7f805ff3.png)

it still causes the units to shake a bit as they fight over dominance for a good spot, but now at least the rally point is generally unobstructed, also here's an example where the rally point has a fake size of 4, but that clearance would be a bit overkill:

![Screen Shot 2021-03-11 at 12 35 46](https://user-images.githubusercontent.com/3179271/110782181-1cb81300-8267-11eb-8e3f-d1cad26fc687.png)

and as for that other method, that was a disaster, i tried creating a "skyscraper" block property that makes air units collide with "high" blocks like surge towers & command centers, but oh dear the collision comp for that was a nightmare, units legs were a nightmare, power node layers, other layers, allaround one big mess, not to mention only the center of units colliding with blocks, needless to say that attempt didn't make it in:

![Screen Shot 2021-03-11 at 11 47 06](https://user-images.githubusercontent.com/3179271/110782459-71f42480-8267-11eb-9f61-ec66f26817b9.png)

anyways, my goal is/was to make the command center easier to spot/click/use when there is a cluster of units blotting out the sky, the spawn zone knockback method seems pretty clean, but it could use some cleanup e.g. only knocking back units that are currently actively trying to rally at that point since it feels slightly weird if it interferes with all allied units 🤔  


