### PR TITLE
If a block doesn't rotate, then don't check if the payload conveyor is trying to input into the output side

### DIFF
--- a/core/src/mindustry/world/blocks/distribution/PayloadConveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/PayloadConveyor.java
@@ -113,7 +113,7 @@ public class PayloadConveyor extends Block{
 
             int ntrns = 1 + size/2;
             Tile next = tile.nearby(Geometry.d4(rotation).x * ntrns, Geometry.d4(rotation).y * ntrns);
-            blocked = (next != null && next.solid() && !next.block().outputsPayload) || (next != null && next.block().rotate && (next.rotation + 2) % 4 == rotation);
+            blocked = (next != null && next.solid() && !next.block().outputsPayload) || (this.next != null && this.next.block.rotate && (this.next.rotation + 2) % 4 == rotation);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/distribution/PayloadConveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/PayloadConveyor.java
@@ -113,7 +113,7 @@ public class PayloadConveyor extends Block{
 
             int ntrns = 1 + size/2;
             Tile next = tile.nearby(Geometry.d4(rotation).x * ntrns, Geometry.d4(rotation).y * ntrns);
-            blocked = (next != null && next.solid() && !next.block().outputsPayload) || (this.next != null && this.next.rotate && (this.next.rotation + 2) % 4 == rotation);
+            blocked = (next != null && next.solid() && !next.block().outputsPayload) || (this.next != null && this.next.block.rotate && (this.next.rotation + 2) % 4 == rotation);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/distribution/PayloadConveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/PayloadConveyor.java
@@ -113,7 +113,7 @@ public class PayloadConveyor extends Block{
 
             int ntrns = 1 + size/2;
             Tile next = tile.nearby(Geometry.d4(rotation).x * ntrns, Geometry.d4(rotation).y * ntrns);
-            blocked = (next != null && next.solid() && !next.block().outputsPayload) || (this.next != null && this.next.block.rotate && (this.next.rotation + 2) % 4 == rotation);
+            blocked = (next != null && next.solid() && !next.block().outputsPayload) || (next != null && next.block().rotate && (next.rotation + 2) % 4 == rotation);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/distribution/PayloadConveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/PayloadConveyor.java
@@ -113,7 +113,7 @@ public class PayloadConveyor extends Block{
 
             int ntrns = 1 + size/2;
             Tile next = tile.nearby(Geometry.d4(rotation).x * ntrns, Geometry.d4(rotation).y * ntrns);
-            blocked = (next != null && next.solid() && !next.block().outputsPayload) || (this.next != null && (this.next.rotation + 2)%4 == rotation);
+            blocked = (next != null && next.solid() && !next.block().outputsPayload) || (this.next != null && this.next.rotate && (this.next.rotation + 2) % 4 == rotation);
         }
 
         @Override


### PR DESCRIPTION
Fixes the issue where one side of the payload void counts as an output, and thus a payload router will ignore it.

Bugged:

https://user-images.githubusercontent.com/54301439/129461712-d079a830-fba9-4859-b8e0-8f97fc5abd92.mp4

(Watch left-most payload router)

Fixed:

https://user-images.githubusercontent.com/54301439/129461831-5e83743d-4407-448d-8572-f05635e1d3e6.mp4

All payload voids placed directly next to a router were placed with `F` copy/paste so they all have the same rotation.

---

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.

(If you're wondering how I stumbled upon this bug, it has to do with payload-based turrets having issues with routers)