### PR TITLE
Spore Rebalance

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -1306,7 +1306,7 @@ public class Blocks implements ContentList{
         cultivator = new AttributeCrafter("cultivator"){{
             requirements(Category.production, with(Items.copper, 25, Items.lead, 25, Items.silicon, 10));
             outputItem = new ItemStack(Items.sporePod, 1);
-            craftTime = 100;
+            craftTime = 80;
             size = 2;
             hasLiquids = true;
             hasPower = true;
@@ -1320,8 +1320,8 @@ public class Blocks implements ContentList{
             drawer = new DrawCultivator();
             maxBoost = 2f;
 
-            consumes.power(80f / 60f);
-            consumes.liquid(Liquids.water, 20f / 60f);
+            consumes.power(85f / 60f);
+            consumes.liquid(Liquids.water, 24f / 60f);
         }};
 
         oilExtractor = new Fracker("oil-extractor"){{

--- a/core/src/mindustry/content/Items.java
+++ b/core/src/mindustry/content/Items.java
@@ -79,7 +79,7 @@ public class Items implements ContentList{
         }};
 
         sporePod = new Item("spore-pod", Color.valueOf("7457ce")){{
-            flammability = 1.15f;
+            flammability = 0.9f;
         }};
 
         blastCompound = new Item("blast-compound", Color.valueOf("ff795e")){{


### PR DESCRIPTION
So the current state of spore tech became worse since the initial PR was released. 

The water to spore pod ratio rigged it's production since it takes more water to produce a spore pod. 

The only way to regain the buff back is to change the values to the original ones proposed in #5088,  but with an extra change; flammability. 

If we change the flammability to 90% (100% is already good, but feels similar to coal) it should affect the power production of steam generators and can (possibly) remove the existence of direct spore pod - steam generator powercubes. 

Speaking of powercubes, adding the extra commit to Items.java is considered unnecessary since it won't bring back land powercubes, but will possibly nerf the water limited powercubes. 