### PR TITLE
Make MenuRenderer units use Vars.content rather than hardcoded values

### DIFF
--- a/core/src/mindustry/graphics/MenuRenderer.java
+++ b/core/src/mindustry/graphics/MenuRenderer.java
@@ -30,11 +30,13 @@ public class MenuRenderer implements Disposable{
     private float time = 0f;
     private float flyerRot = 45f;
     private int flyers = Mathf.chance(0.2) ? Mathf.random(35) : Mathf.random(15);
-    private UnitType flyerType = Structs.select(UnitTypes.flare, UnitTypes.flare, UnitTypes.horizon, UnitTypes.mono, UnitTypes.poly, UnitTypes.mega, UnitTypes.zenith);
+    private Seq<UnitType> flyerTypes;
+    private UnitType flyerType;
 
     public MenuRenderer(){
         Time.mark();
         generate();
+        calculateUnit();
         cache();
         Log.debug("Time to generate menu: @", Time.elapsed());
     }
@@ -162,6 +164,16 @@ public class MenuRenderer implements Disposable{
         }
 
         world.endMapLoad();
+    }
+
+    private void calculateUnit(){
+        content.units().each(u -> {
+            if(u.hitSize <= 20 && u.flying && u.region != Core.atlas.find("error")){
+                flyerTypes.add(u);
+            }
+        });
+
+        flyerType = flyerTypes.random();
     }
 
     private void cache(){


### PR DESCRIPTION
Adds a `calculateUnit` function to randomize the units based on Vars.content, hitSize, flying, and whether the region is error.png