### PR TITLE
Nerf block lighting, buff illuminator

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -221,7 +221,7 @@ public class Blocks implements ContentList{
             blendGroup = basalt;
 
             emitLight = true;
-            lightRadius = 30f;
+            lightRadius = 17f;
             lightColor = Color.orange.cpy().a(0.15f);
         }};
 
@@ -232,7 +232,7 @@ public class Blocks implements ContentList{
             blendGroup = basalt;
 
             emitLight = true;
-            lightRadius = 50f;
+            lightRadius = 24f;
             lightColor = Color.orange.cpy().a(0.3f);
         }};
 
@@ -1996,7 +1996,7 @@ public class Blocks implements ContentList{
         illuminator = new LightBlock("illuminator"){{
             requirements(Category.effect, BuildVisibility.lightingOnly, with(Items.graphite, 12, Items.silicon, 8));
             brightness = 0.75f;
-            radius = 120f;
+            radius = 180f;
             consumes.power(0.05f);
         }};
 

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -132,7 +132,7 @@ public abstract class BulletType extends Content{
     public float puddleAmount = 5f;
     public Liquid puddleLiquid = Liquids.water;
 
-    public float lightRadius = 16f;
+    public float lightRadius = 6f;
     public float lightOpacity = 0.3f;
     public Color lightColor = Pal.powerLight;
 

--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -889,7 +889,7 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
             float fract = 1f;
             float opacity = color.a * fract;
             if(opacity > 0.001f){
-                Drawf.light(team, x, y, block.size * 30f * fract, color, opacity);
+                Drawf.light(team, x, y, block.size * 17f * fract, color, opacity);
             }
         }
     }

