### PR TITLE
Add Kotlin Support

### DIFF
--- a/annotations/src/main/java/mindustry/annotations/impl/AssetsProcess.java
+++ b/annotations/src/main/java/mindustry/annotations/impl/AssetsProcess.java
@@ -20,8 +20,8 @@ public class AssetsProcess extends BaseProcessor{
 
     @Override
     public void process(RoundEnvironment env) throws Exception{
-        processSounds("Sounds", rootDirectory + "/core/assets/sounds", "arc.audio.Sound");
-        processSounds("Musics", rootDirectory + "/core/assets/music", "arc.audio.Music");
+        processSounds("Sounds", rootDirectory + "/assets/sounds", "arc.audio.Sound");
+        processSounds("Musics", rootDirectory + "/assets/music", "arc.audio.Music");
         processUI(env.getElementsAnnotatedWith(StyleDefaults.class));
     }
 
@@ -33,11 +33,11 @@ public class AssetsProcess extends BaseProcessor{
         MethodSpec.Builder loadStyles = MethodSpec.methodBuilder("loadStyles").addModifiers(Modifier.PUBLIC, Modifier.STATIC);
         MethodSpec.Builder icload = MethodSpec.methodBuilder("load").addModifiers(Modifier.PUBLIC, Modifier.STATIC);
         CodeBlock.Builder ichinit = CodeBlock.builder();
-        String resources = rootDirectory + "/core/assets-raw/sprites/ui";
-        Jval icons = Jval.read(Fi.get(rootDirectory + "/core/assets-raw/fontgen/config.json").readString());
+        String resources = rootDirectory + "/assets-raw/sprites/ui";
+        Jval icons = Jval.read(Fi.get(rootDirectory + "/assets-raw/fontgen/config.json").readString());
 
         ObjectMap<String, String> texIcons = new OrderedMap<>();
-        PropertiesUtils.load(texIcons, Fi.get(rootDirectory + "/core/assets/icons/icons.properties").reader());
+        PropertiesUtils.load(texIcons, Fi.get(rootDirectory + "/assets/icons/icons.properties").reader());
 
         StringBuilder iconcAll = new StringBuilder();
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,11 @@ buildscript{
     }
 }
 
+plugins {
+    id 'org.jetbrains.kotlin.jvm' version '1.4.32'
+    id "org.jetbrains.kotlin.kapt" version "1.4.32"
+}
+
 allprojects{
     apply plugin: 'maven'
     
@@ -287,6 +292,16 @@ project(":ios"){
 
 project(":core"){
     apply plugin: "java-library"
+    apply plugin: "kotlin"
+    apply plugin: "kotlin-kapt"
+
+    kapt {
+        javacOptions {
+            option("-source", "14")
+            option("-target", "1.8")
+            option("--enable-preview")
+        }
+    }
 
     compileJava.options.fork = true
 
@@ -354,10 +369,9 @@ project(":core"){
         api "com.github.Anuken:rhino:$rhinoVersion"
         if(localArc() && debugged()) api arcModule("extensions:recorder")
 
-        compileOnly project(":annotations")
-        annotationProcessor project(":annotations")
         annotationProcessor 'com.github.Anuken:jabel:34e4c172e65b3928cd9eabe1993654ea79c409cd'
-
+        compileOnly project(":annotations")
+        kapt project(":annotations")
     }
 
     afterEvaluate{

--- a/core/assets/contributors
+++ b/core/assets/contributors
@@ -119,3 +119,4 @@ BTA_Susideur
 nilq
 AsgerHB
 AzCraft
+foo

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,9 @@
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xms256m -Xmx1024m
 archash=0e99b0291f81d74d335dca8b0cf3bf26931f1197
+# Don't recompute annotations if sources haven't been changed
+kapt.incremantal.apt = true
+# Multithreaded
+kapt.use.worker.api=true
+# Compilation avoidance (see https://kotlinlang.org/docs/kapt.html#compile-avoidance-for-kapt-since-1-3-20)
+kapt.include.compile.classpath=false


### PR DESCRIPTION
This PR makes the annotations module use the kotlin annotation processor, kapt, instead of the java one.  This enables kotlin code to be put in the core module, as well as speeds up compilation time to only a few seconds if no code in core has been changed (so not often).
NOTE: This breaks tests because it resets entity revisions to 0.  I'm not sure how to fix this because I haven't worked with revisions.