### PR TITLE
Convert some editor keys to keybinds

### DIFF
--- a/core/src/mindustry/editor/MapView.java
+++ b/core/src/mindustry/editor/MapView.java
@@ -70,16 +70,16 @@ public class MapView extends Element implements GestureListener{
                     return false;
                 }
 
-                if(!mobile && button != KeyCode.mouseLeft && button != KeyCode.mouseMiddle && button != KeyCode.mouseRight){
+                if(!mobile && button != Core.keybinds.get(Binding.select).key && button != Core.keybinds.get(Binding.pick).key && button != Core.keybinds.get(Binding.break_block).key){
                     return true;
                 }
-                
-                if(button == KeyCode.mouseRight){
+
+                if(button == Core.keybinds.get(Binding.break_block).key){
                     lastTool = tool;
                     tool = EditorTool.eraser;
                 }
 
-                if(button == KeyCode.mouseMiddle){
+                if(button == Core.keybinds.get(Binding.pick).key){
                     lastTool = tool;
                     tool = EditorTool.zoom;
                 }
@@ -105,7 +105,7 @@ public class MapView extends Element implements GestureListener{
 
             @Override
             public void touchUp(InputEvent event, float x, float y, int pointer, KeyCode button){
-                if(!mobile && button != KeyCode.mouseLeft && button != KeyCode.mouseMiddle && button != KeyCode.mouseRight){
+                if(!mobile && button != Core.keybinds.get(Binding.select).key && button != Core.keybinds.get(Binding.pick).key && button != Core.keybinds.get(Binding.break_block).key){
                     return;
                 }
 
@@ -120,7 +120,7 @@ public class MapView extends Element implements GestureListener{
 
                 editor.flushOp();
 
-                if((button == KeyCode.mouseMiddle || button == KeyCode.mouseRight) && lastTool != null){
+                if((button == Core.keybinds.get(Binding.pick).key || button == Core.keybinds.get(Binding.break_block).key) && lastTool != null){
                     tool = lastTool;
                     lastTool = null;
                 }
@@ -198,7 +198,7 @@ public class MapView extends Element implements GestureListener{
 
         if(Core.scene.getScrollFocus() != this) return;
 
-        zoom += Core.input.axis(KeyCode.scroll) / 10f * zoom;
+        zoom += Core.input.axis(Binding.zoom) / 10f * zoom;
         clampZoom();
     }
 


### PR DESCRIPTION
This PR changes some editor keys to their equivalent default keybinds. No keys are changed. Resolves [suggestion #2241](https://github.com/Anuken/Mindustry-Suggestions/issues/2241), resolves [suggestion #2138](https://github.com/Anuken/Mindustry-Suggestions/issues/2138).

* Mouse left → "Select" binding
* Mouse middle → "Pick Block" binding
* Mouse right → "Break Block" binding
* Mouse scroll → "Zoom" binding

I did not want to rock the boat, but since game controls have evolved a little since editor keys were first mapped, I would prefer that editor keys were changed as follows, for consistency with game controls:

* Mouse middle (used for panning) → "Pan" binding (mouse forward)
* L-Shift (used for picking tiles) → "Pick Block" binding (mouse middle)
  * Behavior should be changed so key does not need to be held and combined with left-click to perform the action

If desired, I can amend this PR to make these changes.