### PR TITLE
Dont disconnect when connecting to steam servers on non steam

### DIFF
--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -290,6 +290,7 @@ public class NetClient implements ApplicationListener{
 
     @Remote(called = Loc.client, variants = Variant.one)
     public static void connect(String ip, int port){
+        if(!steam && ip.startsWith("steam:")) return;
         netClient.disconnectQuietly();
         logic.reset();
 


### PR DESCRIPTION
This will allow sending steam players to steam servers while completely ignoring non steam ones.