### PR TITLE
Allow hiding of steam servers

### DIFF
--- a/desktop/src/mindustry/desktop/steam/SNet.java
+++ b/desktop/src/mindustry/desktop/steam/SNet.java
@@ -312,6 +312,7 @@ public class SNet implements SteamNetworkingCallback, SteamMatchmakingCallback, 
             for(int i = 0; i < matches; i++){
                 try{
                     SteamID lobby = smat.getLobbyByIndex(i);
+                    if(!smat.getLobbyData(lobby, "hidden").equals("false")) continue;
                     String mode = smat.getLobbyData(lobby, "gamemode");
                     //make sure versions are equal, don't list incompatible lobbies
                     if(mode == null || mode.isEmpty() || (Version.build != -1 && Strings.parseInt(smat.getLobbyData(lobby, "version"), -1) != Version.build)) continue;
@@ -359,6 +360,7 @@ public class SNet implements SteamNetworkingCallback, SteamMatchmakingCallback, 
             smat.setLobbyData(steamID, "versionType", Version.type);
             smat.setLobbyData(steamID, "wave", state.wave + "");
             smat.setLobbyData(steamID, "gamemode", state.rules.mode().name() + "");
+            smat.setLobbyData(steamID, "hidden", "false");
         }
     }
 

--- a/desktop/src/mindustry/desktop/steam/SNet.java
+++ b/desktop/src/mindustry/desktop/steam/SNet.java
@@ -312,7 +312,7 @@ public class SNet implements SteamNetworkingCallback, SteamMatchmakingCallback, 
             for(int i = 0; i < matches; i++){
                 try{
                     SteamID lobby = smat.getLobbyByIndex(i);
-                    if(!smat.getLobbyData(lobby, "hidden").equals("false")) continue;
+                    if(smat.getLobbyData(lobby, "hidden").equals("true")) continue;
                     String mode = smat.getLobbyData(lobby, "gamemode");
                     //make sure versions are equal, don't list incompatible lobbies
                     if(mode == null || mode.isEmpty() || (Version.build != -1 && Strings.parseInt(smat.getLobbyData(lobby, "version"), -1) != Version.build)) continue;
@@ -360,7 +360,6 @@ public class SNet implements SteamNetworkingCallback, SteamMatchmakingCallback, 
             smat.setLobbyData(steamID, "versionType", Version.type);
             smat.setLobbyData(steamID, "wave", state.wave + "");
             smat.setLobbyData(steamID, "gamemode", state.rules.mode().name() + "");
-            smat.setLobbyData(steamID, "hidden", "false");
         }
     }
 


### PR DESCRIPTION
Theres no way to hide them while keeping them public in the steam api so instead this jank is needed. This wont do anything on a vanilla install but will allow people hosting headless steam servers to hide them if they only use the server to verify if players are on steam or not.
![](https://i-dont.go-outsi.de/54K4TXLjZ.png) ![](https://discord-cdn.is-terrible.com/54K50WZiB.png)