### PR TITLE
Keep v6 mod compatibility for the deprecated expanded field

### DIFF
--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -793,6 +793,11 @@ public class Block extends UnlockableContent{
         }
 
         clipSize = Math.max(clipSize, size * tilesize);
+        
+        //only kept to ensure compatibility with v6 mods.
+        if(expanded){
+            clipSize += tilesize * 10f;
+        }
 
         if(emitLight){
             clipSize = Math.max(clipSize, lightRadius * 2f);


### PR DESCRIPTION
This makes certain expanded blocks of v6 mods not look ugly in v7.
The magic number 10 comes from the v6 BlockRenderer.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
