### PR TITLE
Cultivator adjustments (buff)

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -1299,14 +1299,14 @@ public class Blocks implements ContentList{
         cultivator = new Cultivator("cultivator"){{
             requirements(Category.production, with(Items.copper, 25, Items.lead, 25, Items.silicon, 10));
             outputItem = new ItemStack(Items.sporePod, 1);
-            craftTime = 140;
+            craftTime = 80;
             size = 2;
             hasLiquids = true;
             hasPower = true;
             hasItems = true;
 
-            consumes.power(0.9f);
-            consumes.liquid(Liquids.water, 0.2f);
+            consumes.power(1.4f);
+            consumes.liquid(Liquids.water, 0.35f);
         }};
 
         oilExtractor = new Fracker("oil-extractor"){{


### PR DESCRIPTION
Spores are pretty underrated, all the time. And so, this could be the fix for the spore pods to catch up with other items.

This issue has been discussed in issue https://github.com/Anuken/Mindustry-Suggestions/issues/2248. Production time should be decreased to 1.33/s while the water consumption is still proportional to the original one.
The power consumption however is not completely proportional (should be 96/s) but if you compare it to the oil extractors, it still consumes a lot of power. So as a slight buff, 
from 96 units/s to 84 units/s.

Effects: 
It could change the oil industries and schematics, reducing its space consumption (from 7 to 4 cultivators) and power consumption. 
The blast compound will also get a fair buff, the blast mixer ratio to cultivators will lessen (from 2:1 to 1;1)
And lastly, powercubes, but they should be built near a water source, like a hydro generators.