### PR TITLE
Customizable timescale per team?

### DIFF
--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -1393,7 +1393,7 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
 
         timeScaleDuration -= Time.delta;
         if(timeScaleDuration <= 0f || !block.canOverdrive){
-            timeScale = 1f;
+            timeScale = state.rules.teams.get(team).timescale;
         }
 
         if(!enabled && block.autoResetEnabled){

--- a/core/src/mindustry/game/Rules.java
+++ b/core/src/mindustry/game/Rules.java
@@ -118,6 +118,8 @@ public class Rules{
         public boolean infiniteResources;
         /** If true, this team has infinite unit ammo. */
         public boolean infiniteAmmo;
+        /** Default timescale of un-boosted blocks. */
+        public float timescale = 1f;
     }
 
     /** Copies this ruleset exactly. Not efficient at all, do not use often. */


### PR DESCRIPTION
just a questionable toy for plugins, being able to speed up (or even slow down) certain teams, some potential for pvp when teams are unbalanced, "map wide" overdrive projector coverage without abusive tricks, but calling `rules.teams.get(team)` for each block each tick might be a performance hit? i'll just leave it here as a draft for others / anuke to comment on for now 🤔 

> doesn't get subtracted from how much overdrive projectors boost, but if the number is higher they are just decoration