### PR TITLE
Boss locator with spore color

### DIFF
--- a/core/src/mindustry/graphics/OverlayRenderer.java
+++ b/core/src/mindustry/graphics/OverlayRenderer.java
@@ -14,6 +14,7 @@ import mindustry.ui.*;
 import mindustry.world.*;
 
 import static mindustry.Vars.*;
+import static mindustry.graphics.Pal.spore;
 
 public class OverlayRenderer{
     private static final float indicatorLength = 14f;
@@ -60,7 +61,12 @@ public class OverlayRenderer{
                     .setCenter(Core.camera.position.x, Core.camera.position.y).contains(unit.x, unit.y)){
                         Tmp.v1.set(unit.x, unit.y).sub(player).setLength(indicatorLength);
 
-                        Lines.stroke(1f, unit.team().color);
+                        if (unit.isBoss()) {
+                            Lines.stroke(1f, spore);
+                        }
+                        else {
+                            Lines.stroke(1f, unit.team().color);
+                        }
                         Lines.lineAngle(player.x + Tmp.v1.x, player.y + Tmp.v1.y, Tmp.v1.angle(), 3f);
                         Draw.reset();
                     }


### PR DESCRIPTION
This update it means if there is a boss, the boss has a extra line that stroke to it. The color is the spore color.
(Sorry for my bad English)

This pull request solves this [issue](https://github.com/Anuken/Mindustry-Suggestions/issues/2268) But it have no settings, because a boss/guardian is very rare.