### PR TITLE
Hidden blocks only in the Placement UI

### DIFF
--- a/core/src/mindustry/ui/fragments/PlacementFragment.java
+++ b/core/src/mindustry/ui/fragments/PlacementFragment.java
@@ -443,7 +443,7 @@ public class PlacementFragment extends Fragment{
     }
 
     boolean unlocked(Block block){
-        return block.unlockedNow();
+        return block.unlockedNow() && block.placeablePlayer;
     }
 
     boolean hasInfoBox(){

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -100,6 +100,8 @@ public class Block extends UnlockableContent{
     public boolean requiresWater = false;
     /** whether this block can be placed on any liquids, anywhere */
     public boolean placeableLiquid = false;
+    /** whether this block can be placed directly by the player via PlacementFragment */
+    public boolean placeablePlayer = true;
     /** whether this floor can be placed on. */
     public boolean placeableOn = true;
     /** whether this block has insulating properties. */


### PR DESCRIPTION
- when the blocks are sus.
- Hides the block from the player. This is different from `BuildVisibility`; The player & the world can still interact with the block (e.g. payload sources, picking up blocks) but it will not show up in the placementFragment, thus preventing the player from placing down those blocks *manually*.
- Not intended to be perfect (can be easily bypassed), but to prevent giving overwelming the player with too many similar blocks or something, to be used in mods.
- [ ] ~~todo: prevent schematics as it is just a glorified middle click~~

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
