### PR TITLE
Always increment launchpad counter

### DIFF
--- a/core/src/mindustry/world/blocks/campaign/LaunchPad.java
+++ b/core/src/mindustry/world/blocks/campaign/LaunchPad.java
@@ -133,8 +133,8 @@ public class LaunchPad extends Block{
         public void updateTile(){
             if(!state.isCampaign()) return;
 
-            //launch when full and base conditions are met
-            if(items.total() >= itemCapacity && efficiency() >= 1f && (launchCounter += edelta()) >= launchTime){
+            //increment launchCounter then launch when full and base conditions are met
+            if((launchCounter += edelta()) >= launchTime && items.total() >= itemCapacity){
                 launchSound.at(x, y);
                 LaunchPayload entity = LaunchPayload.create();
                 items.each((item, amount) -> entity.stacks.add(new ItemStack(item, amount)));


### PR DESCRIPTION
After switching from `timer` to incrementing `launchCounter` (https://github.com/Anuken/Mindustry/commit/28b235ef07be92808cdba260168ff314db426376#diff-1a24378e67f837237740bfb4613e955e9d21250b0adc0a94db1515cbed7680de), launch pads wait until their capacity is full before starting the countdown. Assuming that was unintentional, this change makes the countdown start immediately again.

Also, if a launch pad does not have full power, it will do nothing except drain power. Removing `efficiency() >= 1f` allows the launch pad to work, but at a slower rate.