### PR TITLE
Healing Status Effect Stat

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -737,6 +737,7 @@ stat.speedmultiplier = Speed Multiplier
 stat.reloadmultiplier = Reload Multiplier
 stat.buildspeedmultiplier = Build Speed Multiplier
 stat.reactive = Reacts
+stat.healing = Healing
 
 ability.forcefield = Force Field
 ability.repairfield = Repair Field

--- a/core/src/mindustry/type/StatusEffect.java
+++ b/core/src/mindustry/type/StatusEffect.java
@@ -76,6 +76,7 @@ public class StatusEffect extends UnlockableContent{
         if(reloadMultiplier != 1) stats.addPercent(Stat.reloadMultiplier, reloadMultiplier);
         if(buildSpeedMultiplier != 1) stats.addPercent(Stat.buildSpeedMultiplier, buildSpeedMultiplier);
         if(damage > 0) stats.add(Stat.damage, damage * 60f, StatUnit.perSecond);
+        if(damage < 0) stats.add(Stat.healing, -(damage * 60f), StatUnit.perSecond);
 
         boolean reacts = false;
 

--- a/core/src/mindustry/world/meta/Stat.java
+++ b/core/src/mindustry/world/meta/Stat.java
@@ -40,6 +40,7 @@ public enum Stat{
     reloadMultiplier,
     buildSpeedMultiplier,
     reactive,
+    healing,
 
     itemCapacity(StatCat.items),
     itemsMoved(StatCat.items),


### PR DESCRIPTION
When damage < 0, add a healing stat
Not used in main game, but clears up confusion about healing status effects (exotic mod)