### PR TITLE
Logic sensor for unit item/payload timer

### DIFF
--- a/core/src/mindustry/entities/comp/UnitComp.java
+++ b/core/src/mindustry/entities/comp/UnitComp.java
@@ -146,8 +146,8 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
                     controller instanceof FormationAI ? ctrlFormation :
                     0;
             case commanded -> controller instanceof FormationAI && isValid() ? 1 : 0;
-            case itemTimer -> controller instanceof LogicAI && isValid() ? ((LogicAI)controller).itemTimer : 0;
-            case payloadTimer -> controller instanceof LogicAI && isValid() ? ((LogicAI)controller).payTimer : 0;
+            case itemTimer -> controller instanceof LogicAI ai && isValid() ? ai.itemTimer : 0;
+            case payloadTimer -> controller instanceof LogicAI ai && isValid() ? ai.payTimer : 0;
             case payloadCount -> self() instanceof Payloadc pay ? pay.payloads().size : 0;
             case size -> hitSize / tilesize;
             default -> Float.NaN;

--- a/core/src/mindustry/entities/comp/UnitComp.java
+++ b/core/src/mindustry/entities/comp/UnitComp.java
@@ -146,6 +146,8 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
                     controller instanceof FormationAI ? ctrlFormation :
                     0;
             case commanded -> controller instanceof FormationAI && isValid() ? 1 : 0;
+            case itemTimer -> controller instanceof LogicAI && isValid() ? ((LogicAI)controller).itemTimer : 0;
+            case payloadTimer -> controller instanceof LogicAI && isValid() ? ((LogicAI)controller).payloadTimer : 0;
             case payloadCount -> self() instanceof Payloadc pay ? pay.payloads().size : 0;
             case size -> hitSize / tilesize;
             default -> Float.NaN;

--- a/core/src/mindustry/entities/comp/UnitComp.java
+++ b/core/src/mindustry/entities/comp/UnitComp.java
@@ -147,7 +147,7 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
                     0;
             case commanded -> controller instanceof FormationAI && isValid() ? 1 : 0;
             case itemTimer -> controller instanceof LogicAI && isValid() ? ((LogicAI)controller).itemTimer : 0;
-            case payloadTimer -> controller instanceof LogicAI && isValid() ? ((LogicAI)controller).payloadTimer : 0;
+            case payloadTimer -> controller instanceof LogicAI && isValid() ? ((LogicAI)controller).payTimer : 0;
             case payloadCount -> self() instanceof Payloadc pay ? pay.payloads().size : 0;
             case size -> hitSize / tilesize;
             default -> Float.NaN;

--- a/core/src/mindustry/logic/LAccess.java
+++ b/core/src/mindustry/logic/LAccess.java
@@ -41,6 +41,8 @@ public enum LAccess{
     controlled,
     controller,
     commanded,
+    itemTimer,
+    payloadTimer,
     name,
     config,
     payloadCount,


### PR DESCRIPTION
Adds the logic sensor values `@itemTimer` and `@payTimer`, which sense the amount of time until a unit can take or drop items/payloads with logic.
Based on this suggestion I made earlier: [https://github.com/Anuken/Mindustry-Suggestions/issues/2394](https://github.com/Anuken/Mindustry-Suggestions/issues/2394)