### PR TITLE
reuse <content.sector.name> for sector list

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -564,7 +564,6 @@ weather.sandstorm.name = Sandstorm
 weather.sporestorm.name = Sporestorm
 weather.fog.name = Fog
 
-sectorlist = Sectors
 sectorlist.attacked = {0} under attack
 sectors.unexplored = [lightgray]Unexplored
 sectors.resources = Resources:

--- a/core/src/mindustry/ui/dialogs/PlanetDialog.java
+++ b/core/src/mindustry/ui/dialogs/PlanetDialog.java
@@ -539,7 +539,7 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
                 c.top().right();
                 c.defaults().width(280f);
 
-                c.button(bundle.get("sectorlist") +
+                c.button(bundle.get("content.sector.name") +
                     (attacked == 0 ? "" : "\n[red]⚠[lightgray] " + bundle.format("sectorlist.attacked", "[red]" + attacked + "[]")),
                     Icon.downOpen, Styles.squareTogglet, () -> sectorsShown = !sectorsShown)
                 .height(60f).checked(b -> {


### PR DESCRIPTION
reuse ~~plastic~~ bundle string, save the earth
- deprecate `sectorlist`, and reuse the `content.sector.name` for sector list instead

---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
