### PR TITLE
Remove deconstructThreshold

### DIFF
--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -223,8 +223,6 @@ public class Block extends UnlockableContent{
     public BuildVisibility buildVisibility = BuildVisibility.hidden;
     /** Multiplier for speed of building this block. */
     public float buildCostMultiplier = 1f;
-    /** Build completion at which deconstruction finishes. */
-    public float deconstructThreshold = 0f;
     /** If true, this block deconstructs immediately. Instant deconstruction implies no resource refund. */
     public boolean instantDeconstruct = false;
     /** Effect for breaking the block. Passes size as rotation. */

--- a/core/src/mindustry/world/blocks/ConstructBlock.java
+++ b/core/src/mindustry/world/blocks/ConstructBlock.java
@@ -309,7 +309,7 @@ public class ConstructBlock extends Block{
 
             progress = Mathf.clamp(progress - amount);
 
-            if(progress <= current.deconstructThreshold || state.rules.infiniteResources){
+            if(state.rules.infiniteResources){
                 if(lastBuilder == null) lastBuilder = builder;
                 Call.deconstructFinish(tile, this.current, lastBuilder);
             }

--- a/core/src/mindustry/world/blocks/environment/Prop.java
+++ b/core/src/mindustry/world/blocks/environment/Prop.java
@@ -13,7 +13,6 @@ public class Prop extends Block{
         alwaysReplace = true;
         instantDeconstruct = true;
         
-        deconstructThreshold = 0.35f;
         breakEffect = Fx.breakProp;
     }
 


### PR DESCRIPTION
Not needed anymore for its original purpose since boulders now deconstruct instantly, and this would return an incomplete refund if the block had building materials anyways.

I did search github for mods that seemingly used this property in any way, and so far i only came across @sk7725’s betamindy payload deconstructor.

Though i didn’t go through all the github results since like 99% are just results of mindustry forks, the damage (if any) caused by removing this value will probably be minimal.