### PR TITLE
More Target varieties for energy field ability

### DIFF
--- a/core/src/mindustry/entities/abilities/EnergyFieldAbility.java
+++ b/core/src/mindustry/entities/abilities/EnergyFieldAbility.java
@@ -27,6 +27,9 @@ public class EnergyFieldAbility extends Ability{
     public float statusDuration = 60f * 6f;
     public float x, y;
     public boolean hitBuildings = true;
+    public boolean hitUnits = true;
+    public boolean targetGround = true;
+    public boolean targetAir = true;
     public int maxTargets = 25;
     public float healPercent = 2.5f;
 
@@ -99,13 +102,15 @@ public class EnergyFieldAbility extends Ability{
 
             all.clear();
 
-            Units.nearby(null, rx, ry, range, other -> {
-                if(other != unit){
-                    all.add(other);
-                }
-            });
+            if(hitUnits){
+                Units.nearby(null, rx, ry, range, other -> {
+                    if(other != unit && (other.isFlying() ? targetAir : targetGround)){
+                        all.add(other);
+                    }
+                });
+            }
 
-            if(hitBuildings){
+            if(hitBuildings && targetGround){
                 Units.nearbyBuildings(rx, ry, range, b -> {
                     if(b.team != Team.derelict || state.rules.coreCapture){
                         all.add(b);

--- a/core/src/mindustry/entities/abilities/EnergyFieldAbility.java
+++ b/core/src/mindustry/entities/abilities/EnergyFieldAbility.java
@@ -26,10 +26,7 @@ public class EnergyFieldAbility extends Ability{
     public Sound shootSound = Sounds.spark;
     public float statusDuration = 60f * 6f;
     public float x, y;
-    public boolean hitBuildings = true;
-    public boolean hitUnits = true;
-    public boolean targetGround = true;
-    public boolean targetAir = true;
+    public boolean targetGround = true, targetAir = true, hitBuildings = true, hitUnits = true;
     public int maxTargets = 25;
     public float healPercent = 2.5f;
 


### PR DESCRIPTION
add `targetGround`, `targetAir` and `hitUnits` to energy field ability, I don't think I have to explain what those do.
this will create more varieties for mods, and for future units(?)

(please think that there's a video here)
(in the video, `targetGround` is set to false, so the Aegires doesn't shock the boats, but it still shock the Flares)

---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
