### PR TITLE
Allow for dynamic laser absorption and insulation

### DIFF
--- a/core/src/mindustry/entities/Damage.java
+++ b/core/src/mindustry/entities/Damage.java
@@ -89,7 +89,7 @@ public class Damage{
         furthest = null;
 
         boolean found = world.raycast(b.tileX(), b.tileY(), World.toTile(b.x + Tmp.v1.x), World.toTile(b.y + Tmp.v1.y),
-        (x, y) -> (furthest = world.tile(x, y)) != null && furthest.team() != b.team && furthest.block().absorbLasers);
+        (x, y) -> (furthest = world.tile(x, y)) != null && furthest.team() != b.team && (furthest.build != null && furthest.build.absorbLasers()));
 
         return found && furthest != null ? Math.max(6f, b.dst(furthest.worldx(), furthest.worldy())) : length;
     }

--- a/core/src/mindustry/entities/Lightning.java
+++ b/core/src/mindustry/entities/Lightning.java
@@ -53,7 +53,7 @@ public class Lightning{
                 world.raycastEach(World.toTile(from.getX()), World.toTile(from.getY()), World.toTile(to.getX()), World.toTile(to.getY()), (wx, wy) -> {
 
                     Tile tile = world.tile(wx, wy);
-                    if(tile != null && tile.block().insulated && tile.team() != team){
+                    if(tile != null && tile.build.isInsulated() && tile.team() != team){
                         bhit = true;
                         //snap it instead of removing
                         lines.get(lines.size -1).set(wx * tilesize, wy * tilesize);

--- a/core/src/mindustry/entities/Lightning.java
+++ b/core/src/mindustry/entities/Lightning.java
@@ -53,7 +53,7 @@ public class Lightning{
                 world.raycastEach(World.toTile(from.getX()), World.toTile(from.getY()), World.toTile(to.getX()), World.toTile(to.getY()), (wx, wy) -> {
 
                     Tile tile = world.tile(wx, wy);
-                    if(tile != null && tile.build.isInsulated() && tile.team() != team){
+                    if(tile != null && (tile.build != null && tile.build.isInsulated()) && tile.team() != team){
                         bhit = true;
                         //snap it instead of removing
                         lines.get(lines.size -1).set(wx * tilesize, wy * tilesize);

--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -1179,6 +1179,10 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
         return amount;
     }
 
+    public boolean absorbLasers(){
+        return block.absorbLasers;
+    }
+
     public boolean collide(Bullet other){
         return true;
     }

--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -1183,6 +1183,10 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
         return block.absorbLasers;
     }
 
+    public boolean isInsulated(){
+        return block.insulated;
+    }
+
     public boolean collide(Bullet other){
         return true;
     }

--- a/core/src/mindustry/world/blocks/power/PowerNode.java
+++ b/core/src/mindustry/world/blocks/power/PowerNode.java
@@ -341,7 +341,7 @@ public class PowerNode extends PowerBlock{
     public static boolean insulated(int x, int y, int x2, int y2){
         return world.raycast(x, y, x2, y2, (wx, wy) -> {
             Building tile = world.build(wx, wy);
-            return tile != null && tile.block.insulated;
+            return tile != null && tile.isInsulated();
         });
     }
 


### PR DESCRIPTION
Creates `absorbLasers()` in `BuildingComp`, so that scripts can make a block sometimes absorb lasers and sometimes don't.
Same with `isInsulated()`.