### PR TITLE
Allow weapons on Miner units to function.

### DIFF
--- a/core/src/mindustry/ai/types/MinerAI.java
+++ b/core/src/mindustry/ai/types/MinerAI.java
@@ -75,8 +75,4 @@ public class MinerAI extends AIController{
             circle(core, unit.type.range / 1.8f);
         }
     }
-
-    @Override
-    protected void updateTargeting(){
-    }
 }


### PR DESCRIPTION
`target` shouldn't affect anything because it is unused in `updateMovement()`