### PR TITLE
Press T to save schematic

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -62,6 +62,7 @@ schematic.copy = Copy to Clipboard
 schematic.copy.import = Import from Clipboard
 schematic.shareworkshop = Share on Workshop
 schematic.flip = [accent][[{0}][]/[accent][[{1}][]: Flip Schematic
+schematic.save = [accent][[{0}][]: Save Schematic
 schematic.saved = Schematic saved.
 schematic.delete.confirm = This schematic will be utterly eradicated.
 schematic.rename = Rename Schematic

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -88,6 +88,9 @@ public class DesktopInput extends InputHandler{
             t.bottom();
             t.table(Styles.black6, b -> {
                 b.defaults().left();
+                b.label(() -> Core.bundle.format("schematic.save",
+                Core.keybinds.get(Binding.schematic_menu).key.toString())).style(Styles.outlineLabel).visible(() -> Core.settings.getBool("hints") || !(lastSchematic == null || lastSchematic.file != null));
+                b.row();
                 b.label(() -> Core.bundle.format("schematic.flip",
                     Core.keybinds.get(Binding.schematic_flip_x).key.toString(),
                     Core.keybinds.get(Binding.schematic_flip_y).key.toString())).style(Styles.outlineLabel).visible(() -> Core.settings.getBool("hints"));
@@ -447,6 +450,12 @@ public class DesktopInput extends InputHandler{
         if(!selectRequests.isEmpty()){
             if(Core.input.keyTap(Binding.schematic_menu) && !(lastSchematic == null || lastSchematic.file != null)){
                 this.showSchematicSave();
+            }else if(Core.input.keyTap(Binding.schematic_menu)){
+                if(ui.schematics.isShown()){
+                    ui.schematics.hide();
+                }else{
+                    ui.schematics.show();
+                }
             }
 
             if(Core.input.keyTap(Binding.schematic_flip_x)){

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -421,15 +421,11 @@ public class DesktopInput extends InputHandler{
             schemY = rawCursorY;
         }
 
-        if(Core.input.keyTap(Binding.schematic_menu) && !Core.scene.hasKeyboard()){
-            if(selectRequests.isEmpty()){
-                if(ui.schematics.isShown()){
-                    ui.schematics.hide();
-                }else{
-                    ui.schematics.show();
-                }
+        if(Core.input.keyTap(Binding.schematic_menu) && selectRequests.isEmpty() && !Core.scene.hasKeyboard()){
+            if(ui.schematics.isShown()){
+                ui.schematics.hide();
             }else{
-                this.showSchematicSave();
+                ui.schematics.show();
             }
         }
 
@@ -449,6 +445,10 @@ public class DesktopInput extends InputHandler{
         }
 
         if(!selectRequests.isEmpty()){
+            if(Core.input.keyTap(Binding.schematic_menu) && !(lastSchematic == null || lastSchematic.file != null)){
+                this.showSchematicSave();
+            }
+
             if(Core.input.keyTap(Binding.schematic_flip_x)){
                 flipRequests(selectRequests, true);
             }

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -89,7 +89,7 @@ public class DesktopInput extends InputHandler{
             t.table(Styles.black6, b -> {
                 b.defaults().left();
                 b.label(() -> Core.bundle.format("schematic.save",
-                Core.keybinds.get(Binding.schematic_menu).key.toString())).style(Styles.outlineLabel).visible(() -> Core.settings.getBool("hints") || !(lastSchematic == null || lastSchematic.file != null));
+                Core.keybinds.get(Binding.schematic_menu).key.toString())).style(Styles.outlineLabel).visible(() -> Core.settings.getBool("hints") && !(lastSchematic == null || lastSchematic.file != null));
                 b.row();
                 b.label(() -> Core.bundle.format("schematic.flip",
                     Core.keybinds.get(Binding.schematic_flip_x).key.toString(),
@@ -449,7 +449,7 @@ public class DesktopInput extends InputHandler{
 
         if(!selectRequests.isEmpty()){
             if(Core.input.keyTap(Binding.schematic_menu) && !(Core.input.keyDown(Binding.control) || lastSchematic == null || lastSchematic.file != null)){
-                this.showSchematicSave();
+                showSchematicSave();
             }else if(Core.input.keyTap(Binding.schematic_menu)){
                 if(ui.schematics.isShown()){
                     ui.schematics.hide();

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -448,7 +448,7 @@ public class DesktopInput extends InputHandler{
         }
 
         if(!selectRequests.isEmpty()){
-            if(Core.input.keyTap(Binding.schematic_menu) && !(lastSchematic == null || lastSchematic.file != null)){
+            if(Core.input.keyTap(Binding.schematic_menu) && !(Core.input.keyDown(Binding.control) || lastSchematic == null || lastSchematic.file != null)){
                 this.showSchematicSave();
             }else if(Core.input.keyTap(Binding.schematic_menu)){
                 if(ui.schematics.isShown()){

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -422,10 +422,14 @@ public class DesktopInput extends InputHandler{
         }
 
         if(Core.input.keyTap(Binding.schematic_menu) && !Core.scene.hasKeyboard()){
-            if(ui.schematics.isShown()){
-                ui.schematics.hide();
+            if(selectRequests.isEmpty()){
+                if(ui.schematics.isShown()){
+                    ui.schematics.hide();
+                }else{
+                    ui.schematics.show();
+                }
             }else{
-                ui.schematics.show();
+                this.showSchematicSave();
             }
         }
 


### PR DESCRIPTION
I'm just too lazy to drag my mouse and click the "**Save Schematic...**" button
this PR make pressing "**T**" while selecting blocks jumps into the save schematic dialog, rather than dragging the mouse into the bottom of the screen and click the shiny shiny button.

**For Your Information:** this PR does not create a new keybind, it reused the open schematics UI button, as we don't open schematics _while_ saving a schematic anyways.

---
### Behavior:
when you're selecting/copying blocks, pressing T will redirect you to the save schematic screen, and if you already saved the schematic, pressing T will redirect you to the schematics dialog instead, like it was.
but in some extremely specific cases, you may want to open schematics dialog _while_ selecting/copying blocks, you can do that by pressing `Ctrl + T`, _note that keybinds may vary, nothing in the PR is hardcoded_.

---
- [X] the behavior is fine and acceptable, but I'd like to improve it more.
- [ ] I'll try to reduce the if/else, if possible.

https://user-images.githubusercontent.com/85090668/130087249-5159f02b-dcbe-481d-9ea1-021081aae9b7.mp4

---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
