### PR TITLE
Fix an unintended kick of all clients

### DIFF
--- a/core/src/mindustry/world/Tile.java
+++ b/core/src/mindustry/world/Tile.java
@@ -628,6 +628,7 @@ public class Tile implements Position, QuadTreeObject, Displayable{
 
     @Remote(called = Loc.server)
     public static void setTile(Tile tile, Block block, Team team, int rotation){
+        if(tile == null) return;
         tile.setBlock(block, team, rotation);
     }
 


### PR DESCRIPTION
This almost never happens but since the flood uses this method extensively, everyone gets disconnected every hour or so so I fixed it myself. As you can see the rest of the lobby gets kicked.

![](https://i-dont.go-outsi.de/d2V1Mq.png) ![](https://vexera.is-ne.at/kE6hl7.png)