### PR TITLE
Remote Menu with callback via MenuOptionChooseEvent

### DIFF
--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -347,7 +347,22 @@ public class NetClient implements ApplicationListener{
     public static void infoMessage(String message){
         if(message == null) return;
 
-        ui.showText("", message);
+        ui.showText("", message, (option) -> Call.menuChoose(player, option));
+    }
+
+    @Remote(variants = Variant.both)
+    public static void infoMessage(String title, String message){
+        if(title == null && message == null) return;
+        if(title == null) title = "";
+
+        ui.showText(title, message, (option) -> Call.menuChoose(player, option));
+    }
+
+    @Remote(variants = Variant.both)
+    public static void menu(String title, String message, String[][] options){
+        if(title == null) title = "";
+
+        ui.showMenu(title, message, options, (option) -> Call.menuChoose(player, option));
     }
 
     @Remote(variants = Variant.both)

--- a/core/src/mindustry/core/UI.java
+++ b/core/src/mindustry/core/UI.java
@@ -425,18 +425,60 @@ public class UI implements ApplicationListener, Loadable{
     }
 
     public void showText(String titleText, String text){
-        showText(titleText, text, Align.center);
+        showText(titleText, text, (i) -> {});
+    }
+
+    public void showText(String titleText, String text, Cons<Integer> callback){
+        showText(titleText, text, Align.center, callback);
     }
 
     public void showText(String titleText, String text, int align){
+        showText(titleText, text, align, (i) -> {});
+    }
+
+    public void showText(String titleText, String text, int align, Cons<Integer> callback){
         new Dialog(titleText){{
             cont.row();
             cont.image().width(400f).pad(2).colspan(2).height(4f).color(Pal.accent);
             cont.row();
             cont.add(text).width(400f).wrap().get().setAlignment(align, align);
             cont.row();
-            buttons.button("@ok", this::hide).size(110, 50).pad(4);
-            closeOnBack();
+            buttons.button("@ok", () -> {
+                callback.get(0);
+                hide();
+            }).size(110, 50).pad(4);
+            closeOnBack(() -> callback.get(-1));
+        }}.show();
+    }
+
+    public void showMenu(String title, String message, String[][] options, Cons<Integer> callback){
+        new Dialog(title){{
+            cont.row();
+            cont.image().width(400f).pad(2).colspan(2).height(4f).color(Pal.accent);
+            cont.row();
+            cont.add(message).width(400f).wrap().get().setAlignment(Align.center);
+            cont.row();
+
+            int option = 0;
+            for(String[] optionsRow : options){
+                Table buttonRow = buttons.row().table().get().row();
+                int fullWidth = 400 - (optionsRow.length - 1) * 8; // adjust to count padding as well
+                int width = fullWidth / optionsRow.length;
+                int lastWidth = fullWidth - width * (optionsRow.length - 1); // take the rest of space for uneven table
+
+                for(int i = 0; i < optionsRow.length; i++){
+                    if(optionsRow[i] == null) continue;
+
+                    String optionName = optionsRow[i];
+                    int finalOption = option;
+                    buttonRow.button(optionName, () -> {
+                        callback.get(finalOption);
+                        hide();
+                    }).size(i == optionsRow.length - 1 ? lastWidth : width, 50).pad(4);
+                    option++;
+                }
+            }
+            closeOnBack(() -> callback.get(-1));
         }}.show();
     }
 

--- a/core/src/mindustry/game/EventType.java
+++ b/core/src/mindustry/game/EventType.java
@@ -206,6 +206,17 @@ public class EventType{
         }
     }
 
+    /** Called when a player chooses an option in menu. */
+    public static class MenuOptionChooseEvent{
+        public final Player player;
+        public final int option;
+
+        public MenuOptionChooseEvent(Player player, int option){
+            this.option = option;
+            this.player = player;
+        }
+    }
+
     public static class PickupEvent{
         public final Unit carrier;
         public final @Nullable Unit unit;

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -331,6 +331,11 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         Events.fire(new TapEvent(player, tile));
     }
 
+    @Remote(targets = Loc.both, called = Loc.both)
+    public static void menuChoose(@Nullable Player player, int option){
+        Events.fire(new MenuOptionChooseEvent(player, option));
+    }
+
     @Remote(targets = Loc.both, called = Loc.both, forward = true)
     public static void unitControl(Player player, @Nullable Unit unit){
         if(player == null) return;

--- a/core/src/mindustry/io/TypeIO.java
+++ b/core/src/mindustry/io/TypeIO.java
@@ -95,6 +95,9 @@ public class TypeIO{
         }else if(object instanceof BuildingBox b){
             write.b(12);
             write.i(b.pos);
+        }else if(object instanceof String[][] strings){
+            write.b(16);
+            writeStrings(write, strings);
         }else{
             throw new IllegalArgumentException("Unknown object type: " + object.getClass());
         }
@@ -126,6 +129,7 @@ public class TypeIO{
             case 13: return LAccess.all[read.s()];
             case 14: int blen = read.i(); byte[] bytes = new byte[blen]; read.b(bytes); return bytes;
             case 15: return UnitCommand.all[read.b()];
+            case 16: return readStrings(read);
             default: throw new IllegalArgumentException("Unknown object type: " + type);
         }
     }
@@ -605,6 +609,35 @@ public class TypeIO{
             byte[] bytes = new byte[slength];
             buffer.readFully(bytes);
             return new String(bytes, charset);
+        }else{
+            return null;
+        }
+    }
+
+    public static void writeStrings(Writes write, String[][] strings){
+        write.b(strings.length);
+        for(int i = 0; i < strings.length; i++){
+            write.b(strings[i].length);
+            for(int j = 0; j < strings[i].length; j++){
+                writeString(write, strings[i][j]);
+            }
+        }
+    }
+
+    public static String[][] readStrings(Reads read){
+        byte rows = read.b();
+        if(rows != -1){
+            String[][] strings = new String[rows][];
+            for(byte i = 0; i < rows; i++){
+                byte columns = read.b();
+                if(columns != -1){
+                    strings[i] = new String[columns];
+                    for(byte j = 0; j < columns; j++){
+                        strings[i][j] = readString(read);
+                    }
+                }
+            }
+            return strings;
         }else{
             return null;
         }


### PR DESCRIPTION
Please note https://github.com/Anuken/Arc/pull/62 is required for this to build.
This PR provides several things:
- Ability to get feedback from client's button presses for current `Call.infoMessage` from server, including "back/esc"
- Ability to create new menu on client from server, with feedback
- Allows to use `Call.infoMessage` with `title`

### Motivation
- Better UI for choosing, voting, answering online.
- I hate typing on mobile and I suspect some players don't even bother voting to kick griefer if they are from mobile because it takes typing out `/vote y` instead of 1 tap on screen.
- I have no idea if user *really* spent time reading my welcome screen or he is just standing afk

### Here is how it looks

General idea of menu with feedback:
![menu_1](https://user-images.githubusercontent.com/4199082/119188748-c72c8d80-ba83-11eb-94b7-b2ce5873c364.gif)

Test with different layout width:
![image](https://user-images.githubusercontent.com/4199082/119188806-de6b7b00-ba83-11eb-880e-db90e9d3ed8d.png)
