### PR TITLE
Add assetsJar artifact for core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -322,9 +322,20 @@ project(":core"){
         classifier = 'sources'
         from sourceSets.main.allSource
     }
-    
+
+    task assetsJar(type: Jar, dependsOn: ":tools:pack"){
+        classifier = 'assets'
+        from files("assets"){
+            exclude "config"
+            exclude "cache"
+            exclude "music"
+            exclude "sounds"
+        }
+    }
+
     artifacts{
         archives sourcesJar
+        archives assetsJar
     }
 
     dependencies{

--- a/build.gradle
+++ b/build.gradle
@@ -333,9 +333,18 @@ project(":core"){
         }
     }
 
+    task musicJar(type: Jar){
+        classifier = 'music'
+        from files("assets"){
+            include "music/*"
+            include "sounds/*"
+        }
+    }
+
     artifacts{
         archives sourcesJar
         archives assetsJar
+        archives musicJar
     }
 
     dependencies{


### PR DESCRIPTION
Add artifact output: core.assets.jar

This artifact can provider dependence for projects like coreBot, that don't run the game but need assets for some work.