### PR TITLE
universal battery amount formatting

### DIFF
--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -430,7 +430,7 @@ public class Block extends UnlockableContent{
             boolean buffered = cons.buffered;
             float capacity = cons.capacity;
 
-            bars.add("power", entity -> new Bar(() -> buffered ? Core.bundle.format("bar.poweramount", Float.isNaN(entity.power.status * capacity) ? "<ERROR>" : (int)(entity.power.status * capacity)) :
+            bars.add("power", entity -> new Bar(() -> buffered ? Core.bundle.format("bar.poweramount", Float.isNaN(entity.power.status * capacity) ? "<ERROR>" : entity.power.status * capacity > 1000 ? UI.formatAmount((long)(entity.power.status * capacity)) : (int)(entity.power.status * capacity)) :
                 Core.bundle.get("bar.power"), () -> Pal.powerBar, () -> Mathf.zero(cons.requestedPower(entity)) && entity.power.graph.getPowerProduced() + entity.power.graph.getBatteryStored() > 0f ? 1f : entity.power.status));
         }
 


### PR DESCRIPTION
change battery's power amount formatting from "**50,000**" / "**4,000**" to "**50k**" / "**4.0k**" to keep consistencies with other power blocks and make formatting universal (some countries use "**.**" as a separator instead of "**,**" like "**50.000**") this PR will eradicate the formatting confusion and make checking power easier to look at for them.

while it looks good, it may decrease number precision, but well, who cares, why would they want to see exact amount of battery power anyways (exact amount can still be accessed by logic).

![small](https://cdn.discordapp.com/attachments/861492448621363220/874542570989031464/IMG_20210810_133847.jpg)
![large](https://cdn.discordapp.com/attachments/861492448621363220/874542571186188288/IMG_20210810_133942.jpg)

---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
