### PR TITLE
Fix ammo multiplier exception in itemturret

### DIFF
--- a/core/src/mindustry/world/blocks/defense/turrets/ItemTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/ItemTurret.java
@@ -136,6 +136,7 @@ public class ItemTurret extends Turret{
             }
 
             BulletType type = ammoTypes.get(item);
+            if(type == null) return;
             totalAmmo += type.ammoMultiplier;
 
             //find ammo entry by type


### PR DESCRIPTION
not really a vanilla issue, but on my bleeding edge server i randomly use `handleStack` on blocks that have a non-null `ItemModule` without checking `acceptStack` prior, i know & understand that its the order things should be done in, but for the `handleItem` method to completely crash if the item is not linked to any ammo seems a bit an excessive of a reaction:

<img width="808" alt="Screen Shot 2021-06-22 at 18 35 39" src="https://user-images.githubusercontent.com/3179271/122965915-06067980-d389-11eb-8205-f744a80adb07.png">

(i don't mind what you end up doing with it, since i have this in the server's fork now anyways, just sharing my findings :3)