### PR TITLE
Make Mod an abstract class

### DIFF
--- a/core/src/mindustry/mod/Mod.java
+++ b/core/src/mindustry/mod/Mod.java
@@ -4,7 +4,7 @@ import arc.files.*;
 import arc.util.*;
 import mindustry.*;
 
-public class Mod{
+public abstract class Mod{
     /** @return the config file for this plugin, as the file 'mods/[plugin-name]/config.json'.*/
     public Fi getConfig(){
         return Vars.mods.getConfig(this);


### PR DESCRIPTION
In theory, there's no point in making an instance of `Mod` without inheritance.