### PR TITLE
File name printing

### DIFF
--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -339,7 +339,11 @@ public class ServerControl implements ApplicationListener{
             if(!maps.all().isEmpty()){
                 info("Maps:");
                 for(Map map : maps.all()){
-                    info("  @: &fi@ / @x@", map.name().replace(' ', '_'), map.custom ? "Custom" : "Default", map.width, map.height);
+                    if(map.custom){
+                        info("  @ (@): &fiCustom / @x@", map.name().replace(' ', '_'), map.file.name(), map.width, map.height);
+                    }else{
+                        info("  @: &fiDefault / @x@", map.name().replace(' ', '_'), map.width, map.height);
+                    }
                 }
             }else{
                 info("No maps found.");


### PR DESCRIPTION
This can be useful if you have a large number of maps, with a different file name on behalf of the map.
![изображение](https://user-images.githubusercontent.com/55407440/114278355-1c629180-9a38-11eb-99df-938f3939bc8e.png)
