### PR TITLE
Make CoreItemsDisplay not show up if nothing to show

### DIFF
--- a/core/src/mindustry/ui/CoreItemsDisplay.java
+++ b/core/src/mindustry/ui/CoreItemsDisplay.java
@@ -19,12 +19,15 @@ public class CoreItemsDisplay extends Table{
 
     public void resetUsed(){
         usedItems.clear();
+        background(null);
     }
 
     void rebuild(){
         clear();
-        background(Styles.black6);
-        margin(4);
+        if(usedItems.size > 0){
+            background(Styles.black6);
+            margin(4);
+        }
 
         update(() -> {
             core = Vars.player.team().core();


### PR DESCRIPTION
Fixes this GIANT SQUARE when you start with no loadout.
![image](https://user-images.githubusercontent.com/4199082/118535566-4a33a800-b753-11eb-9b4d-f5b206d66a0a.png)
After:
![image](https://user-images.githubusercontent.com/4199082/118535694-73543880-b753-11eb-9899-479ebd77fb22.png)

Questions:
- should I use also `reset()` for `Table`?
- should I reset margin to 0?
- setting background to `null` is not really intuitive approach but the code chunk is not huge and hey it works