### PR TITLE
Randomly Rotated Particle Weather Particles

### DIFF
--- a/core/src/mindustry/type/Weather.java
+++ b/core/src/mindustry/type/Weather.java
@@ -113,7 +113,8 @@ public class Weather extends UnlockableContent{
                               float density, float intensity, float opacity,
                               float windx, float windy,
                               float minAlpha, float maxAlpha,
-                              float sinSclMin, float sinSclMax, float sinMagMin, float sinMagMax){
+                              float sinSclMin, float sinSclMax, float sinMagMin, float sinMagMax,
+                              boolean randomParticleRotation){
         rand.setSeed(0);
         Tmp.r1.setCentered(Core.camera.position.x, Core.camera.position.y, Core.graphics.getWidth() / renderer.minScale(), Core.graphics.getHeight() / renderer.minScale());
         Tmp.r1.grow(sizeMax * 1.5f);
@@ -128,6 +129,7 @@ public class Weather extends UnlockableContent{
             float x = (rand.random(0f, world.unitWidth()) + Time.time * windx * scl2);
             float y = (rand.random(0f, world.unitHeight()) + Time.time * windy * scl);
             float alpha = rand.random(minAlpha, maxAlpha);
+            float rotation = randomParticleRotation ? rand.random(0f, 360f) : 0f;
 
             x += Mathf.sin(y, rand.random(sinSclMin, sinSclMax), rand.random(sinMagMin, sinMagMax));
 
@@ -140,7 +142,7 @@ public class Weather extends UnlockableContent{
 
             if(Tmp.r3.setCentered(x, y, size).overlaps(Tmp.r2)){
                 Draw.alpha(alpha * opacity);
-                Draw.rect(region, x, y, size, size);
+                Draw.rect(region, x, y, size, size, rotation);
             }
         }
     }

--- a/core/src/mindustry/type/weather/ParticleWeather.java
+++ b/core/src/mindustry/type/weather/ParticleWeather.java
@@ -16,7 +16,7 @@ public class ParticleWeather extends Weather{
     public float sinSclMin = 30f, sinSclMax = 80f, sinMagMin = 1f, sinMagMax = 7f;
 
     public Color noiseColor = color;
-    public boolean drawNoise = false, drawParticles = true, useWindVector = false;
+    public boolean drawNoise = false, drawParticles = true, useWindVector = false, randomParticleRotation = false;
     public int noiseLayers = 1;
     public float noiseLayerSpeedM = 1.1f, noiseLayerAlphaM = 0.8f, noiseLayerSclM = 0.99f, noiseLayerColorM = 1f;
     public String noisePath = "noiseAlpha";
@@ -84,7 +84,7 @@ public class ParticleWeather extends Weather{
         }
 
         if(drawParticles){
-            drawParticles(region, color, sizeMin, sizeMax, density, state.intensity, state.opacity, windx, windy, minAlpha, maxAlpha, sinSclMin, sinSclMax, sinMagMin, sinMagMax);
+            drawParticles(region, color, sizeMin, sizeMax, density, state.intensity, state.opacity, windx, windy, minAlpha, maxAlpha, sinSclMin, sinSclMax, sinMagMin, sinMagMax, randomParticleRotation);
         }
     }
 }


### PR DESCRIPTION
Adds `randomParticleRotation` (name could be shortened) as a boolean to decide if the particles in ParticleWeather are randomly rotated or not, for modded weathers that don't use symmetrical particles.