### PR TITLE
Add spawn function for using `Posc`

### DIFF
--- a/core/src/mindustry/type/UnitType.java
+++ b/core/src/mindustry/type/UnitType.java
@@ -145,6 +145,14 @@ public class UnitType extends UnlockableContent{
         return spawn(state.rules.defaultTeam, x, y);
     }
 
+    public Unit spawn(Team team, Position pos){
+        return spawn(team, pos.getX(), pos.getY());
+    }
+
+    public Unit spawn(Position pos){
+        return spawn(state.rules.defaultTeam, pos);
+    }
+
     public boolean hasWeapons(){
         return weapons.size > 0;
     }


### PR DESCRIPTION
Allows you to spawn a unit at the location of any `Posc`, meaning you can spawn a unit at `Vars.player`, rather than `Vars.player.x, Vars.player.y`. This is particularly useful to cut down on the amount of typing it takes to spawn a unit via console, which is done a lot in modding.