### PR TITLE
Server qol

### DIFF
--- a/core/assets/contributors
+++ b/core/assets/contributors
@@ -126,3 +126,4 @@ Skat
 WilloIzCitron
 SAMBUYYA
 genNAowl
+TranquillyUnpleasant

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -344,14 +344,17 @@ public class ServerControl implements ApplicationListener{
             }
         });
 
-        handler.register("maps", "Display all available maps.", arg -> {
+        handler.register("maps", "[all] [full]", "Display available maps. 'all' to include default maps. 'full' to show full map names.", arg -> {
+            boolean all = Arrays.asList(arg).contains("all");
+            boolean full = Arrays.asList(arg).contains("full");
             if(!maps.all().isEmpty()){
                 info("Maps:");
-                for(Map map : maps.all()){
+                for(Map map : all ? maps.all() : maps.customMaps()){
+                    String mapName = (full ? map.name() : Strings.stripColors(map.name())).replace(' ', '_');
                     if(map.custom){
-                        info("  @ (@): &fiCustom / @x@", map.name().replace(' ', '_'), map.file.name(), map.width, map.height);
+                        info("  @ (@): &fiCustom / @x@", mapName, map.file.name(), map.width, map.height);
                     }else{
-                        info("  @: &fiDefault / @x@", map.name().replace(' ', '_'), map.width, map.height);
+                        info("  @: &fiDefault / @x@", mapName, map.width, map.height);
                     }
                 }
             }else{

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -259,7 +259,16 @@ public class ServerControl implements ApplicationListener{
     }
 
     protected void registerCommands(){
-        handler.register("help", "Displays this command list.", arg -> {
+        handler.register("help", "[command]", "Displays this command list.", arg -> {
+            if (arg.length > 0){
+                Command command = handler.getCommandList().find(c -> c.text.equalsIgnoreCase(arg[0]));
+                if (command == null) err("Command " + arg[0] + " not found!");
+                else {
+                    info(command.text + ":");
+                    info("  &b&lb " + command.text + (command.paramText.isEmpty() ? "" : " &lc&fi") + command.paramText + "&fr - &lw" + command.description);
+                }
+                return;
+            }
             info("Commands:");
             for(Command command : handler.getCommandList()){
                 info("  &b&lb " + command.text + (command.paramText.isEmpty() ? "" : " &lc&fi") + command.paramText + "&fr - &lw" + command.description);

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -345,9 +345,8 @@ public class ServerControl implements ApplicationListener{
             }
         });
 
-        handler.register("maps", "[all] [full]", "Display available maps. 'all' to include default maps. 'full' to show full map names.", arg -> {
-            boolean all = Arrays.asList(arg).contains("all");
-            boolean full = Arrays.asList(arg).contains("full");
+        handler.register("maps", "[all]", "Display available maps. 'all' to include default maps.", arg -> {
+            boolean all = arg.length > 0 && arg[0].equalsIgnoreCase("all");
             if(!maps.all().isEmpty()){
                 info("Maps:");
                 for(Map map : all ? maps.all() : maps.customMaps()){

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -260,19 +260,19 @@ public class ServerControl implements ApplicationListener{
 
     protected void registerCommands(){
         handler.register("help", "[command]", "Display the command list, or get help for a specific command.", arg -> {
-            if (arg.length > 0){
+            if(arg.length > 0){
                 Command command = handler.getCommandList().find(c -> c.text.equalsIgnoreCase(arg[0]));
-                if (command == null) {
+                if(command == null){
                     err("Command " + arg[0] + " not found!");
                 }else{
                     info(command.text + ":");
                     info("  &b&lb " + command.text + (command.paramText.isEmpty() ? "" : " &lc&fi") + command.paramText + "&fr - &lw" + command.description);
                 }
-                return;
-            }
-            info("Commands:");
-            for(Command command : handler.getCommandList()){
-                info("  &b&lb " + command.text + (command.paramText.isEmpty() ? "" : " &lc&fi") + command.paramText + "&fr - &lw" + command.description);
+            }else{
+                info("Commands:");
+                for(Command command : handler.getCommandList()){
+                    info("  &b&lb " + command.text + (command.paramText.isEmpty() ? "" : " &lc&fi") + command.paramText + "&fr - &lw" + command.description);
+                }
             }
         });
 

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -662,7 +662,7 @@ public class ServerControl implements ApplicationListener{
         });
 
         handler.register("nextmap", "<mapname...>", "Set the next map to be played after a game-over. Overrides shuffling.", arg -> {
-            Map res = maps.all().find(map -> map.name().equalsIgnoreCase(arg[0].replace('_', ' ')) || map.name().equalsIgnoreCase(arg[0]));
+            Map res = maps.all().find(map -> Strings.stripColors(map.name().replace('_', ' ')).equalsIgnoreCase(Strings.stripColors(arg[0]).replace('_', ' ')));
             if(res != null){
                 nextMapOverride = res;
                 info("Next map set to '@'.", res.name());

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -315,7 +315,7 @@ public class ServerControl implements ApplicationListener{
 
             Map result;
             if(arg.length > 0){
-                result = maps.all().find(map -> map.name().equalsIgnoreCase(arg[0].replace('_', ' ')) || map.name().equalsIgnoreCase(arg[0]));
+                result = maps.all().find(map -> Strings.stripColors(map.name().replace('_', ' ')).equalsIgnoreCase(Strings.stripColors(arg[0]).replace('_', ' ')));
 
                 if(result == null){
                     err("No map with name '@' found.", arg[0]);

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -259,7 +259,7 @@ public class ServerControl implements ApplicationListener{
     }
 
     protected void registerCommands(){
-        handler.register("help", "[command]", "Displays this command list.", arg -> {
+        handler.register("help", "[command]", "Display the command list, or get help for a specific command.", arg -> {
             if (arg.length > 0){
                 Command command = handler.getCommandList().find(c -> c.text.equalsIgnoreCase(arg[0]));
                 if (command == null) err("Command " + arg[0] + " not found!");

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -262,8 +262,9 @@ public class ServerControl implements ApplicationListener{
         handler.register("help", "[command]", "Display the command list, or get help for a specific command.", arg -> {
             if (arg.length > 0){
                 Command command = handler.getCommandList().find(c -> c.text.equalsIgnoreCase(arg[0]));
-                if (command == null) err("Command " + arg[0] + " not found!");
-                else {
+                if (command == null) {
+                    err("Command " + arg[0] + " not found!");
+                }else{
                     info(command.text + ":");
                     info("  &b&lb " + command.text + (command.paramText.isEmpty() ? "" : " &lc&fi") + command.paramText + "&fr - &lw" + command.description);
                 }

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -163,9 +163,9 @@ public class ServerControl implements ApplicationListener{
         Events.on(GameOverEvent.class, event -> {
             if(inExtraRound) return;
             if(state.rules.waves){
-                info("Game over! Reached wave @ with @ players online on map @.", state.wave, Groups.player.size(), Strings.capitalize(state.map.name()));
+                info("Game over! Reached wave @ with @ players online on map @.", state.wave, Groups.player.size(), Strings.capitalize(Strings.stripColors(state.map.name())));
             }else{
-                info("Game over! Team @ is victorious with @ players online on map @.", event.winner.name, Groups.player.size(), Strings.capitalize(state.map.name()));
+                info("Game over! Team @ is victorious with @ players online on map @.", event.winner.name, Groups.player.size(), Strings.capitalize(Strings.stripColors(state.map.name())));
             }
 
             //set next map to be played
@@ -174,14 +174,14 @@ public class ServerControl implements ApplicationListener{
             if(map != null){
                 Call.infoMessage((state.rules.pvp
                 ? "[accent]The " + event.winner.name + " team is victorious![]\n" : "[scarlet]Game over![]\n")
-                + "\nNext selected map:[accent] " + map.name() + "[]"
+                + "\nNext selected map:[accent] " + Strings.stripColors(map.name()) + "[]"
                 + (map.tags.containsKey("author") && !map.tags.get("author").trim().isEmpty() ? " by[accent] " + map.author() + "[white]" : "") + "." +
                 "\nNew game begins in " + roundExtraTime + " seconds.");
 
                 state.gameOver = true;
                 Call.updateGameOver(event.winner);
 
-                info("Selected next map to be @.", map.name());
+                info("Selected next map to be @.", Strings.stripColors(map.name()));
 
                 play(true, () -> world.loadMap(map, map.applyRules(lastMode)));
             }else{
@@ -378,7 +378,7 @@ public class ServerControl implements ApplicationListener{
                 info("Status: &rserver closed");
             }else{
                 info("Status:");
-                info("  Playing on map &fi@ / Wave @", Strings.capitalize(state.map.name()), state.wave);
+                info("  Playing on map &fi@ / Wave @", Strings.capitalize(Strings.stripColors(state.map.name())), state.wave);
 
                 if(state.rules.waves){
                     info("  @ enemies.", state.enemies);
@@ -665,7 +665,7 @@ public class ServerControl implements ApplicationListener{
             Map res = maps.all().find(map -> Strings.stripColors(map.name().replace('_', ' ')).equalsIgnoreCase(Strings.stripColors(arg[0]).replace('_', ' ')));
             if(res != null){
                 nextMapOverride = res;
-                info("Next map set to '@'.", res.name());
+                info("Next map set to '@'.", Strings.stripColors(res.name()));
             }else{
                 err("No map '@' found.", arg[0]);
             }

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -350,7 +350,7 @@ public class ServerControl implements ApplicationListener{
             if(!maps.all().isEmpty()){
                 info("Maps:");
                 for(Map map : all ? maps.all() : maps.customMaps()){
-                    String mapName = (full ? map.name() : Strings.stripColors(map.name())).replace(' ', '_');
+                    String mapName = Strings.stripColors(map.name()).replace(' ', '_');
                     if(map.custom){
                         info("  @ (@): &fiCustom / @x@", mapName, map.file.name(), map.width, map.height);
                     }else{


### PR DESCRIPTION
Some QoL changes to the server terminal interface. Changes:
- `maps` displays custom maps only by default.
- Remove colors from map names so the name is actually readable for some maps.
The command has an additional `all` optional parameter to show default maps as well. 
The command description has been updated to reflect this.

- Color codes are removed from various places that show map names in terminal.
- Map finding function now strips both input and map name equally before comparing, making it compatible with all input/map name combinations. This change is reflected in both `host` and `nextmap` commands.

- The `help` command has an additional optional command parameter, to get help on a specific command.
The command description for help has also been updated to reflect this change.

- Look ma im a contributor!