### PR TITLE
Fixed unit logic controller updating

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -339,6 +339,7 @@ public class LExecutor{
         public static LogicAI checkLogicAI(LExecutor exec, Object unitObj){
             if(unitObj instanceof Unit unit && exec.obj(varUnit) == unit && unit.team == exec.team && !unit.isPlayer() && !(unit.controller() instanceof FormationAI)){
                 if(unit.controller() instanceof LogicAI la){
+                    la.controller = exec.building(varThis);
                     return la;
                 }else{
                     var la = new LogicAI();


### PR DESCRIPTION
Under the current behavior, a unit will not update its highlighted processor until it is no longer logic-controlled, even if it receives new instructions from another processor. With this fix, the highlighted processor will always be one from which it last received instructions. This will also fix the `@controller` sensor value to reflect this change.

Incorrect behavior:
```
ubind @flare
ucontrol approach @thisx @thisy 3 0 0
op sub @counter @counter 1
```
![image](https://user-images.githubusercontent.com/81588289/118159152-4cf46d00-b3e2-11eb-9c83-146608ec7196.png)

With the fixed behavior, the highlighted processor should be the one farthest to the right.