### PR TITLE
Ignore mods icons on server

### DIFF
--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -138,7 +138,7 @@ public class Mods implements Loadable{
 
     private void loadIcon(LoadedMod mod){
         //try to load icon for each mod that can have one
-        if(mod.root.child("icon.png").exists()){
+        if(mod.root.child("icon.png").exists() && !headless){
             try{
                 mod.iconTexture = new Texture(mod.root.child("icon.png"));
                 mod.iconTexture.setFilter(TextureFilter.linear);


### PR DESCRIPTION
This method is used in [mindustry.mod.Mods#importMod](https://github.com/Anuken/Mindustry/blob/7dc3dfd29e286597d80374b64556d27464541310/core/src/mindustry/mod/Mods.java#L80) that can throw an `java.lang.UnsatisfiedLinkError` exception. 
![изображение](https://user-images.githubusercontent.com/55407440/116256607-0402ae80-a77c-11eb-8bf4-83015eee677f.png)

