### PR TITLE
chat prefix/suffix prototype

### DIFF
--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -160,11 +160,24 @@ public class NetClient implements ApplicationListener{
         clientPacketReliable(type, contents);
     }
 
-    //called on all clients
+    @Deprecated
     @Remote(targets = Loc.server, variants = Variant.both)
     public static void sendMessage(String message, String sender, Player playersender){
         if(Vars.ui != null){
             Vars.ui.chatfrag.addMessage(message, sender);
+        }
+
+        if(playersender != null){
+            playersender.lastText(message);
+            playersender.textFadeTime(1f);
+        }
+    }
+
+    //called on all clients
+    @Remote(targets = Loc.server, variants = Variant.both)
+    public static void sendMessage(String prefix, String sender, String suffix, String message, Player playersender){
+        if(Vars.ui != null){
+            Vars.ui.chatfrag.addMessage(prefix, sender, suffix, message);
         }
 
         if(playersender != null){
@@ -219,7 +232,7 @@ public class NetClient implements ApplicationListener{
 
             //invoke event for all clients but also locally
             //this is required so other clients get the correct name even if they don't know who's sending it yet
-            Call.sendMessage(message, colorizeName(player.id(), player.name), player);
+            Call.sendMessage(Config.chatPrefix.string(), colorizeName(player.id(), player.name), Config.chatSuffix.string(), message, player);
         }else{
 
             //a command was sent, now get the output

--- a/core/src/mindustry/net/Administration.java
+++ b/core/src/mindustry/net/Administration.java
@@ -479,7 +479,9 @@ public class Administration{
         autosave("Whether the periodically save the map when playing.", false),
         autosaveAmount("The maximum amount of autosaves. Older ones get replaced.", 10),
         autosaveSpacing("Spacing between autosaves in seconds.", 60 * 5),
-        debug("Enable debug logging", false, () -> Log.level = debug() ? LogLevel.debug : LogLevel.info);
+        debug("Enable debug logging", false, () -> Log.level = debug() ? LogLevel.debug : LogLevel.info),
+        chatPrefix("Goes before the name of the chatting player.", "[coral][["),
+        chatSuffix("Goes behind the name of the chatting player.", "[coral]]:[white] ");
 
         public static final Config[] all = values();
 

--- a/core/src/mindustry/ui/fragments/ChatFragment.java
+++ b/core/src/mindustry/ui/fragments/ChatFragment.java
@@ -256,28 +256,37 @@ public class ChatFragment extends Table{
         return shown;
     }
 
+    @Deprecated
     public void addMessage(String message, String sender){
+        addMessage("[coral][[", sender, "[coral]]:[white] ", message);
+    }
+
+    public void addMessage(String prefix, String sender, String suffix, String message){
         if(sender == null && message == null) return;
-        messages.insert(0, new ChatMessage(message, sender));
+        messages.insert(0, new ChatMessage(prefix, sender, suffix, message));
 
         fadetime += 1f;
         fadetime = Math.min(fadetime, messagesShown) + 1f;
-        
+
         if(scrollPos > 0) scrollPos++;
     }
 
     private static class ChatMessage{
+        public final String prefix;
         public final String sender;
+        public final String suffix;
         public final String message;
         public final String formattedMessage;
 
-        public ChatMessage(String message, String sender){
-            this.message = message;
+        public ChatMessage(String prefix, String sender, String suffix, String message){
+            this.prefix = prefix;
             this.sender = sender;
+            this.suffix = suffix;
+            this.message = message;
             if(sender == null){ //no sender, this is a server message?
                 formattedMessage = message == null ? "" : message;
             }else{
-                formattedMessage = "[coral][[" + sender + "[coral]]:[white] " + message;
+                formattedMessage = prefix + sender + suffix + message;
             }
         }
     }


### PR DESCRIPTION
throughout versions 5.0 and 6.0 my nydus server(s) have used a custom chat format, but their implementation is imperfect:

in v5 we used `Call.sendMessage(message, null, null);`
this has as a side effect that the chat message does not appear above the name of the player

in v6 we used `Call.sendMessage(message, null, player);`
this has as a side effect the entire message is duplicated above the player:

![photo_2021-06-06 19 05 58](https://user-images.githubusercontent.com/3179271/120933395-4794f480-c6fa-11eb-8458-4ed54bc8b8c4.jpeg)

ideally there should be a way to introduce a mechanic to allow for a prefix/suffix/format without duplicate text.

in this prototype i have added a configurable prefix & suffix that currently gets sent with each chat call.
(server sided and not client sided, to allow for per player/message chat formatting, fairly important)

<img width="517" alt="Screen Shot 2021-06-06 at 18 57 43" src="https://user-images.githubusercontent.com/3179271/120933666-647df780-c6fb-11eb-8260-5df89605b374.png">

![Screen Shot 2021-06-06 at 18 56 49](https://user-images.githubusercontent.com/3179271/120933664-634cca80-c6fb-11eb-88ae-44d7a163e891.png)

now this is far from perfect, i don't like the code i wrote for this _that_ much, and it feels like i am over complicating it.

for mods & plugins i have kept in some deprecated backwards compatibility, but that is currently not very ideal:
(not to mention the default is now duplicate, and while typing this i found `Config.<key>.defaultValue`)

<img width="1380" alt="Screen Shot 2021-06-06 at 19 11 56" src="https://user-images.githubusercontent.com/3179271/120933601-1ec12f00-c6fb-11eb-8e2d-1a8722891d18.png">

for now i'll be leaving this here as a draft to gather some reactions & suggestions while i think about what i'll end up doing 🤔 
