### PR TITLE
Delete both EasyPlay and Mindurka due to conflicts

### DIFF
--- a/servers_v6.json
+++ b/servers_v6.json
@@ -21,7 +21,7 @@
   },
   {
     "name": "C.A.M.S.",
-    "address": ["routerchain.ddns.net", "nikochio.ddns.net", "easyplay.su"]
+    "address": ["routerchain.ddns.net", "nikochio.ddns.net"]
   },
   {
     "name": "BE6.RUN",
@@ -86,10 +86,6 @@
   {
     "name": "Nydus",
     "address": ["v6.mindustry.nydus.app:6566"]
-  },
-  {
-    "name": "MD Community",
-    "address": ["62.109.31.34", "185.13.47.140:1001"]
   },
   {
     "name": "Mindustry.Party",


### PR DESCRIPTION
**[RUS]**
Из-за конфликтов, которые происходят между Ру и Миндуркой. Я думаю, что единственный способ решить данную проблему - удалить оба сервера из глобального списка.

**[ENG]**
Due to the conflicts that occur between Ru and Mindurka. I think that the only way to solve this problem is to remove both servers from the global list.