### PR TITLE
Conveyor Upgrade End Rotation

### DIFF
--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1242,12 +1242,14 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
             diagonal = !diagonal;
         }
 
+        int endRotation = -1;
         if(diagonal){
             var start = world.build(startX, startY);
             var end = world.build(endX, endY);
             if(block != null && start instanceof ChainedBuilding && end instanceof ChainedBuilding
                     && block.canReplace(end.block) && block.canReplace(start.block)){
                 points = Placement.upgradeLine(startX, startY, endX, endY);
+                endRotation = end.rotation;
             }else{
                 points = Placement.pathfindLine(block != null && block.conveyorPlacement, startX, startY, endX, endY);
             }
@@ -1281,6 +1283,8 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
                 int result = baseRotation;
                 if(next != null){
                     result = Tile.relativeTo(point.x, point.y, next.x, next.y);
+                }else if(endRotation != -1){
+                    result = endRotation;
                 }else if(block.conveyorPlacement && i > 0){
                     Point2 prev = points.get(i - 1);
                     result = Tile.relativeTo(prev.x, prev.y, point.x, point.y);


### PR DESCRIPTION
Currently, upgrading conveyors does not preserve the last conveyor's direction.

Before
<img src="https://user-images.githubusercontent.com/8357916/123906997-0b843680-d92a-11eb-9a4e-a5ea9964834d.gif" width="300">

After
<img src="https://user-images.githubusercontent.com/8357916/123907002-0cb56380-d92a-11eb-8e6c-f017e02e1a4a.gif" width="300">