### PR TITLE
Smoother boundaries between light sources

### DIFF
--- a/core/src/mindustry/graphics/LightRenderer.java
+++ b/core/src/mindustry/graphics/LightRenderer.java
@@ -183,14 +183,13 @@ public class LightRenderer{
 
         Draw.color();
         buffer.begin(Color.clear);
-        Gl.blendEquationSeparate(Gl.funcAdd, Gl.max);
+        Gl.blendEquationSeparate(Gl.funcAdd, Gl.funcAdd);
 
         for(Runnable run : lights){
             run.run();
         }
         Draw.reset();
         buffer.end();
-        Gl.blendEquationSeparate(Gl.funcAdd, Gl.funcAdd);
 
         Draw.color();
         Shaders.light.ambient.set(state.rules.ambientLight);


### PR DESCRIPTION
Fixes the apparent dark lines between light sources. While the lines aren't actually darker, I think the lack of smoothing between light sources made them stick out.

Before:
https://user-images.githubusercontent.com/83549256/117671817-35657c00-b177-11eb-9fad-c73c92871034.mp4

After:
https://user-images.githubusercontent.com/83549256/117671849-3e564d80-b177-11eb-82ef-c23cd33034ac.mp4
