### PR TITLE
Split parts of `hit(b, x, y)` into separate methods

### DIFF
--- a/core/src/mindustry/content/Bullets.java
+++ b/core/src/mindustry/content/Bullets.java
@@ -79,7 +79,7 @@ public class Bullets implements ContentList{
         }};
 
         artilleryPlastic = new ArtilleryBulletType(3.4f, 20, "shell"){{
-            hitEffect = Fx.plasticExplosion;
+            hitEffect = despawnEffect = Fx.plasticExplosion;
             knockback = 1f;
             lifetime = 80f;
             width = height = 13f;
@@ -93,7 +93,7 @@ public class Bullets implements ContentList{
         }};
 
         artilleryHoming = new ArtilleryBulletType(3f, 20, "shell"){{
-            hitEffect = Fx.flakExplosion;
+            hitEffect = despawnEffect = Fx.flakExplosion;
             knockback = 0.8f;
             lifetime = 80f;
             width = height = 11f;
@@ -107,7 +107,7 @@ public class Bullets implements ContentList{
         }};
 
         artilleryIncendiary = new ArtilleryBulletType(3f, 20, "shell"){{
-            hitEffect = Fx.blastExplosion;
+            hitEffect = despawnEffect = Fx.blastExplosion;
             knockback = 0.8f;
             lifetime = 80f;
             width = height = 13f;
@@ -122,7 +122,7 @@ public class Bullets implements ContentList{
         }};
 
         artilleryExplosive = new ArtilleryBulletType(2f, 20, "shell"){{
-            hitEffect = Fx.blastExplosion;
+            hitEffect = despawnEffect = Fx.blastExplosion;
             knockback = 0.8f;
             lifetime = 80f;
             width = height = 14f;
@@ -154,7 +154,7 @@ public class Bullets implements ContentList{
             shootEffect = Fx.shootSmall;
             width = 6f;
             height = 8f;
-            hitEffect = Fx.flakExplosion;
+            hitEffect = despawnEffect = Fx.flakExplosion;
             splashDamage = 27f * 1.5f;
             splashDamageRadius = 15f;
         }};
@@ -166,7 +166,7 @@ public class Bullets implements ContentList{
             reloadMultiplier = 0.5f;
             width = 6f;
             height = 8f;
-            hitEffect = Fx.flakExplosion;
+            hitEffect = despawnEffect = Fx.flakExplosion;
             splashDamage = 22f * 1.5f;
             splashDamageRadius = 24f;
         }};
@@ -178,7 +178,7 @@ public class Bullets implements ContentList{
             reloadMultiplier = 0.8f;
             width = 6f;
             height = 8f;
-            hitEffect = Fx.flakExplosion;
+            hitEffect = despawnEffect = Fx.flakExplosion;
             splashDamage = 22f * 1.5f;
             splashDamageRadius = 20f;
             fragBullet = flakGlassFrag;
@@ -211,7 +211,7 @@ public class Bullets implements ContentList{
             reloadMultiplier = 0.8f;
             width = 6f;
             height = 8f;
-            hitEffect = Fx.flakExplosion;
+            hitEffect = despawnEffect = Fx.flakExplosion;
             splashDamage = 18f * 1.5f;
             splashDamageRadius = 16f;
             fragBullet = fragGlassFrag;
@@ -225,7 +225,7 @@ public class Bullets implements ContentList{
             splashDamage = 25f * 1.5f;
             fragBullet = fragPlasticFrag;
             fragBullets = 6;
-            hitEffect = Fx.plasticExplosion;
+            hitEffect = despawnEffect = Fx.plasticExplosion;
             frontColor = Pal.plastaniumFront;
             backColor = Pal.plastaniumBack;
             shootEffect = Fx.shootBig;
@@ -263,8 +263,7 @@ public class Bullets implements ContentList{
             splashDamageRadius = 30f;
             splashDamage = 30f * 1.5f;
             ammoMultiplier = 4f;
-            hitEffect = Fx.blastExplosion;
-            despawnEffect = Fx.blastExplosion;
+            hitEffect = despawnEffect = Fx.blastExplosion;
 
             status = StatusEffects.blasted;
             statusDuration = 60f;
@@ -281,7 +280,7 @@ public class Bullets implements ContentList{
             splashDamageRadius = 20f;
             splashDamage = 20f * 1.5f;
             makeFire = true;
-            hitEffect = Fx.blastExplosion;
+            hitEffect = despawnEffect = Fx.blastExplosion;
             status = StatusEffects.burning;
         }};
 
@@ -292,8 +291,7 @@ public class Bullets implements ContentList{
             drag = -0.01f;
             splashDamageRadius = 25f;
             splashDamage = 25f * 1.5f;
-            hitEffect = Fx.blastExplosion;
-            despawnEffect = Fx.blastExplosion;
+            hitEffect = despawnEffect = Fx.blastExplosion;
             lightningDamage = 10;
             lightning = 2;
             lightningLength = 10;

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -131,7 +131,7 @@ public class UnitTypes implements ContentList{
                 ejectEffect = Fx.casing2;
                 shootSound = Sounds.artillery;
                 bullet = new ArtilleryBulletType(2f, 8, "shell"){{
-                    hitEffect = Fx.blastExplosion;
+                    hitEffect = despawnEffect = Fx.blastExplosion;
                     knockback = 0.8f;
                     lifetime = 110f;
                     width = height = 14f;
@@ -239,7 +239,7 @@ public class UnitTypes implements ContentList{
                     shootEffect = Fx.shootBig;
                     fragVelocityMin = 0.4f;
 
-                    hitEffect = Fx.blastExplosion;
+                    hitEffect = despawnEffect = Fx.blastExplosion;
                     splashDamage = 16f;
                     splashDamageRadius = 13f;
 
@@ -255,7 +255,7 @@ public class UnitTypes implements ContentList{
                         pierceCap = 3;
 
                         lifetime = 20f;
-                        hitEffect = Fx.flakExplosion;
+                        hitEffect = despawnEffect = Fx.flakExplosion;
                         splashDamage = 15f;
                         splashDamageRadius = 10f;
                     }};
@@ -563,7 +563,7 @@ public class UnitTypes implements ContentList{
                 ejectEffect = Fx.none;
                 shootSound = Sounds.explosion;
                 bullet = new BombBulletType(0f, 0f, "clear"){{
-                    hitEffect = Fx.pulverize;
+                    hitEffect = despawnEffect = Fx.pulverize;
                     lifetime = 10f;
                     speed = 1f;
                     splashDamageRadius = 58f;
@@ -764,7 +764,7 @@ public class UnitTypes implements ContentList{
                 recoil = 3f;
 
                 bullet = new ArtilleryBulletType(2f, 12){{
-                    hitEffect = Fx.sapExplosion;
+                    hitEffect = despawnEffect = Fx.sapExplosion;
                     knockback = 0.8f;
                     lifetime = 70f;
                     width = height = 19f;
@@ -862,7 +862,7 @@ public class UnitTypes implements ContentList{
                 shadow = 30f;
 
                 bullet = new ArtilleryBulletType(3f, 50){{
-                    hitEffect = Fx.sapExplosion;
+                    hitEffect = despawnEffect = Fx.sapExplosion;
                     knockback = 0.8f;
                     lifetime = 80f;
                     width = height = 25f;
@@ -884,7 +884,7 @@ public class UnitTypes implements ContentList{
                     fragBullets = 9;
 
                     fragBullet = new ArtilleryBulletType(2.3f, 30){{
-                        hitEffect = Fx.sapExplosion;
+                        hitEffect = despawnEffect = Fx.sapExplosion;
                         knockback = 0.8f;
                         lifetime = 90f;
                         width = height = 20f;
@@ -966,7 +966,7 @@ public class UnitTypes implements ContentList{
                 bullet = new BombBulletType(27f, 25f){{
                     width = 10f;
                     height = 14f;
-                    hitEffect = Fx.flakExplosion;
+                    hitEffect = despawnEffect = Fx.flakExplosion;
                     shootEffect = Fx.none;
                     smokeEffect = Fx.none;
 
@@ -1013,8 +1013,7 @@ public class UnitTypes implements ContentList{
                     trailColor = Pal.unitBack;
                     backColor = Pal.unitBack;
                     frontColor = Pal.unitFront;
-                    hitEffect = Fx.blastExplosion;
-                    despawnEffect = Fx.blastExplosion;
+                    hitEffect = despawnEffect = Fx.blastExplosion;
                     weaveScale = 6f;
                     weaveMag = 1f;
                 }};
@@ -1044,8 +1043,7 @@ public class UnitTypes implements ContentList{
                 splashDamage = 30f;
                 ammoMultiplier = 4f;
                 lifetime = 50f;
-                hitEffect = Fx.blastExplosion;
-                despawnEffect = Fx.blastExplosion;
+                hitEffect = despawnEffect = Fx.blastExplosion;
 
                 status = StatusEffects.blasted;
                 statusDuration = 60f;
@@ -1446,8 +1444,7 @@ public class UnitTypes implements ContentList{
                     trailColor = Color.gray;
                     backColor = Pal.bulletYellowBack;
                     frontColor = Pal.bulletYellow;
-                    hitEffect = Fx.blastExplosion;
-                    despawnEffect = Fx.blastExplosion;
+                    hitEffect = despawnEffect = Fx.blastExplosion;
                     weaveScale = 8f;
                     weaveMag = 2f;
                 }};
@@ -1533,7 +1530,7 @@ public class UnitTypes implements ContentList{
 
                 bullet = new ArtilleryBulletType(3.2f, 12){{
                     trailMult = 0.8f;
-                    hitEffect = Fx.massiveExplosion;
+                    hitEffect = despawnEffect = Fx.massiveExplosion;
                     knockback = 1.5f;
                     lifetime = 100f;
                     height = 15.5f;
@@ -1584,8 +1581,7 @@ public class UnitTypes implements ContentList{
                     trailColor = Color.gray;
                     backColor = Pal.bulletYellowBack;
                     frontColor = Pal.bulletYellow;
-                    hitEffect = Fx.blastExplosion;
-                    despawnEffect = Fx.blastExplosion;
+                    hitEffect = despawnEffect = Fx.blastExplosion;
                     weaveScale = 8f;
                     weaveMag = 1f;
                 }};
@@ -1645,8 +1641,7 @@ public class UnitTypes implements ContentList{
                     trailColor = Pal.bulletYellowBack;
                     backColor = Pal.bulletYellowBack;
                     frontColor = Pal.bulletYellow;
-                    hitEffect = Fx.blastExplosion;
-                    despawnEffect = Fx.blastExplosion;
+                    hitEffect = despawnEffect = Fx.blastExplosion;
                     weaveScale = 8f;
                     weaveMag = 2f;
                 }};
@@ -1720,7 +1715,7 @@ public class UnitTypes implements ContentList{
                     updateEffectSeg = 60f;
                     pierceEffect = Fx.railHit;
                     updateEffect = Fx.railTrail;
-                    hitEffect = Fx.massiveExplosion;
+                    hitEffect = despawnEffect = Fx.massiveExplosion;
                     smokeEffect = Fx.shootBig2;
                     damage = 1250;
                     pierceDamageFactor = 0.5f;

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -139,8 +139,7 @@ public abstract class BulletType extends Content{
     public BulletType(float speed, float damage){
         this.speed = speed;
         this.damage = damage;
-        hitEffect = Fx.hitBulletSmall;
-        despawnEffect = Fx.hitBulletSmall;
+        hitEffect = despawnEffect = Fx.hitBulletSmall;
     }
 
     public BulletType(){
@@ -200,6 +199,33 @@ public abstract class BulletType extends Content{
 
         Effect.shake(hitShake, hitShake, b);
 
+        spawnFragBullets(b, x, y);
+
+        spawnPuddles(x, y);
+
+        incend(x, y);
+
+        doSplashDamage(b, x, y);
+
+        spawnLightning(b, x, y);
+    }
+
+    public void despawned(Bullet b){
+        despawnEffect.at(b.x, b.y, b.rotation(), hitColor);
+        hitSound.at(b.x, b.y, hitSoundPitch, hitSoundVolume);
+
+        Effect.shake(despawnShake, despawnShake, b);
+
+        spawnFragBullets(b, b.x, b.y);
+
+        incend(b.x, b.y);
+
+        doSplashDamage(b, b.x, b.y);
+
+        spawnLightning(b, b.x, b.y);
+    }
+
+    public void spawnFragBullets(Bullet b, float x, float y){
         if(fragBullet != null){
             for(int i = 0; i < fragBullets; i++){
                 float len = Mathf.random(1f, 7f);
@@ -207,18 +233,24 @@ public abstract class BulletType extends Content{
                 fragBullet.create(b, x + Angles.trnsx(a, len), y + Angles.trnsy(a, len), a, Mathf.random(fragVelocityMin, fragVelocityMax), Mathf.random(fragLifeMin, fragLifeMax));
             }
         }
+    }
 
+    public void spawnPuddles(float x, float y){
         if(puddleLiquid != null && puddles > 0){
             for(int i = 0; i < puddles; i++){
                 Tile tile = world.tileWorld(x + Mathf.range(puddleRange), y + Mathf.range(puddleRange));
                 Puddles.deposit(tile, puddleLiquid, puddleAmount);
             }
         }
+    }
 
+    public void incend(float x, float y){
         if(Mathf.chance(incendChance)){
             Damage.createIncend(x, y, incendSpread, incendAmount);
         }
+    }
 
+    public void doSplashDamage(Bullet b, float x, float y){
         if(splashDamageRadius > 0 && !b.absorbed){
             Damage.damage(b.team, x, y, splashDamageRadius, splashDamage * b.damageMultiplier(), collidesAir, collidesGround);
 
@@ -239,20 +271,11 @@ public abstract class BulletType extends Content{
                 });
             }
         }
-
-        for(int i = 0; i < lightning; i++){
-            Lightning.create(b, lightningColor, lightningDamage < 0 ? damage : lightningDamage, b.x, b.y, b.rotation() + Mathf.range(lightningCone/2) + lightningAngle, lightningLength + Mathf.random(lightningLengthRand));
-        }
     }
 
-    public void despawned(Bullet b){
-        despawnEffect.at(b.x, b.y, b.rotation(), hitColor);
-        hitSound.at(b);
-
-        Effect.shake(despawnShake, despawnShake, b);
-
-        if(!b.hit && (fragBullet != null || splashDamageRadius > 0 || lightning > 0)){
-            hit(b);
+    public void spawnLightning(Bullet b, float x, float y){
+        for(int i = 0; i < lightning; i++){
+            Lightning.create(b, lightningColor, lightningDamage < 0 ? damage : lightningDamage, b.x, b.y, b.rotation() + Mathf.range(lightningCone/2) + lightningAngle, lightningLength + Mathf.random(lightningLengthRand));
         }
     }
 

--- a/core/src/mindustry/entities/bullet/FlakBulletType.java
+++ b/core/src/mindustry/entities/bullet/FlakBulletType.java
@@ -12,7 +12,7 @@ public class FlakBulletType extends BasicBulletType{
         super(speed, damage, "shell");
         splashDamage = 15f;
         splashDamageRadius = 34f;
-        hitEffect = Fx.flakExplosionBig;
+        hitEffect = despawnEffect = Fx.flakExplosionBig;
         width = 8f;
         height = 10f;
         collidesGround = false;

--- a/core/src/mindustry/entities/bullet/LaserBoltBulletType.java
+++ b/core/src/mindustry/entities/bullet/LaserBoltBulletType.java
@@ -10,9 +10,7 @@ public class LaserBoltBulletType extends BasicBulletType{
     public LaserBoltBulletType(float speed, float damage){
         super(speed, damage);
 
-        smokeEffect = Fx.hitLaser;
-        hitEffect = Fx.hitLaser;
-        despawnEffect = Fx.hitLaser;
+        smokeEffect = hitEffect = despawnEffect = Fx.hitLaser;
         hittable = false;
         reflectable = false;
     }

--- a/core/src/mindustry/entities/bullet/RailBulletType.java
+++ b/core/src/mindustry/entities/bullet/RailBulletType.java
@@ -19,8 +19,7 @@ public class RailBulletType extends BulletType{
         pierceBuilding = true;
         pierce = true;
         reflectable = false;
-        hitEffect = Fx.none;
-        despawnEffect = Fx.none;
+        hitEffect = despawnEffect = Fx.none;
         collides = false;
         lifetime = 1f;
         speed = 0.01f;


### PR DESCRIPTION
Pros:
- Easier to read. You can tell what each part does by the method name.
- Scripting/Java modding: Instead of overriding the entirety of `hit` to change something, you can just override one of the methods instead
- `despawned` and `hit` still exist, so pre-existing scripts are unaffected.
- `despawned` no longer calls `hit`, fixing
  - `hitSound` being played twice
  - `hitEffect` and `despawnEffect` displaying at the same time
Cons:
- None that I can think of

(Feel free to suggest different names for the methods. They're kinda h)