--- a/core/src/mindustry/graphics/Drawf.java
+++ b/core/src/mindustry/graphics/Drawf.java
@@ -204,6 +204,10 @@ public class Drawf{
     }
 
     public static void laser(Team team, TextureRegion line, TextureRegion edge, float x, float y, float x2, float y2, float rotation, float scale){
+        laser(team, line, edge, x, y, x2, y2, rotation, scale, Color.orange, 0.3f);
+    }
+
+    public static void laser(Team team, TextureRegion line, TextureRegion edge, float x, float y, float x2, float y2, float rotation, float scale, Color color, float opacity){
         float scl = 8f * scale * Draw.scl;
         float vx = Mathf.cosDeg(rotation) * scl, vy = Mathf.sinDeg(rotation) * scl;
 
@@ -214,7 +218,7 @@ public class Drawf{
         Lines.line(line, x + vx, y + vy, x2 - vx, y2 - vy, false);
         Lines.stroke(1f);
 
-        light(team, x, y, x2, y2);
+        light(team, x, y, x2, y2, scl + 18f, color, opacity);
     }
 
     public static void tri(float x, float y, float width, float length, float rotation){

--- a/core/src/mindustry/type/UnitType.java
+++ b/core/src/mindustry/type/UnitType.java
@@ -94,7 +94,7 @@ public class UnitType extends UnlockableContent{
     public float strafePenalty = 0.5f;
     public float hitSize = 6f;
     public float itemOffsetY = 3f;
-    public float lightRadius = 60f, lightOpacity = 0.6f;
+    public float lightRadius = 20f, lightOpacity = 0.6f;
     public Color lightColor = Pal.powerLight;
     public boolean drawCell = true, drawItems = true, drawShields = true;
     public int trailLength = 3;

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -176,13 +176,13 @@ public class Block extends UnlockableContent{
     /** How reflective this block is. */
     public float albedo = 0f;
     /** Environmental passive light color. */
-    public Color lightColor = Color.white.cpy();
+    public Color lightColor = Color.white.cpy().a(0.3f);
     /**
      * Whether this environmental block passively emits light.
      * Not valid for non-environmental blocks. */
     public boolean emitLight = false;
     /** Radius of the light emitted by this block. */
-    public float lightRadius = 60f;
+    public float lightRadius = 20f;
 
     /** The sound that this block makes while active. One sound loop. Do not overuse. */
     public Sound loopSound = Sounds.none;

--- a/core/src/mindustry/world/blocks/defense/MendProjector.java
+++ b/core/src/mindustry/world/blocks/defense/MendProjector.java
@@ -122,7 +122,7 @@ public class MendProjector extends Block{
 
         @Override
         public void drawLight(){
-            Drawf.light(team, x, y, 50f * smoothEfficiency, baseColor, 0.7f * smoothEfficiency);
+            Drawf.light(team, x, y, 32f * smoothEfficiency, baseColor, 0.53f * smoothEfficiency);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
+++ b/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
@@ -88,7 +88,7 @@ public class OverdriveProjector extends Block{
 
         @Override
         public void drawLight(){
-            Drawf.light(team, x, y, 50f * smoothEfficiency, baseColor, 0.7f * smoothEfficiency);
+            Drawf.light(team, x, y, 32f * smoothEfficiency, baseColor, 0.53f * smoothEfficiency);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/power/ImpactReactor.java
+++ b/core/src/mindustry/world/blocks/power/ImpactReactor.java
@@ -122,7 +122,7 @@ public class ImpactReactor extends PowerGenerator{
 
         @Override
         public void drawLight(){
-            Drawf.light(team, x, y, (110f + Mathf.absin(5, 5f)) * warmup, Tmp.c1.set(plasma2).lerp(plasma1, Mathf.absin(7f, 0.2f)), 0.8f * warmup);
+            Drawf.light(team, x, y, (36f + Mathf.absin(5, 5f)) * warmup, Tmp.c1.set(plasma2).lerp(plasma1, Mathf.absin(7f, 0.2f)), 0.8f * warmup);
         }
         
         @Override

--- a/core/src/mindustry/world/blocks/power/ItemLiquidGenerator.java
+++ b/core/src/mindustry/world/blocks/power/ItemLiquidGenerator.java
@@ -171,7 +171,7 @@ public class ItemLiquidGenerator extends PowerGenerator{
 
         @Override
         public void drawLight(){
-            Drawf.light(team, x, y, (60f + Mathf.absin(10f, 5f)) * size, Color.orange, 0.5f * heat);
+            Drawf.light(team, x, y, (20f + Mathf.absin(10f, 5f)) * size, Color.orange, 0.5f * heat);
         }
     }
 }

--- a/core/src/mindustry/world/blocks/power/NuclearReactor.java
+++ b/core/src/mindustry/world/blocks/power/NuclearReactor.java
@@ -160,7 +160,7 @@ public class NuclearReactor extends PowerGenerator{
         @Override
         public void drawLight(){
             float fract = productionEfficiency;
-            Drawf.light(team, x, y, (90f + Mathf.absin(5, 5f)) * fract, Tmp.c1.set(lightColor).lerp(Color.scarlet, heat), 0.6f * fract);
+            Drawf.light(team, x, y, (30f + Mathf.absin(5, 5f)) * fract, Tmp.c1.set(lightColor).lerp(Color.scarlet, heat), 0.6f * fract);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/power/ThermalGenerator.java
+++ b/core/src/mindustry/world/blocks/power/ThermalGenerator.java
@@ -52,7 +52,7 @@ public class ThermalGenerator extends PowerGenerator{
 
         @Override
         public void drawLight(){
-            Drawf.light(team, x, y, (40f + Mathf.absin(10f, 5f)) * productionEfficiency * size, Color.scarlet, 0.4f);
+            Drawf.light(team, x, y, (12f + Mathf.absin(10f, 5f)) * productionEfficiency * size, Color.scarlet, 0.4f);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/production/GenericSmelter.java
+++ b/core/src/mindustry/world/blocks/production/GenericSmelter.java
@@ -44,7 +44,7 @@ public class GenericSmelter extends GenericCrafter{
 
         @Override
         public void drawLight(){
-            Drawf.light(team, x, y, (60f + Mathf.absin(10f, 5f)) * warmup * size, flameColor, 0.65f);
+            Drawf.light(team, x, y, (20f + Mathf.absin(10f, 5f)) * warmup * size, flameColor, 0.46f);
         }
     }
 }


### PR DESCRIPTION
After some discussion in balancing, we decided that illuminator is underused because everything else already creates enough light that there's no reason to build them.
![image](https://user-images.githubusercontent.com/54301439/112075129-22e6a300-8b35-11eb-99aa-eb2a52d7d59c.png)
This weakens light produced by other sources, and buffs illuminator light proudction.