### PR TITLE
chargeMoveFract

### DIFF
--- a/core/src/mindustry/world/blocks/defense/turrets/LaserTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/LaserTurret.java
@@ -94,7 +94,7 @@ public class LaserTurret extends PowerTurret{
 
         @Override
         protected void turnToTarget(float targetRot){
-            rotation = Angles.moveToward(rotation, targetRot, efficiency() * rotateSpeed * delta() * (bulletLife > 0f ? firingMoveFract : 1f));
+            rotation = Angles.moveToward(rotation, targetRot, efficiency() * rotateSpeed * delta() * (charging ? chargeMoveFract : 1f) * (bulletLife > 0f ? firingMoveFract : 1f));
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -70,6 +70,7 @@ public class Turret extends ReloadTurret{
     public Effect chargeEffect = Fx.none;
     public Effect chargeBeginEffect = Fx.none;
     public Sound chargeSound = Sounds.none;
+    public float chargeMoveFract = 0f;
 
     public Sortf unitSort = Unit::dst2;
 
@@ -318,11 +319,11 @@ public class Turret extends ReloadTurret{
         }
 
         protected void turnToTarget(float targetRot){
-            rotation = Angles.moveToward(rotation, targetRot, rotateSpeed * delta() * baseReloadSpeed());
+            rotation = Angles.moveToward(rotation, targetRot, rotateSpeed * delta() * (charging ? chargeMoveFract : 1f) * baseReloadSpeed());
         }
 
         public boolean shouldTurn(){
-            return !charging;
+            return true;
         }
 
         /** Consume ammo and return a type. */


### PR DESCRIPTION
Instead of locking the turret's rotation, it applies a rotation speed modifier similarly to `firingMoveFract` on `LaserTurret`s when charging.