### PR TITLE
Delete RCR server

### DIFF
--- a/servers_v6.json
+++ b/servers_v6.json
@@ -1,9 +1,5 @@
 [
   {
-    "name": "RCR",
-    "address": ["rcr.fvds.ru"]
-  },
-  {
     "name": "SMokeOfAnarchy.duckdns.org",
     "address": ["smokeofanarchy.duckdns.org:6853"]
   },


### PR DESCRIPTION
RCR is a bad, poorly configured server. Without administration. The owner of the server does not care about the server.Their server is full of violators who are not banned, which proves that there is no administration.
![unknown-1](https://user-images.githubusercontent.com/76648940/119024988-59f9f900-b9ac-11eb-83f8-7020bcce4125.png)
![unknown](https://cdn.discordapp.com/attachments/815595438215266354/844997067415617606/Screenshot_2021-05-20-23-08-13-959_com.discord.jpg)
![unknown-2](https://cdn.discordapp.com/attachments/815595438215266354/844997783655546940/unknown.png)