### PR TITLE
Fixed desync on servers

### DIFF
--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -418,9 +418,6 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
         unit.remove();
         grabber.get(new UnitPayload(unit));
         Fx.unitDrop.at(unit);
-        if(Vars.net.client()){
-            Vars.netClient.clearRemovedEntity(unit.id);
-        }
     }
 
     public boolean canUnload(){


### PR DESCRIPTION
When you ctrl click a unit into a payload, the unit desyncs on the client and isnt removed correctly. Removing these 3 lines fixes it, this fix probably isn't ideal but whatever, its better than it desyncing.

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
