### PR TITLE
payloadCapacity sensor for logic

### DIFF
--- a/core/src/mindustry/entities/comp/UnitComp.java
+++ b/core/src/mindustry/entities/comp/UnitComp.java
@@ -179,7 +179,7 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
                     0;
             case commanded -> controller instanceof FormationAI && isValid() ? 1 : 0;
             case payloadCount -> ((Object)this) instanceof Payloadc pay ? pay.payloads().size : 0;
-            case payloadCapacity -> type.payloadCapacity != 8 ? type.payloadCapacity / tilePayload : 0;
+            case payloadCapacity -> this instanceof Payloadc ? type.payloadCapacity / tilePayload : 0;
             case size -> hitSize / tilesize;
             default -> Float.NaN;
         };

--- a/core/src/mindustry/entities/comp/UnitComp.java
+++ b/core/src/mindustry/entities/comp/UnitComp.java
@@ -179,6 +179,7 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
                     0;
             case commanded -> controller instanceof FormationAI && isValid() ? 1 : 0;
             case payloadCount -> ((Object)this) instanceof Payloadc pay ? pay.payloads().size : 0;
+            case payloadCapacity -> type.payloadCapacity != 8 ? type.payloadCapacity / tilePayload : 0;
             case size -> hitSize / tilesize;
             default -> Float.NaN;
         };

--- a/core/src/mindustry/logic/LAccess.java
+++ b/core/src/mindustry/logic/LAccess.java
@@ -44,6 +44,7 @@ public enum LAccess{
     commanded,
     name,
     payloadCount,
+    payloadCapacity,
     payloadType,
 
     //values with parameters are considered controllable


### PR DESCRIPTION
adds `payloadCapacity` sensor for logic, which senses unit payload capacity in block squared (mega = 4, quad = 9, etc.)
so people (which includes me) don't have to hardcode a payload logic again, I don't know too why this hasn't been added, it gives so much potential to those logic abusers

~~it's me with another PR again don't get annoyed~~

TODO:
- [ ] sometimes it's too precise on imperfect payload number, like oct, in the database, it's showned as 28.09, but in the logic, it's showned as `28.090002059936523`, literally.
- [X] ~~`if above is checked out, I might remove the 8 check, as it'll get rounded/truncated to 0 anyways (or not?)`~~ use Payloadc check, thanks to MrDuck557 for telling me that.

(no preview video)

---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
