### PR TITLE
Multi output crafter

### DIFF
--- a/core/src/mindustry/world/blocks/production/GenericCrafter.java
+++ b/core/src/mindustry/world/blocks/production/GenericCrafter.java
@@ -15,7 +15,8 @@ import mindustry.world.draw.*;
 import mindustry.world.meta.*;
 
 public class GenericCrafter extends Block{
-    public @Nullable ItemStack outputItem; //Keep for backwards compatibility
+    /** @deprecated use outputItems instead, outputItem would likely be removed eventually **/
+    public @Nullable ItemStack outputItem;
     public @Nullable ItemStack[] outputItems;
     public @Nullable LiquidStack outputLiquid;
 

--- a/core/src/mindustry/world/blocks/production/GenericCrafter.java
+++ b/core/src/mindustry/world/blocks/production/GenericCrafter.java
@@ -15,7 +15,6 @@ import mindustry.world.draw.*;
 import mindustry.world.meta.*;
 
 public class GenericCrafter extends Block{
-    /** @deprecated use outputItems instead, outputItem would likely be removed eventually **/
     public @Nullable ItemStack outputItem;
     public @Nullable ItemStack[] outputItems;
     public @Nullable LiquidStack outputLiquid;
@@ -49,8 +48,6 @@ public class GenericCrafter extends Block{
 
         if(outputItems != null){
             stats.add(Stat.output, StatValues.items(craftTime, outputItems));
-        }else if(outputItem != null){
-            stats.add(Stat.output, StatValues.items(craftTime, outputItem));
         }
 
         if(outputLiquid != null){
@@ -68,6 +65,9 @@ public class GenericCrafter extends Block{
     @Override
     public void init(){
         outputsLiquid = outputLiquid != null;
+        if(outputItems == null && outputItem != null){
+            outputItems = new ItemStack[]{outputItem};
+        }
         super.init();
     }
 
@@ -78,7 +78,7 @@ public class GenericCrafter extends Block{
 
     @Override
     public boolean outputsItems(){
-        return outputItem != null;
+        return outputItems != null;
     }
 
     public class GenericCrafterBuild extends Building{
@@ -99,8 +99,12 @@ public class GenericCrafter extends Block{
 
         @Override
         public boolean shouldConsume(){
-            if(outputItem != null && items.get(outputItem.item) + outputItem.amount > itemCapacity){
-                return false;
+            if(outputItems != null){
+                for(ItemStack output : outputItems){
+                    if(items.get(output.item) + output.amount > itemCapacity){
+                        return false;
+                    }
+                }
             }
             return (outputLiquid == null || !(liquids.get(outputLiquid.liquid) >= liquidCapacity - 0.001f)) && enabled;
         }
@@ -127,8 +131,6 @@ public class GenericCrafter extends Block{
                     for(ItemStack output : outputItems){
                         produceItem(output);
                     }
-                }else if(outputItem != null){
-                    produceItem(outputItem);
                 }
 
                 if(outputLiquid != null){
@@ -147,8 +149,6 @@ public class GenericCrafter extends Block{
                             break;
                         }
                     }
-                }else if(outputItem != null){
-                    dump(outputItem.item);
                 }
             }
 

--- a/core/src/mindustry/world/blocks/production/GenericCrafter.java
+++ b/core/src/mindustry/world/blocks/production/GenericCrafter.java
@@ -141,13 +141,11 @@ public class GenericCrafter extends Block{
                 progress %= 1f;
             }
 
-            if(timer(timerDump, dumpTime / timeScale)){
-                if(outputItems != null){
-                    for(ItemStack output : outputItems){
-                        if(items.has(output.item)){
-                            dump(output.item);
-                            break;
-                        }
+            if(outputItems != null && timer(timerDump, dumpTime / timeScale)){
+                for(ItemStack output : outputItems){
+                    if(items.has(output.item)){
+                        dump(output.item);
+                        break;
                     }
                 }
             }

--- a/core/src/mindustry/world/blocks/production/GenericCrafter.java
+++ b/core/src/mindustry/world/blocks/production/GenericCrafter.java
@@ -15,7 +15,8 @@ import mindustry.world.draw.*;
 import mindustry.world.meta.*;
 
 public class GenericCrafter extends Block{
-    public @Nullable ItemStack outputItem;
+    public @Nullable ItemStack outputItem; //Keep for backwards compatibility
+    public @Nullable ItemStack[] outputItems;
     public @Nullable LiquidStack outputLiquid;
 
     public float craftTime = 80;
@@ -45,7 +46,9 @@ public class GenericCrafter extends Block{
         super.setStats();
         stats.add(Stat.productionTime, craftTime / 60f, StatUnit.seconds);
 
-        if(outputItem != null){
+        if(outputItems != null){
+            stats.add(Stat.output, StatValues.items(craftTime, outputItems));
+        }else if(outputItem != null){
             stats.add(Stat.output, StatValues.items(craftTime, outputItem));
         }
 
@@ -119,10 +122,12 @@ public class GenericCrafter extends Block{
             if(progress >= 1f){
                 consume();
 
-                if(outputItem != null){
-                    for(int i = 0; i < outputItem.amount; i++){
-                        offload(outputItem.item);
+                if(outputItems != null){
+                    for(ItemStack output : outputItems){
+                        produceItem(output);
                     }
+                }else if(outputItem != null){
+                    produceItem(outputItem);
                 }
 
                 if(outputLiquid != null){
@@ -133,12 +138,27 @@ public class GenericCrafter extends Block{
                 progress %= 1f;
             }
 
-            if(outputItem != null && timer(timerDump, dumpTime / timeScale)){
-                dump(outputItem.item);
+            if(timer(timerDump, dumpTime / timeScale)){
+                if(outputItems != null){
+                    for(ItemStack output : outputItems){
+                        if(items.has(output.item)){
+                            dump(output.item);
+                            break;
+                        }
+                    }
+                }else if(outputItem != null){
+                    dump(outputItem.item);
+                }
             }
 
             if(outputLiquid != null){
                 dumpLiquid(outputLiquid.liquid);
+            }
+        }
+
+        public void produceItem(ItemStack item){
+            for(int i = 0; i < item.amount; i++){
+                offload(item.item);
             }
         }
 


### PR DESCRIPTION
Adds `outputItems` to `GenericCrafter`. Input an array of ItemStacks and upon craft will produce everything in the array.

`outputItem` still exists so as not to break stuff.