### PR TITLE
Disposable container behavior for mods

### DIFF
--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -496,12 +496,6 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
     public void handlePayload(Building source, Payload payload){
 
     }
-    
-    /** Called by various payload blocks making changes to this building, which is in a BuildPayload. Note that some fields of this building may be null. */
-    public void asPayload(Building holder, BuildPayload self){
-        
-    }
-
 
     /**
      * Tries moving a payload forwards.

--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -496,6 +496,11 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
     public void handlePayload(Building source, Payload payload){
 
     }
+    
+    /** Called by various payload blocks making changes to this building, which is in a BuildPayload. Note that some fields of this building may be null. */
+    public void asPayload(Building holder, BuildPayload self){
+        
+    }
 
 
     /**

--- a/core/src/mindustry/world/blocks/payloads/BlockUnloader.java
+++ b/core/src/mindustry/world/blocks/payloads/BlockUnloader.java
@@ -44,6 +44,7 @@ public class BlockUnloader extends BlockLoader{
                                     Item item = content.item(i);
                                     payload.build.items.remove(item, 1);
                                     items.add(item, 1);
+                                    payload.build.asPayload(this, payload);
                                     break;
                                 }
                             }

--- a/core/src/mindustry/world/blocks/payloads/BlockUnloader.java
+++ b/core/src/mindustry/world/blocks/payloads/BlockUnloader.java
@@ -31,13 +31,7 @@ public class BlockUnloader extends BlockLoader{
         @Override
         public void updateTile(){
             if(shouldExport()){
-                //one-use, disposable block
-                if(payload.block().instantDeconstruct){
-                    payload.block().destroyEffect.at(this, payload.block().size / 2f); //full math for the rotation is size * tilesize / 2f / 8f, according to dynamicExplosion.
-                    payload = null;
-                }else{
-                    moveOutPayload();
-                }
+                moveOutPayload();
             }else if(moveInPayload()){
 
                 //load up items
@@ -53,6 +47,12 @@ public class BlockUnloader extends BlockLoader{
                                     break;
                                 }
                             }
+                        }
+                        
+                        //one-use, disposable block
+                        if(payload.build.items.empty() && payload.block().instantDeconstruct){
+                            payload.block().destroyEffect.at(this, payload.block().size / 2f); //full math for the rotation is size * tilesize / 2f / 8f, according to dynamicExplosion.
+                            payload = null;
                         }
                     }
                 }

--- a/core/src/mindustry/world/blocks/payloads/BlockUnloader.java
+++ b/core/src/mindustry/world/blocks/payloads/BlockUnloader.java
@@ -44,7 +44,6 @@ public class BlockUnloader extends BlockLoader{
                                     Item item = content.item(i);
                                     payload.build.items.remove(item, 1);
                                     items.add(item, 1);
-                                    payload.build.asPayload(this, payload);
                                     break;
                                 }
                             }

--- a/core/src/mindustry/world/blocks/payloads/BlockUnloader.java
+++ b/core/src/mindustry/world/blocks/payloads/BlockUnloader.java
@@ -31,7 +31,13 @@ public class BlockUnloader extends BlockLoader{
         @Override
         public void updateTile(){
             if(shouldExport()){
-                moveOutPayload();
+                //one-use, disposable block
+                if(payload.block().instantDeconstruct){
+                    payload.block().destroyEffect.at(this, payload.block().size / 2f); //full math for the rotation is size * tilesize / 2f / 8f, according to dynamicExplosion.
+                    payload = null;
+                }else{
+                    moveOutPayload();
+                }
             }else if(moveInPayload()){
 
                 //load up items


### PR DESCRIPTION
- Uses instantDeconstruct field, as it implies that this payload is a disposable.
- Disposable blocks (think those cardboard/plastic packaging that are one-use) don't deserve a payload deconstructor.
- Initially additional behavior for mods, but i think some new vanilla blocks can use this as well
- Only disposes of blocks when it actually took items from it
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
