### PR TITLE
Radar shouldn't sense derelict as enemies

### DIFF
--- a/core/src/mindustry/logic/RadarTarget.java
+++ b/core/src/mindustry/logic/RadarTarget.java
@@ -5,7 +5,7 @@ import mindustry.gen.*;
 
 public enum RadarTarget{
     any((team, other) -> true),
-    enemy((team, other) -> team != other.team),
+    enemy((team, other) -> team != other.team && other.team != Team.derelict),
     ally((team, other) -> team == other.team),
     player((team, other) -> other.isPlayer()),
     attacker((pos, other) -> other.canShoot()),


### PR DESCRIPTION
Turrets no longer shoot derelict units by default, they shouldn't be sensed as enemies if this is the case.