### PR TITLE
display sector description in stats dialog

### DIFF
--- a/core/src/mindustry/ui/dialogs/PlanetDialog.java
+++ b/core/src/mindustry/ui/dialogs/PlanetDialog.java
@@ -633,6 +633,10 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
         dialog.cont.pane(c -> {
             c.defaults().padBottom(5);
 
+            if(sector.preset != null){
+            c.add(sector.preset.displayDescription() + "\n").left().row();
+            }
+
             c.add(Core.bundle.get("sectors.time") + " [accent]" + sector.save.getPlayTime()).left().row();
 
             if(sector.info.waves && sector.hasBase()){


### PR DESCRIPTION
A nice feature for newbies to see sector descriptions without actually looking it in Core Database or Tech Tree.
feedback and comments are welcome :D 

**Note:** I haven't tested on mods yet, is there any mods with new preset sector(s) other than Braindustry? I can't make Braindustry work in v7 (BE)

![yes](https://user-images.githubusercontent.com/85090668/128025480-0201b808-4272-4ed6-922f-1ce42cbd3e9c.png)

- [X] actually make it works
- [ ] make spacing more like in core database
- [ ] mod test (cannot find mod to test that works in v7)
------
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
