### PR TITLE
Cultivator buff v2

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -1322,7 +1322,7 @@ public class Blocks implements ContentList{
         cultivator = new AttributeCrafter("cultivator"){{
             requirements(Category.production, with(Items.copper, 25, Items.lead, 25, Items.silicon, 10));
             outputItem = new ItemStack(Items.sporePod, 1);
-            craftTime = 100;
+            craftTime = 80;
             size = 2;
             hasLiquids = true;
             hasPower = true;
@@ -1336,8 +1336,8 @@ public class Blocks implements ContentList{
             drawer = new DrawCultivator();
             maxBoost = 2f;
 
-            consumes.power(80f / 60f);
-            consumes.liquid(Liquids.water, 20f / 60f);
+            consumes.power(90f / 60f);
+            consumes.liquid(Liquids.water, 18f / 60f);
         }};
 
         oilExtractor = new Fracker("oil-extractor"){{


### PR DESCRIPTION
Cultivators are actually nerfed in the new update (v21142) because of it's new production time that doesn't really align with the past setup. 

To summarize:
V6 cultivators use:

- 28 water / spore pod 
- 126 power / spore pod

But BE21142 cultivators use: 

- 33.2 water/s (nerfed) 
- 132.8 power/s (nerfed) 

But with my proposed setup (shown in the code), 

- 24 water/spore pod (buffed) 
- 120 power/spore pod (buffed) 

Those are just **minor** effects, the **major** one was the space covered to make **3 spore pod/s** (watex included in the area calculation) 

- Original: 84 square meters
- Updated: 88 square meters (nerfed) 
- Proposed: 64 square meters (significantly buffed) 

That's a significant boost in terms of compact schematic building, makes blast compound easier and affordable to produce at all lands. 

(Note: I'm PickAPlayerFirst, the one who suggested the cultivator buff, I just changed my account)