### PR TITLE
Added addUpgrade method to Reconstructor to avoid dealing with incompatible Rhino JS Array

### DIFF
--- a/core/src/mindustry/world/blocks/units/Reconstructor.java
+++ b/core/src/mindustry/world/blocks/units/Reconstructor.java
@@ -97,6 +97,10 @@ public class Reconstructor extends UnitBlock{
         super.init();
     }
 
+    public void addUpgrade(UnitType from, UnitType to){
+        upgrades.add(new UnitType[]{from, to});
+    }
+
     public class ReconstructorBuild extends UnitBuild{
 
         public float fraction(){


### PR DESCRIPTION
With this PR, scripts in mods will be able to add unit upgrade plans to reconstructors without wrangling with Rhino JS arrays.

Rhino's `NativeArray` cannot be used like a traditional Java array when adding to a sequence of arrays since it neither extends nor can it be casted as Java's `Array`. The new method addition addresses this by accepting two `UnitType`s instead of an array of them and initializing a Java Array on the spot.

Any scripts that previously had a hacky way of handling this issue will continue to function still.