### PR TITLE
Fix crash when there's no sectors on planet

### DIFF
--- a/core/src/mindustry/type/Planet.java
+++ b/core/src/mindustry/type/Planet.java
@@ -111,6 +111,9 @@ public class Planet extends UnlockableContent{
     }
 
     public @Nullable Sector getLastSector(){
+        if(sectors.isEmpty()){
+            return null;
+        }
         return sectors.get(Math.min(Core.settings.getInt(name + "-last-sector", startSector), sectors.size - 1));
     }
 


### PR DESCRIPTION
`sectors.size - 1` is `-1` when there's no sectors on planet.
relevant crash log:
```
[E] java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 16
	at arc.struct.Seq.get(Seq.java:451)
	at mindustry.type.Planet.getLastSector(Planet.java:114)
	at mindustry.ui.dialogs.PlanetDialog.show(PlanetDialog.java:185)
        ...
        at mindustry.desktop.DesktopLauncher.main(DesktopLauncher.java:36)
```