### PR TITLE
Add firstItemNeeded sensor

### DIFF
--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -1333,11 +1333,30 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
         };
     }
 
+    public Item firstItemNeeded(){
+        for(Consume c : block.consumes.all()){
+            if(c.isOptional()) continue;
+
+            ItemStack[] needed = 
+                c instanceof ConsumeItems ? ((ConsumeItems)c).items : 
+                c instanceof ConsumeItemFilter ? new ItemStack[]{new ItemStack(content.items().find(((ConsumeItemFilter)c).filter), 1)} : 
+                c instanceof ConsumeItemDynamic ? ((ConsumeItemDynamic)c).items.get(tile.build) : 
+                ItemStack.empty;
+
+            for(ItemStack stack : needed){
+                if(!items.has(stack)) return stack.item;
+            }
+        }
+
+        return null;
+    }
+
     @Override
     public Object senseObject(LAccess sensor){
         return switch(sensor){
             case type -> block;
             case firstItem -> items == null ? null : items.first();
+            case firstItemNeeded -> block.hasItems ? firstItemNeeded() : null;
             case config -> block.configurations.containsKey(Item.class) || block.configurations.containsKey(Liquid.class) ? config() : null;
             case payloadType -> getPayload() instanceof UnitPayload p1 ? p1.unit.type : getPayload() instanceof BuildPayload p2 ? p2.block() : null;
             default -> noSensed;

--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -1340,7 +1340,7 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
             ItemStack[] needed = 
                 c instanceof ConsumeItems ? ((ConsumeItems)c).items : 
                 c instanceof ConsumeItemFilter ? new ItemStack[]{new ItemStack(content.items().find(((ConsumeItemFilter)c).filter), 1)} : 
-                c instanceof ConsumeItemDynamic ? ((ConsumeItemDynamic)c).items.get(tile.build) : 
+                c instanceof ConsumeItemDynamic ? ((ConsumeItemDynamic)c).items.get(self()) : 
                 ItemStack.empty;
 
             for(ItemStack stack : needed){

--- a/core/src/mindustry/logic/LAccess.java
+++ b/core/src/mindustry/logic/LAccess.java
@@ -6,6 +6,7 @@ import arc.struct.*;
 public enum LAccess{
     totalItems,
     firstItem,
+    firstItemNeeded,
     totalLiquids,
     totalPower,
     itemCapacity,

--- a/core/src/mindustry/world/modules/ItemModule.java
+++ b/core/src/mindustry/world/modules/ItemModule.java
@@ -127,6 +127,10 @@ public class ItemModule extends BlockModule{
         return get(item) >= amount;
     }
 
+    public boolean has(ItemStack stack){
+        return get(stack.item) >= stack.amount;
+    }
+
     public boolean has(ItemStack[] stacks){
         for(ItemStack stack : stacks){
             if(!has(stack.item, stack.amount)) return false;


### PR DESCRIPTION
Relevant: https://github.com/Anuken/Mindustry-Suggestions/issues/2206

This PR adds a `firstItemNeeded` sensor, which returns the first item needed. 

This way, one can use the same flare logic to supply many different unit factories.
![SameLogic](https://user-images.githubusercontent.com/68400583/112739503-a6373880-8f29-11eb-99eb-b22836ac35ce.gif)
~~Ignore the naval factory which I forgot to put logic for~~

Here's the extremely simplified pseudocode of the logic above. 

Unit Bind + Flag checks
if currentFlareItem = firstItemNeeded drop off items
otherwise get firstItemNeeded from core

Notes:
 - Does not consider "optional items" like phase-fabric boosters as "needed items"
 - `ConsumeItemFilter` support is kind of wack, might need to work that out
 - Does not work with turrets