### PR TITLE
Power node update time

### DIFF
--- a/core/src/mindustry/world/blocks/power/PowerGraph.java
+++ b/core/src/mindustry/world/blocks/power/PowerGraph.java
@@ -49,7 +49,7 @@ public class PowerGraph{
     }
 
     public float getPowerBalance(){
-        return powerBalance.mean();
+        return powerBalance.rawMean();
     }
 
     public float getLastPowerNeeded(){

--- a/core/src/mindustry/world/blocks/power/PowerGraph.java
+++ b/core/src/mindustry/world/blocks/power/PowerGraph.java
@@ -18,7 +18,7 @@ public class PowerGraph{
     private final Seq<Building> batteries = new Seq<>(false);
     private final Seq<Building> all = new Seq<>(false);
 
-    private final WindowedMean powerBalance = new WindowedMean(60);
+    private final WindowedMean powerBalance = new WindowedMean(15);
     private float lastPowerProduced, lastPowerNeeded, lastPowerStored;
     private float lastScaledPowerIn, lastScaledPowerOut, lastCapacity;
     //diodes workaround for correct energy production info


### PR DESCRIPTION
Power bar (on power nodes) doesn't take a full second to reflect the current state of the power graph. I also reduced the WindowedMean size so that the displayed power is more current (shows the past 0.25s mean rather than the past 1.0s).