### PR TITLE
Change int parameters to long type in kick method

### DIFF
--- a/core/src/mindustry/entities/comp/PlayerComp.java
+++ b/core/src/mindustry/entities/comp/PlayerComp.java
@@ -223,7 +223,7 @@ abstract class PlayerComp implements UnitController, Entityc, Syncc, Timerc, Dra
         con.kick(reason);
     }
 
-    void kick(String reason, int duration){
+    void kick(String reason, long duration){
         con.kick(reason, duration);
     }
 

--- a/core/src/mindustry/net/NetConnection.java
+++ b/core/src/mindustry/net/NetConnection.java
@@ -62,7 +62,7 @@ public abstract class NetConnection{
     }
 
     /** Kick with an arbitrary reason, and a kick duration in milliseconds. */
-    public void kick(String reason, int kickDuration){
+    public void kick(String reason, long kickDuration){
         if(kicked) return;
 
         Log.info("Kicking connection @; Reason: @", address, reason.replace("\n", " "));


### PR DESCRIPTION
This looks inappropriate, since the `mindustry.net.Administration#handleKicked` method takes `duration` as `long`
https://github.com/Anuken/Mindustry/blob/496d6b139e6bda12de182f9cb74bb3decefef71a/core/src/mindustry/net/Administration.java#L93