### PR TITLE
Instruction address display

### DIFF
--- a/core/src/mindustry/logic/LCanvas.java
+++ b/core/src/mindustry/logic/LCanvas.java
@@ -217,6 +217,8 @@ public class LCanvas extends Table{
 
                 e.setSize(width, e.getPrefHeight());
                 e.setPosition(0, height - cy, Align.topLeft);
+                
+                if(e instanceof StatementElem se) se.address = i;
 
                 cy += e.getPrefHeight() + space;
                 seq.add(e);
@@ -316,6 +318,7 @@ public class LCanvas extends Table{
 
     public class StatementElem extends Table{
         public LStatement st;
+        public int address = 0;
 
         public StatementElem(LStatement st){
             this.st = st;
@@ -335,6 +338,8 @@ public class LCanvas extends Table{
 
                 t.add(st.name()).style(Styles.outlineLabel).color(color).padRight(8);
                 t.add().growX();
+
+                t.label(() -> address + "").name("address").style(Styles.outlineLabel).color(color).padRight(8);
 
                 t.button(Icon.copy, Styles.logici, () -> {
                 }).size(24f).padRight(6).get().tapped(this::copy);

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -708,7 +708,7 @@ public class LStatements{
 
         public transient StatementElem dest;
 
-        public int destIndex;
+        public int destIndex = -1;
 
         public ConditionOp op = ConditionOp.notEqual;
         public String value = "x", compare = "false";
@@ -739,6 +739,10 @@ public class LStatements{
             }, Styles.logict, () -> {}).size(op == ConditionOp.always ? 80f : 48f, 40f).pad(4f).color(table.color);
 
             if(op != ConditionOp.always) field(table, compare, str -> compare = str);
+
+            row(table);
+
+            table.label(() -> " go to " + ((dest != null) ? dest.address:destIndex));
         }
 
         //elements need separate conversion logic

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -742,7 +742,7 @@ public class LStatements{
 
             row(table);
 
-            table.label(() -> " go to " + ((dest != null) ? dest.address:destIndex));
+            table.label(() -> " go to " + ((dest != null) ? dest.address:-1));
         }
 
         //elements need separate conversion logic

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -742,7 +742,7 @@ public class LStatements{
 
             row(table);
 
-            table.label(() -> " go to " + ((dest != null) ? dest.address:-1));
+            table.label(() -> " jump to " + ((dest != null) ? dest.address:-1));
         }
 
         //elements need separate conversion logic


### PR DESCRIPTION
Add an address label by the side of copy button.
Add target address label for JumpI.
Mentioned in this [feature request](https://github.com/Anuken/Mindustry-Suggestions/issues/2470)

![address display 2](https://user-images.githubusercontent.com/65377021/120804630-79ca1900-c577-11eb-9656-a7c79d707b43.gif)
![address display 1](https://user-images.githubusercontent.com/65377021/120804639-7d5da000-c577-11eb-81a4-91ae2174164a.gif)
