### PR TITLE
SpinSprite DrawRotator for json mods

### DIFF
--- a/core/src/mindustry/world/draw/DrawRotator.java
+++ b/core/src/mindustry/world/draw/DrawRotator.java
@@ -2,16 +2,22 @@ package mindustry.world.draw;
 
 import arc.*;
 import arc.graphics.g2d.*;
+import mindustry.graphics.*;
 import mindustry.world.*;
 import mindustry.world.blocks.production.GenericCrafter.*;
 
 public class DrawRotator extends DrawBlock{
     public TextureRegion rotator, top;
+    public boolean drawSpinSprite = false;
 
     @Override
     public void draw(GenericCrafterBuild build){
         Draw.rect(build.block.region, build.x, build.y);
-        Draw.rect(rotator, build.x, build.y, build.totalProgress * 2f);
+        if(drawSpinSprite){
+            Drawf.spinSprite(rotator, build.x, build.y, build.totalProgress * 2f);
+        }else{
+            Draw.rect(rotator, build.x, build.y, build.totalProgress * 2f);
+        }
         if(top.found()) Draw.rect(top, build.x, build.y);
     }
 


### PR DESCRIPTION
- This is set to false by default because unlike drills, most rotators in other blocks and modded blocks are "flat".