### PR TITLE
Just a Few Small Changes to Status Effect Stat Displays

### DIFF
--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -401,9 +401,14 @@ public class BulletType extends Content implements Cloneable{
             //pierceBuilding is not enabled by default, because a bullet may want to *not* pierce buildings
         }
 
-        if(lightningType == null && lightning > 0){
-            status = status == StatusEffects.none ? StatusEffects.shocked : status;
-            lightningType = !collidesAir ? Bullets.damageLightningGround : Bullets.damageLightning;
+        if(lightning > 0){
+            if(status == StatusEffects.none){
+                status = StatusEffects.shocked;
+            }
+
+            if(lightningType == null){
+                lightningType = !collidesAir ? Bullets.damageLightningGround : Bullets.damageLightning;
+            }
         }
     }
 

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -401,7 +401,8 @@ public class BulletType extends Content implements Cloneable{
             //pierceBuilding is not enabled by default, because a bullet may want to *not* pierce buildings
         }
 
-        if(lightningType == null){
+        if(lightningType == null && lightning > 0){
+            status = status == StatusEffects.none ? StatusEffects.shocked : status;
             lightningType = !collidesAir ? Bullets.damageLightningGround : Bullets.damageLightning;
         }
     }

--- a/core/src/mindustry/world/meta/StatValues.java
+++ b/core/src/mindustry/world/meta/StatValues.java
@@ -270,10 +270,6 @@ public class StatValues{
                         sep(bt, "@bullet.incendiary");
                     }
 
-                    if(type.status != StatusEffects.none){
-                        sep(bt, (type.minfo.mod == null ? type.status.emoji() : "") + "[stat]" + type.status.localizedName);
-                    }
-
                     if(type.homingPower > 0.01f){
                         sep(bt, "@bullet.homing");
                     }
@@ -284,6 +280,10 @@ public class StatValues{
 
                     if(type.fragBullet != null){
                         sep(bt, "@bullet.frag");
+                    }
+
+                    if(type.status != StatusEffects.none){
+                        sep(bt, (type.minfo.mod == null ? type.status.emoji() : "") + "[stat]" + type.status.localizedName);
                     }
                 }).padTop(unit ? 0 : -9).left().get().background(unit ? null : Tex.underline);
 


### PR DESCRIPTION
1. Moved the Status Effect emoji for bullets to the end. 
Why? Because this: 
![Cleaner](https://user-images.githubusercontent.com/68400583/120876031-61e89a00-c563-11eb-82ab-975dffb74919.jpg)
Looks cleaner than this: 
![Less Clean](https://user-images.githubusercontent.com/68400583/120876059-83498600-c563-11eb-8ee3-0ab17e589e08.jpg)

2. All bullets with lightning automatically have the Shocked Status Effect (Unless they already have another one)
Because all lightning applies Shocked anyways, so why not display that stat in the bullet?
![Shocked](https://user-images.githubusercontent.com/68400583/120876121-d3c0e380-c563-11eb-9b21-ab5a5b8b44e8.jpg)
