### PR TITLE
Remove MindustryPlay

### DIFF
--- a/servers_v6.json
+++ b/servers_v6.json
@@ -80,10 +80,6 @@
     "address": ["obvilionnetwork.ru", "obvilionnetwork.ru:7001", "obvilionnetwork.ru:7002", "obvilionnetwork.ru:7003"]
   },
   {
-    "name": "Mindustry PLAY",
-    "address": ["92.63.100.160"]
-  },
-  {
     "name": "Nydus",
     "address": ["v6.mindustry.nydus.app:6566"]
   },


### PR DESCRIPTION
Hi. We are here to #removeMindustryPlay. 
We have some reasons for it:
1) Their admins are toxic, idiots, they don't work with their servers and also they ban people for no reason.
2) Their servers are vanilla and don't have any unique features.
3) A big part of community wants to remove it.
I think a lot of people will support this pull request.

So, #removeMindustryPlay