### PR TITLE
Increase Surge Swarmer Ammo Multipler

### DIFF
--- a/core/src/mindustry/content/Bullets.java
+++ b/core/src/mindustry/content/Bullets.java
@@ -280,6 +280,7 @@ public class Bullets implements ContentList{
             homingPower = 0.08f;
             splashDamageRadius = 20f;
             splashDamage = 20f * 1.5f;
+            ammoMultiplier = 3f;
             makeFire = true;
             hitEffect = Fx.blastExplosion;
             status = StatusEffects.burning;
@@ -292,6 +293,7 @@ public class Bullets implements ContentList{
             drag = -0.01f;
             splashDamageRadius = 25f;
             splashDamage = 25f * 1.5f;
+            ammoMultiplier = 5f;
             hitEffect = Fx.blastExplosion;
             despawnEffect = Fx.blastExplosion;
             lightningDamage = 10;


### PR DESCRIPTION
Increase Surge alloy Ammo Multiplier from x2 to x5
Increase Pyratite Ammo Multiplier from x2 to x3
x2 Is far too low for a small and fast firing turret like swarmer, especially for surge alloy, which is very expensive to make. This is also different from the blast multiplier, which is at x4.
This low multiplier is actively hindering the viability of swarmer, as currently blast compound is the only viable ammunition.
This cosensus has been reach over #balancing on the Mindustry Discord and over issue #1180. Although the surge multiplier was the heat of the discussion the Pyratite multiplier is also too low, considering the multiplier for metaglass on cyclones.