### PR TITLE
Leg mass for spider units.

### DIFF
--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -589,6 +589,7 @@ public class UnitTypes implements ContentList{
             legLength = 9f;
             legTrns = 0.6f;
             legMoveSpace = 1.4f;
+            legPayloadMass = 9f;
             hovering = true;
             armor = 3f;
 
@@ -628,6 +629,7 @@ public class UnitTypes implements ContentList{
             legTrns = 0.8f;
             legMoveSpace = 1.4f;
             legBaseOffset = 2f;
+            legPayloadMass = 18f;
             hovering = true;
             armor = 5f;
             ammoType = AmmoTypes.power;
@@ -702,6 +704,7 @@ public class UnitTypes implements ContentList{
             legLengthScl = 0.96f;
             rippleScale = 2f;
             legSpeed = 0.2f;
+            legPayloadMass = 31f;
             ammoType = AmmoTypes.power;
             buildSpeed = 1f;
 
@@ -805,6 +808,7 @@ public class UnitTypes implements ContentList{
             legLengthScl = 0.93f;
             rippleScale = 3f;
             legSpeed = 0.19f;
+            legPayloadMass = 64f;
             ammoType = AmmoTypes.powerHigh;
             buildSpeed = 1f;
 

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -589,7 +589,7 @@ public class UnitTypes implements ContentList{
             legLength = 9f;
             legTrns = 0.6f;
             legMoveSpace = 1.4f;
-            legPayloadMass = 9f;
+            legPayloadSize = 9f;
             hovering = true;
             armor = 3f;
 
@@ -629,7 +629,7 @@ public class UnitTypes implements ContentList{
             legTrns = 0.8f;
             legMoveSpace = 1.4f;
             legBaseOffset = 2f;
-            legPayloadMass = 18f;
+            legPayloadSize = 18f;
             hovering = true;
             armor = 5f;
             ammoType = AmmoTypes.power;
@@ -704,7 +704,7 @@ public class UnitTypes implements ContentList{
             legLengthScl = 0.96f;
             rippleScale = 2f;
             legSpeed = 0.2f;
-            legPayloadMass = 31f;
+            legPayloadSize = 31f;
             ammoType = AmmoTypes.power;
             buildSpeed = 1f;
 
@@ -808,7 +808,7 @@ public class UnitTypes implements ContentList{
             legLengthScl = 0.93f;
             rippleScale = 3f;
             legSpeed = 0.19f;
-            legPayloadMass = 64f;
+            legPayloadSize = 64f;
             ammoType = AmmoTypes.powerHigh;
             buildSpeed = 1f;
 

--- a/core/src/mindustry/entities/comp/PayloadComp.java
+++ b/core/src/mindustry/entities/comp/PayloadComp.java
@@ -31,8 +31,8 @@ abstract class PayloadComp implements Posc, Rotc, Hitboxc, Unitc{
 
     boolean canPickup(Unit unit){
         float unitSize = unit.hitSize * unit.hitSize;
-        float legMass = unit.type.allowLegStep ? unit.type.legCount * unit.type.legPayloadMass : 0;
-        return payloadUsed() + unitSize + legMass <= type.payloadCapacity + 0.001f && unit.team == team() && unit.isAI();
+        float legSize = unit.type.allowLegStep ? unit.type.legCount * unit.type.legPayloadSize : 0;
+        return payloadUsed() + unitSize + legSize <= type.payloadCapacity + 0.001f && unit.team == team() && unit.isAI();
     }
 
     boolean canPickup(Building build){

--- a/core/src/mindustry/entities/comp/PayloadComp.java
+++ b/core/src/mindustry/entities/comp/PayloadComp.java
@@ -30,7 +30,9 @@ abstract class PayloadComp implements Posc, Rotc, Hitboxc, Unitc{
     }
 
     boolean canPickup(Unit unit){
-        return payloadUsed() + unit.hitSize * unit.hitSize <= type.payloadCapacity + 0.001f && unit.team == team() && unit.isAI();
+        float unitSize = unit.hitSize * unit.hitSize;
+        float legMass = unit.type.allowLegStep ? unit.type.legCount * unit.type.legPayloadMass : 0;
+        return payloadUsed() + unitSize + legMass <= type.payloadCapacity + 0.001f && unit.team == team() && unit.isAI();
     }
 
     boolean canPickup(Building build){

--- a/core/src/mindustry/type/UnitType.java
+++ b/core/src/mindustry/type/UnitType.java
@@ -65,7 +65,7 @@ public class UnitType extends UnlockableContent{
     public BlockFlag targetFlag = BlockFlag.generator;
 
     public int legCount = 4, legGroupSize = 2;
-    public float legLength = 10f, legSpeed = 0.1f, legTrns = 1f, legBaseOffset = 0f, legMoveSpace = 1f, legExtension = 0, legPairOffset = 0, legLengthScl = 1f, kinematicScl = 1f, maxStretch = 1.75f;
+    public float legLength = 10f, legSpeed = 0.1f, legTrns = 1f, legBaseOffset = 0f, legMoveSpace = 1f, legExtension = 0, legPairOffset = 0, legLengthScl = 1f, kinematicScl = 1f, maxStretch = 1.75f, legPayloadMass;
     public float legSplashDamage = 0f, legSplashRange = 5;
     public boolean flipBackLegs = true;
 

--- a/core/src/mindustry/type/UnitType.java
+++ b/core/src/mindustry/type/UnitType.java
@@ -65,7 +65,7 @@ public class UnitType extends UnlockableContent{
     public BlockFlag targetFlag = BlockFlag.generator;
 
     public int legCount = 4, legGroupSize = 2;
-    public float legLength = 10f, legSpeed = 0.1f, legTrns = 1f, legBaseOffset = 0f, legMoveSpace = 1f, legExtension = 0, legPairOffset = 0, legLengthScl = 1f, kinematicScl = 1f, maxStretch = 1.75f, legPayloadMass;
+    public float legLength = 10f, legSpeed = 0.1f, legTrns = 1f, legBaseOffset = 0f, legMoveSpace = 1f, legExtension = 0, legPairOffset = 0, legLengthScl = 1f, kinematicScl = 1f, maxStretch = 1.75f, legPayloadSize;
     public float legSplashDamage = 0f, legSplashRange = 5;
     public boolean flipBackLegs = true;
 


### PR DESCRIPTION
Adds `legPayloadMass`, which is the mass taken up per leg.

Reason: It makes sense for the legs to take up payload space, but also since some of the vanilla spiders have smaller `hitSize`s because most of their size is leg (example: Toxopid, which is about the same size as Zenith)