### PR TITLE
Make PathCost interface public

### DIFF
--- a/core/src/mindustry/ai/Pathfinder.java
+++ b/core/src/mindustry/ai/Pathfinder.java
@@ -465,7 +465,7 @@ public class Pathfinder implements Runnable{
         protected abstract void getPositions(IntSeq out);
     }
 
-    interface PathCost{
+    public interface PathCost{
         int getCost(Team traversing, int tile);
     }
 


### PR DESCRIPTION
Makes the `PathCost` interface public, allowing Java mods to implement special unit pathfinding priorities.

I have a set of units in a mod that are normally naval, but are amphibious and able to traverse land with a speed penalty. This PR will allow me to path their AI over water unless needing to go over land, similarly to how Spider units prefer to not step over blocks.