### PR TITLE
Move capping code from armored to normal conduits

### DIFF
--- a/core/src/mindustry/world/blocks/liquid/ArmoredConduit.java
+++ b/core/src/mindustry/world/blocks/liquid/ArmoredConduit.java
@@ -1,13 +1,10 @@
 package mindustry.world.blocks.liquid;
 
-import arc.graphics.g2d.*;
-import mindustry.annotations.Annotations.*;
 import mindustry.gen.*;
 import mindustry.type.*;
 import mindustry.world.*;
 
 public class ArmoredConduit extends Conduit{
-    public @Load("@-cap") TextureRegion capRegion;
 
     public ArmoredConduit(String name){
         super(name);
@@ -21,17 +18,6 @@ public class ArmoredConduit extends Conduit{
     }
 
     public class ArmoredConduitBuild extends ConduitBuild{
-        @Override
-        public void draw(){
-            super.draw();
-
-            //draw the cap when a conduit would normally leak
-            Building next = front();
-            if(next != null && next.team == team && next.block.hasLiquids) return;
-
-            Draw.rect(capRegion, x, y, rotdeg());
-        }
-
         @Override
         public boolean acceptLiquid(Building source, Liquid liquid){
             return super.acceptLiquid(source, liquid) && (source.block instanceof Conduit ||

--- a/core/src/mindustry/world/blocks/liquid/Conduit.java
+++ b/core/src/mindustry/world/blocks/liquid/Conduit.java
@@ -28,6 +28,7 @@ public class Conduit extends LiquidBlock implements Autotiler{
 
     public @Load(value = "@-top-#", length = 5) TextureRegion[] topRegions;
     public @Load(value = "@-bottom-#", length = 5, fallback = "conduit-bottom-#") TextureRegion[] botRegions;
+    public @Load("@-cap") TextureRegion capRegion;
 
     public boolean leaks = true;
 
@@ -83,6 +84,7 @@ public class Conduit extends LiquidBlock implements Autotiler{
     public class ConduitBuild extends LiquidBuild implements ChainedBuilding{
         public float smoothLiquid;
         public int blendbits, xscl, yscl, blending;
+        public boolean capped;
 
         @Override
         public void draw(){
@@ -104,6 +106,8 @@ public class Conduit extends LiquidBlock implements Autotiler{
             Draw.scl(xscl, yscl);
             drawAt(x, y, blendbits, rotation, SliceMode.none);
             Draw.reset();
+
+            if(capped && capRegion.found()) Draw.rect(capRegion, x, y, rotdeg());
         }
 
         protected void drawAt(float x, float y, int bits, float rotation, SliceMode slice){
@@ -124,6 +128,9 @@ public class Conduit extends LiquidBlock implements Autotiler{
             xscl = bits[1];
             yscl = bits[2];
             blending = bits[4];
+
+            Building next = front();
+            capped = next == null || next.team != team || !next.block.hasLiquids;
         }
 
         @Override


### PR DESCRIPTION
this pull was mainly to get the check outside the draw function and into the proximity updater, but decided i might as well just move it into the base conduit class, capping behavior is separated from leaking and controlled by the sprite region existing:

![Screen Shot 2021-03-23 at 13 21 14](https://user-images.githubusercontent.com/3179271/112145456-ab6b4f00-8bda-11eb-8938-c2d28faa753e.png)

> just a pic that shows its all still visibly working as intended ^ (the sprites were still packed from #4978)