### PR TITLE
Fix saving tags of overwritten schematic

### DIFF
--- a/core/src/mindustry/game/Schematics.java
+++ b/core/src/mindustry/game/Schematics.java
@@ -114,6 +114,7 @@ public class Schematics implements Loadable{
         target.tiles.addAll(newSchematic.tiles);
         target.width = newSchematic.width;
         target.height = newSchematic.height;
+        newSchematic.labels = target.labels;
         newSchematic.tags.putAll(target.tags);
         newSchematic.file = target.file;
 


### PR DESCRIPTION
Currently, if you overwrite a schematic with tags and restart the game without modifying the schematic again, it will not have any tags. This PR fixes this issue.

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
