### PR TITLE
Fix small linecast issue

### DIFF
--- a/core/src/mindustry/entities/Damage.java
+++ b/core/src/mindustry/entities/Damage.java
@@ -266,8 +266,8 @@ public class Damage{
         });
 
         if(tmpBuilding != null && tmpUnit != null){
-            if(Mathf.dst2(x, y, tmpUnit.getX(), tmpUnit.getY()) <= Mathf.dst2(x, y, tmpBuilding.getX(), tmpBuilding.getY())){
-                return tmpUnit;
+            if(Mathf.dst2(x, y, tmpBuilding.getX(), tmpBuilding.getY()) <= Mathf.dst2(x, y, tmpUnit.getX(), tmpUnit.getY())){
+                return tmpBuilding;
             }
         }else if(tmpBuilding != null){
             return tmpBuilding;


### PR DESCRIPTION
With the current code, if unit and building aren't null, and the unit isn't closer than the building, the `return` is skipped, then it'll return unit anyways. The change now checks for building instead of unit since the default return is unit.