### PR TITLE
update link to jdk in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See [CONTRIBUTING](CONTRIBUTING.md).
 Bleeding-edge builds are generated automatically for every commit. You can see them [here](https://github.com/Anuken/MindustryBuilds/releases).
 
 If you'd rather compile on your own, follow these instructions.
-First, make sure you have [JDK 14](https://adoptopenjdk.net/) installed. **Other JDK versions will not work.** Open a terminal in the Mindustry directory and run the following commands:
+First, make sure you have [JDK 14](https://adoptopenjdk.net/archive.html?variant=openjdk14&jvmVariant=hotspot) installed. **Other JDK versions will not work.** Open a terminal in the Mindustry directory and run the following commands:
 
 ### Windows
 


### PR DESCRIPTION
I'm not sure if I'm just stupid, but according to the "Other JDK versions will not work." message and the fact that I couldn't get mindustry to compile with the linked JDK 16, I thought I'd update the link to a JDK version you're actually meant to use.

If this is really stupid for a reason I don't know, don't hesitate to tell me.