### PR TITLE
Allow banned blocks to still be placeable within in game map editor.

### DIFF
--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -588,7 +588,7 @@ public class Block extends UnlockableContent{
     }
 
     public boolean isPlaceable(){
-        return isVisible() && !state.rules.bannedBlocks.contains(this);
+        return isVisible() && (!state.rules.bannedBlocks.contains(this) || state.rules.editor);
     }
 
     /** Called when building of this block begins. */


### PR DESCRIPTION
This makes it so you don't have to pointlessly unban and then re ban blocks while making maps.