### PR TITLE
Heal Targetting on Turrets

### DIFF
--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -326,7 +326,7 @@ public class Turret extends ReloadTurret{
         }
 
         protected boolean canHeal(){
-            return hasAmmo() && targetHealing && peekAmmo().healPercent > 0;
+            return hasAmmo() && targetHealing && peekAmmo().collidesTeam && peekAmmo().healPercent > 0;
         }
 
         protected void findTarget(){

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -16,6 +16,7 @@ import mindustry.core.*;
 import mindustry.entities.*;
 import mindustry.entities.Units.*;
 import mindustry.entities.bullet.*;
+import mindustry.game.*;
 import mindustry.game.EventType.*;
 import mindustry.gen.*;
 import mindustry.graphics.*;
@@ -64,6 +65,7 @@ public class Turret extends ReloadTurret{
     public boolean accurateDelay = false;
     public boolean targetAir = true;
     public boolean targetGround = true;
+    public boolean targetHealing = false;
 
     //charging
     public float chargeTime = -1f;
@@ -320,7 +322,11 @@ public class Turret extends ReloadTurret{
         }
 
         protected boolean validateTarget(){
-            return !Units.invalidateTarget(target, team, x, y) || isControlled() || logicControlled();
+            return !Units.invalidateTarget(target, canHeal() ? Team.derelict : team, x, y) || isControlled() || logicControlled();
+        }
+
+        protected boolean canHeal(){
+            return hasAmmo() && targetHealing && peekAmmo().healPercent > 0;
         }
 
         protected void findTarget(){
@@ -328,6 +334,10 @@ public class Turret extends ReloadTurret{
                 target = Units.bestEnemy(team, x, y, range, e -> !e.dead() && !e.isGrounded(), unitSort);
             }else{
                 target = Units.bestTarget(team, x, y, range, e -> !e.dead() && (e.isGrounded() || targetAir) && (!e.isGrounded() || targetGround), b -> true, unitSort);
+
+                if(target == null && canHeal()){
+                    target = Units.findAllyTile(team, x, y, range, b -> b.damaged() && b != self());
+                }
             }
         }
 


### PR DESCRIPTION
If the turret `targetHealing = true` and the current bullet can heal, then the turret can target your own blocks to heal them.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
