### PR TITLE
Do not reset mineTile of units to null if client

### DIFF
--- a/core/src/mindustry/entities/comp/MinerComp.java
+++ b/core/src/mindustry/entities/comp/MinerComp.java
@@ -62,7 +62,7 @@ abstract class MinerComp implements Itemsc, Posc, Teamc, Rotc, Drawc{
             }
         }
 
-        if(!validMine(mineTile)){
+        if((!net.client() || isLocal()) && !validMine(mineTile)){
             mineTile = null;
             mineTimer = 0f;
         }else if(mining()){


### PR DESCRIPTION
That allows server to put any tile into `mineTile` while client still draws it perfectly fine. Without that, client resets it regardless of server's data.
This way some ~~crazy~~ stuff can be allowed by servers if they want to, like
![Анимация](https://user-images.githubusercontent.com/4199082/118405805-23f20780-b682-11eb-9a52-22a48138a485.gif)
