### PR TITLE
Wave UI

### DIFF
--- a/core/src/mindustry/editor/WaveInfoDialog.java
+++ b/core/src/mindustry/editor/WaveInfoDialog.java
@@ -142,7 +142,9 @@ public class WaveInfoDialog extends BaseDialog{
             main.row();
             main.button("@add", () -> {
                 if(groups == null) groups = new Seq<>();
-                groups.add(new SpawnGroup(lastType));
+                SpawnGroup newGroup = new SpawnGroup(lastType);
+                groups.add(newGroup);
+                expandedGroup = newGroup;
                 buildGroups();
             }).growX().height(70f);
         }), new Label("@waves.none"){{

--- a/core/src/mindustry/editor/WaveInfoDialog.java
+++ b/core/src/mindustry/editor/WaveInfoDialog.java
@@ -172,7 +172,10 @@ public class WaveInfoDialog extends BaseDialog{
                             t.remove();
                             updateWaves();
                         }).pad(-6).size(46f).padRight(-12f);
-                    }, () -> showUpdate(group)).height(46f).pad(-6f).padBottom(0f).row();
+                    }, () -> {
+                        expandedGroup = expandedGroup == group ? null : group;
+                        buildGroups();
+                    }).height(46f).pad(-6f).padBottom(0f).row();
 
                     t.table(spawns -> {
                         spawns.field("" + (group.begin + 1), TextFieldFilter.digitsOnly, text -> {

--- a/core/src/mindustry/editor/WaveInfoDialog.java
+++ b/core/src/mindustry/editor/WaveInfoDialog.java
@@ -153,6 +153,7 @@ public class WaveInfoDialog extends BaseDialog{
         table.margin(10f);
 
         if(groups != null){
+            groups.sort(Comparator.comparing(g -> g.type.health));
 
             for(SpawnGroup group : groups){
                 table.table(Tex.button, t -> {

--- a/core/src/mindustry/editor/WaveInfoDialog.java
+++ b/core/src/mindustry/editor/WaveInfoDialog.java
@@ -14,6 +14,7 @@ import mindustry.gen.*;
 import mindustry.graphics.*;
 import mindustry.io.*;
 import mindustry.type.*;
+import mindustry.ui.*;
 import mindustry.ui.dialogs.*;
 
 import java.util.*;
@@ -174,8 +175,8 @@ public class WaveInfoDialog extends BaseDialog{
 
                         b.add().growX();
 
-                        b.button(Icon.unitsSmall, () -> showUpdate(group)).pad(-6).size(46f);
-                        b.button(Icon.cancel, () -> {
+                        b.button(Icon.unitsSmall, Styles.emptyi, () -> showUpdate(group)).pad(-6).size(46f);
+                        b.button(Icon.cancel, Styles.emptyi, () -> {
                             groups.remove(group);
                             table.getCell(t).pad(0f);
                             t.remove();

--- a/core/src/mindustry/editor/WaveInfoDialog.java
+++ b/core/src/mindustry/editor/WaveInfoDialog.java
@@ -16,12 +16,15 @@ import mindustry.io.*;
 import mindustry.type.*;
 import mindustry.ui.dialogs.*;
 
+import java.util.*;
+
 import static mindustry.Vars.*;
 import static mindustry.game.SpawnGroup.*;
 
 public class WaveInfoDialog extends BaseDialog{
     private int displayed = 20;
     Seq<SpawnGroup> groups = new Seq<>();
+    private SpawnGroup expandedGroup;
 
     private Table table;
     private int start = 0;
@@ -177,84 +180,86 @@ public class WaveInfoDialog extends BaseDialog{
                         buildGroups();
                     }).height(46f).pad(-6f).padBottom(0f).row();
 
-                    t.table(spawns -> {
-                        spawns.field("" + (group.begin + 1), TextFieldFilter.digitsOnly, text -> {
-                            if(Strings.canParsePositiveInt(text)){
-                                group.begin = Strings.parseInt(text) - 1;
-                                updateWaves();
-                            }
-                        }).width(100f);
-                        spawns.add("@waves.to").padLeft(4).padRight(4);
-                        spawns.field(group.end == never ? "" : (group.end + 1) + "", TextFieldFilter.digitsOnly, text -> {
-                            if(Strings.canParsePositiveInt(text)){
-                                group.end = Strings.parseInt(text) - 1;
-                                updateWaves();
-                            }else if(text.isEmpty()){
-                                group.end = never;
-                                updateWaves();
-                            }
-                        }).width(100f).get().setMessageText("∞");
-                    }).row();
+                    if(expandedGroup == group){
+                        t.table(spawns -> {
+                            spawns.field("" + (group.begin + 1), TextFieldFilter.digitsOnly, text -> {
+                                if(Strings.canParsePositiveInt(text)){
+                                    group.begin = Strings.parseInt(text) - 1;
+                                    updateWaves();
+                                }
+                            }).width(100f);
+                            spawns.add("@waves.to").padLeft(4).padRight(4);
+                            spawns.field(group.end == never ? "" : (group.end + 1) + "", TextFieldFilter.digitsOnly, text -> {
+                                if(Strings.canParsePositiveInt(text)){
+                                    group.end = Strings.parseInt(text) - 1;
+                                    updateWaves();
+                                }else if(text.isEmpty()){
+                                    group.end = never;
+                                    updateWaves();
+                                }
+                            }).width(100f).get().setMessageText("∞");
+                        }).row();
 
-                    t.table(p -> {
-                        p.add("@waves.every").padRight(4);
-                        p.field(group.spacing + "", TextFieldFilter.digitsOnly, text -> {
-                            if(Strings.canParsePositiveInt(text) && Strings.parseInt(text) > 0){
-                                group.spacing = Strings.parseInt(text);
-                                updateWaves();
-                            }
-                        }).width(100f);
-                        p.add("@waves.waves").padLeft(4);
-                    }).row();
+                        t.table(p -> {
+                            p.add("@waves.every").padRight(4);
+                            p.field(group.spacing + "", TextFieldFilter.digitsOnly, text -> {
+                                if(Strings.canParsePositiveInt(text) && Strings.parseInt(text) > 0){
+                                    group.spacing = Strings.parseInt(text);
+                                    updateWaves();
+                                }
+                            }).width(100f);
+                            p.add("@waves.waves").padLeft(4);
+                        }).row();
 
-                    t.table(a -> {
-                        a.field(group.unitAmount + "", TextFieldFilter.digitsOnly, text -> {
-                            if(Strings.canParsePositiveInt(text)){
-                                group.unitAmount = Strings.parseInt(text);
-                                updateWaves();
-                            }
-                        }).width(80f);
+                        t.table(a -> {
+                            a.field(group.unitAmount + "", TextFieldFilter.digitsOnly, text -> {
+                                if(Strings.canParsePositiveInt(text)){
+                                    group.unitAmount = Strings.parseInt(text);
+                                    updateWaves();
+                                }
+                            }).width(80f);
 
-                        a.add(" + ");
-                        a.field(Strings.fixed(Math.max((Mathf.zero(group.unitScaling) ? 0 : 1f / group.unitScaling), 0), 2), TextFieldFilter.floatsOnly, text -> {
-                            if(Strings.canParsePositiveFloat(text)){
-                                group.unitScaling = 1f / Strings.parseFloat(text);
-                                updateWaves();
-                            }
-                        }).width(80f);
-                        a.add("@waves.perspawn").padLeft(4);
-                    }).row();
+                            a.add(" + ");
+                            a.field(Strings.fixed(Math.max((Mathf.zero(group.unitScaling) ? 0 : 1f / group.unitScaling), 0), 2), TextFieldFilter.floatsOnly, text -> {
+                                if(Strings.canParsePositiveFloat(text)){
+                                    group.unitScaling = 1f / Strings.parseFloat(text);
+                                    updateWaves();
+                                }
+                            }).width(80f);
+                            a.add("@waves.perspawn").padLeft(4);
+                        }).row();
 
-                    t.table(a -> {
-                        a.field(group.max + "", TextFieldFilter.digitsOnly, text -> {
-                            if(Strings.canParsePositiveInt(text)){
-                                group.max = Strings.parseInt(text);
-                                updateWaves();
-                            }
-                        }).width(80f);
+                        t.table(a -> {
+                            a.field(group.max + "", TextFieldFilter.digitsOnly, text -> {
+                                if(Strings.canParsePositiveInt(text)){
+                                    group.max = Strings.parseInt(text);
+                                    updateWaves();
+                                }
+                            }).width(80f);
 
-                        a.add("@waves.max").padLeft(5);
-                    }).row();
+                            a.add("@waves.max").padLeft(5);
+                        }).row();
 
-                    t.table(a -> {
-                        a.field((int)group.shields + "", TextFieldFilter.digitsOnly, text -> {
-                            if(Strings.canParsePositiveInt(text)){
-                                group.shields = Strings.parseInt(text);
-                                updateWaves();
-                            }
-                        }).width(80f);
+                        t.table(a -> {
+                            a.field((int)group.shields + "", TextFieldFilter.digitsOnly, text -> {
+                                if(Strings.canParsePositiveInt(text)){
+                                    group.shields = Strings.parseInt(text);
+                                    updateWaves();
+                                }
+                            }).width(80f);
 
-                        a.add(" + ");
-                        a.field((int)group.shieldScaling + "", TextFieldFilter.digitsOnly, text -> {
-                            if(Strings.canParsePositiveInt(text)){
-                                group.shieldScaling = Strings.parseInt(text);
-                                updateWaves();
-                            }
-                        }).width(80f);
-                        a.add("@waves.shields").padLeft(4);
-                    }).row();
+                            a.add(" + ");
+                            a.field((int)group.shieldScaling + "", TextFieldFilter.digitsOnly, text -> {
+                                if(Strings.canParsePositiveInt(text)){
+                                    group.shieldScaling = Strings.parseInt(text);
+                                    updateWaves();
+                                }
+                            }).width(80f);
+                            a.add("@waves.shields").padLeft(4);
+                        }).row();
 
-                    t.check("@waves.guardian", b -> group.effect = (b ? StatusEffects.boss : null)).padTop(4).update(b -> b.setChecked(group.effect == StatusEffects.boss)).padBottom(8f);
+                        t.check("@waves.guardian", b -> group.effect = (b ? StatusEffects.boss : null)).padTop(4).update(b -> b.setChecked(group.effect == StatusEffects.boss)).padBottom(8f);
+                    }
                 }).width(340f).pad(8);
 
                 table.row();

--- a/core/src/mindustry/editor/WaveInfoDialog.java
+++ b/core/src/mindustry/editor/WaveInfoDialog.java
@@ -70,6 +70,12 @@ public class WaveInfoDialog extends BaseDialog{
                 buildGroups();
                 dialog.hide();
             }));
+            dialog.cont.row();
+            dialog.cont.button("@clear", () -> ui.showConfirm("@confirm", "@settings.clear.confirm", () -> {
+                groups.clear();
+                buildGroups();
+                dialog.hide();
+            }));
             dialog.show();
         }).size(270f, 64f);
 

--- a/core/src/mindustry/editor/WaveInfoDialog.java
+++ b/core/src/mindustry/editor/WaveInfoDialog.java
@@ -291,6 +291,7 @@ public class WaveInfoDialog extends BaseDialog{
                 if(++i % 3 == 0) p.row();
             }
         });
+        dialog.addCloseButton();
         dialog.show();
     }
 

--- a/core/src/mindustry/editor/WaveInfoDialog.java
+++ b/core/src/mindustry/editor/WaveInfoDialog.java
@@ -165,6 +165,7 @@ public class WaveInfoDialog extends BaseDialog{
 
                         b.add().growX();
 
+                        b.button(Icon.unitsSmall, () -> showUpdate(group)).pad(-6).size(46f);
                         b.button(Icon.cancel, () -> {
                             groups.remove(group);
                             table.getCell(t).pad(0f);

--- a/core/src/mindustry/editor/WaveInfoDialog.java
+++ b/core/src/mindustry/editor/WaveInfoDialog.java
@@ -145,6 +145,7 @@ public class WaveInfoDialog extends BaseDialog{
                 SpawnGroup newGroup = new SpawnGroup(lastType);
                 groups.add(newGroup);
                 expandedGroup = newGroup;
+                showUpdate(newGroup);
                 buildGroups();
             }).growX().height(70f);
         }), new Label("@waves.none"){{


### PR DESCRIPTION
A few quality of life UI changes to the wave editor to make it less of a pain to work with:
- Units group by type, and are sorted in order of increasing health. This roughly corresponds with their strength and is better than simply retaining insertion order.
- The unit editing panels are now hidden unless clicked on so you can switch between different units more easily, as opposed to having to scroll. Changing the spawn group unit type has a dedicated button now:
![image](https://user-images.githubusercontent.com/62061444/130370907-469881d2-5570-4d3d-957b-48e26447a990.png)
- There is a clear button in the edit menu added. It does a confirmation to prevent accidental wave clearing.
- There is a back button in the unit selection menu.
- The buttons for removing a spawn group and for changing the unit are clear because bordered double buttons looked very weird.

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
