### PR TITLE
Exclude derelict targets from Units.bestEnemy

### DIFF
--- a/core/src/mindustry/entities/Units.java
+++ b/core/src/mindustry/entities/Units.java
@@ -218,7 +218,7 @@ public class Units{
         cdist = 0f;
 
         nearbyEnemies(team, x - range, y - range, range*2f, range*2f, e -> {
-            if(e.dead() || !predicate.get(e) || !e.within(x, y, range + e.hitSize/2f)) return;
+            if(e.dead() || !predicate.get(e) || e.team == Team.derelict || !e.within(x, y, range + e.hitSize/2f)) return;
 
             float cost = sort.cost(e, x, y);
             if(result == null || cost < cdist){


### PR DESCRIPTION
its excluded for `closestEnemy` but (yet) not for `bestEnemy`: (aka turrets still target derelict)

https://github.com/Anuken/Mindustry/blob/b6c645b7018d06fea1ded727fc58ddd91de8fe91/core/src/mindustry/entities/Units.java#L201

> or perhaps the check should move into `nearbyEnemies` so it works for both? not sure if that would break other stuff 🤔 