### PR TITLE
hovering block info

### DIFF
--- a/core/src/mindustry/ui/fragments/PlacementFragment.java
+++ b/core/src/mindustry/ui/fragments/PlacementFragment.java
@@ -192,8 +192,10 @@ public class PlacementFragment extends Fragment{
         }
 
         if(Core.input.keyTap(Binding.block_info)){
-            Block displayBlock = menuHoverBlock != null ? menuHoverBlock : input.block;
-            if(displayBlock != null){
+            var h = world.buildWorld(Core.input.mouseWorld().x, Core.input.mouseWorld().y);
+            Block hovering = h == null ? null : h instanceof ConstructBuild c ? c.current : h.block;
+            Block displayBlock = menuHoverBlock != null ? menuHoverBlock : input.block != null ? input.block : hovering;
+            if(displayBlock != null && state.isCampaign() ? displayBlock.unlocked() :  displayBlock != null){
                 ui.content.show(displayBlock);
                 Events.fire(new BlockInfoEvent());
             }


### PR DESCRIPTION
make block info keybind `(F1)` be able to show the info of hovering blocks, rather than only in the menu. to protect spoilers, it'll not show the info of unresearched blocks in campaign.
the code is not the best, but at least it works (on my machine), so feedbacks are welcome :D

https://user-images.githubusercontent.com/85090668/129604531-987dcfd7-aa72-4cad-b445-29420c9d8744.mp4

(in the video, overdrive dome is not researched, so the info doesn't show)

---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
