### PR TITLE
Allow for block inventory as well as config

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,6 @@
 name: Pull Request Tests
 
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   buildJava14:

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -888,9 +888,9 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         //check if tapped block is configurable
         if(build.block.configurable && build.interactable(player.team())){
             consumed = true;
-            if(((!frag.config.isShown() && build.shouldShowConfigure(player)) //if the config fragment is hidden, show
+            if((!frag.config.isShown() && build.shouldShowConfigure(player)) //if the config fragment is hidden, show
             //alternatively, the current selected block can 'agree' to switch config tiles
-            || (frag.config.isShown() && frag.config.getSelectedTile().onConfigureTileTapped(build)))){
+            || (frag.config.isShown() && frag.config.getSelectedTile().onConfigureTileTapped(build))){
                 Sounds.click.at(build);
                 frag.config.showConfig(build);
             }
@@ -915,7 +915,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         //consume tap event if necessary
         if(build.interactable(player.team()) && build.block.consumesTap){
             consumed = true;
-        }else if(build.interactable(player.team()) && build.block.synthetic() && !consumed){
+        }else if(build.interactable(player.team()) && build.block.synthetic()){
             if(build.block.hasItems && build.items.total() > 0){
                 frag.inv.showFor(build);
                 consumed = true;

--- a/core/src/mindustry/world/blocks/storage/CoreBlock.java
+++ b/core/src/mindustry/world/blocks/storage/CoreBlock.java
@@ -5,6 +5,7 @@ import arc.func.*;
 import arc.graphics.g2d.*;
 import arc.math.*;
 import arc.math.geom.*;
+import arc.scene.ui.layout.*;
 import arc.struct.*;
 import mindustry.*;
 import mindustry.annotations.Annotations.*;
@@ -53,6 +54,7 @@ public class CoreBlock extends StorageBlock{
         drawDisabled = false;
         canOverdrive = false;
         replaceable = false;
+        configurable = true;
     }
 
     @Remote(called = Loc.server)

--- a/core/src/mindustry/world/blocks/storage/CoreBlock.java
+++ b/core/src/mindustry/world/blocks/storage/CoreBlock.java
@@ -388,5 +388,22 @@ public class CoreBlock extends StorageBlock{
                 noEffect = false;
             }
         }
+
+        @Override
+        public void buildConfiguration(Table table){
+            if(!state.isCampaign() || net.client()){
+                deselect();
+                return;
+            }
+
+            table.button(Icon.downOpen, Styles.clearTransi, () -> {
+                ui.planet.showSelect(state.rules.sector, other -> {
+                    if(state.isCampaign()){
+                        other.info.destination = state.rules.sector;
+                    }
+                });
+                deselect();
+            }).size(40f);
+        }
     }
 }


### PR DESCRIPTION
Can now see items in mass drivers and bridges, items can be added or removed from them directly. Also added an extra button to the core in campaign that allows for quick selection of launchpad destinations (select a sector which well send items to the current one).