### PR TITLE
Allow for dynamic counting

### DIFF
--- a/core/src/mindustry/core/Logic.java
+++ b/core/src/mindustry/core/Logic.java
@@ -368,7 +368,7 @@ public class Logic implements ApplicationListener{
 
         if(state.isGame()){
             if(!net.client()){
-                state.enemies = Groups.unit.count(u -> u.team() == state.rules.waveTeam && u.type.isCounted);
+                state.enemies = Groups.unit.count(u -> u.team() == state.rules.waveTeam && u.isCounted());
             }
 
             if(!state.isPaused()){

--- a/core/src/mindustry/entities/comp/UnitComp.java
+++ b/core/src/mindustry/entities/comp/UnitComp.java
@@ -186,6 +186,10 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
         return !disarmed && !(type.canBoost && isFlying());
     }
 
+    public boolean isCounted(){
+        return type.isCounted;
+    }
+
     @Override
     public int itemCapacity(){
         return type.itemCapacity;


### PR DESCRIPTION
Turn `isCounted` into a method. Allows for scripted units to be sometimes counted and sometimes not counted.

---
Example for where this could be used:
![Mindustry_pgzfegM5Fu](https://user-images.githubusercontent.com/54301439/112407732-db4a4d80-8cd3-11eb-8818-9abdb18bc717.png)
The head, segments, and tail all use the same type, so it's impossible to make it count as only one unit.