### PR TITLE
Remove mindustry.ru from global list

### DIFF
--- a/servers_v6.json
+++ b/servers_v6.json
@@ -17,7 +17,7 @@
   },
   {
     "name": "C.A.M.S.",
-    "address": ["routerchain.ddns.net", "nikochio.ddns.net", "mindustry.ru"]
+    "address": ["routerchain.ddns.net", "nikochio.ddns.net"]
   },
   {
     "name": "BE6.RUN",


### PR DESCRIPTION
Данный сервер использует мой плагин `ObvilionNetwork/mindustry-hub-plugin`, где ясно указано, что я запрещаю использовать его данному серверу. Я уже писал по этому поводу владельцу данного сервера еще 6 дней назад. В итоге я не вижу никакого актива с Вашей стороны, только слова "_Ладно, будем редачить код тогда._"

Я хочу, чтобы Вы, владельцы Mindustry RU, незамедлительно прекратили использование моего хаба. 

P.s. Я бы не создал данный PR если бы не ваш игнор.
P.s.s Использование плагина подтверждено владельцем.

![изображение](https://user-images.githubusercontent.com/56699208/111381917-682f4e80-86b7-11eb-8db2-3c23ad57ff63.png)
![изображение](https://user-images.githubusercontent.com/56699208/111382013-8006d280-86b7-11eb-817a-8ece5ddf1037.png)
![изображение](https://user-images.githubusercontent.com/56699208/111382085-9319a280-86b7-11eb-9e39-a3a69a34fc6f.png)
