### PR TITLE
Actually sync ItemTurret's ammo

### DIFF
--- a/core/src/mindustry/world/blocks/defense/turrets/ItemTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/ItemTurret.java
@@ -165,14 +165,16 @@ public class ItemTurret extends Turret{
         @Override
         public void read(Reads read, byte revision){
             super.read(read, revision);
+            ammo.clear();
+            totalAmmo = 0;
             int amount = read.ub();
             for(int i = 0; i < amount; i++){
                 Item item = Vars.content.item(revision < 2 ? read.ub() : read.s());
                 short a = read.s();
-                totalAmmo += a;
 
                 //only add ammo if this is a valid ammo type
                 if(item != null && ammoTypes.containsKey(item)){
+                    totalAmmo += a;
                     ammo.add(new ItemEntry(item, a));
                 }
             }


### PR DESCRIPTION
Earlier every `blockSyncTime` total ammo was doubled in full turrets producing fake client-side bullets. Now it won't.