### PR TITLE
outlaw separator desycning

### DIFF
--- a/core/src/mindustry/world/blocks/production/Separator.java
+++ b/core/src/mindustry/world/blocks/production/Separator.java
@@ -46,7 +46,12 @@ public class Separator extends Block{
         public float progress;
         public float totalProgress;
         public float warmup;
-        public int seed = Mathf.random(0, Integer.MAX_VALUE - 1);
+        public int seed;
+
+        @Override
+        public void created(){
+            seed = Mathf.randomSeed(tile.pos(), 0, Integer.MAX_VALUE - 1);
+        }
 
         @Override
         public boolean shouldAmbientSound(){

--- a/core/src/mindustry/world/blocks/production/Separator.java
+++ b/core/src/mindustry/world/blocks/production/Separator.java
@@ -45,6 +45,7 @@ public class Separator extends Block{
         public float progress;
         public float totalProgress;
         public float warmup;
+        public int seed = Mathf.random(0, Integer.MAX_VALUE - 1);
 
         @Override
         public boolean shouldAmbientSound(){
@@ -91,7 +92,7 @@ public class Separator extends Block{
                 int sum = 0;
                 for(ItemStack stack : results) sum += stack.amount;
 
-                int i = Mathf.random(sum);
+                int i = Mathf.randomSeed(seed++, 0, sum);
                 int count = 0;
                 Item item = null;
 
@@ -122,10 +123,16 @@ public class Separator extends Block{
         }
 
         @Override
+        public byte version(){
+            return 1;
+        }
+
+        @Override
         public void write(Writes write){
             super.write(write);
             write.f(progress);
             write.f(warmup);
+            write.i(seed);
         }
 
         @Override
@@ -133,6 +140,7 @@ public class Separator extends Block{
             super.read(read, revision);
             progress = read.f();
             warmup = read.f();
+            if(revision == 1) seed = read.i();
         }
     }
 }

--- a/core/src/mindustry/world/blocks/production/Separator.java
+++ b/core/src/mindustry/world/blocks/production/Separator.java
@@ -30,6 +30,7 @@ public class Separator extends Block{
         solid = true;
         hasItems = true;
         hasLiquids = true;
+        sync = true;
     }
 
     @Override


### PR DESCRIPTION
an attempt to solve the age old problem of separators desyncing so hard that each time it happens a child in africa dies:

![Screen Shot 2021-06-30 at 17 44 35](https://user-images.githubusercontent.com/3179271/123991676-35da0080-d9cb-11eb-8703-f4fcce39095a.png)

(having the `0` be `MIN_VALUE` causes issues, as well as not `- 1` ing the `MAX_VALUE`, but for the seed itself its seems fine)