### PR TITLE
Lower surge tower schem priority

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -1124,6 +1124,7 @@ public class Blocks implements ContentList{
             size = 2;
             maxNodes = 2;
             laserRange = 40f;
+            schematicPriority = -15;
         }};
 
         diode = new PowerDiode("diode"){{


### PR DESCRIPTION
The priority of surge towers is now -15 (default for power nodes is -10). Schems with surge towers will often see them automatically connected to random buildings only a couple tiles away which are already in range of other nodes, the hope here is that this fixes that.