### PR TITLE
Schematic Button in Menu

### DIFF
--- a/core/src/mindustry/ui/fragments/MenuFragment.java
+++ b/core/src/mindustry/ui/fragments/MenuFragment.java
@@ -54,18 +54,21 @@ public class MenuFragment extends Fragment{
         if(mobile){
             parent.fill(c -> c.bottom().left().button("", Styles.infot, ui.about::show).size(84, 45).name("info"));
             parent.fill(c -> c.bottom().right().button("", Styles.discordt, ui.discord::show).size(84, 45).name("discord"));
-        }else if(becontrol.active()){
-            parent.fill(c -> c.bottom().right().button("@be.check", Icon.refresh, () -> {
-                ui.loadfrag.show();
-                becontrol.checkUpdate(result -> {
-                    ui.loadfrag.hide();
-                    if(!result){
-                        ui.showInfo("@be.noupdates");
-                    }
-                });
-            }).size(200, 60).name("becheck").update(t -> {
-                t.getLabel().setColor(becontrol.isUpdateAvailable() ? Tmp.c1.set(Color.white).lerp(Pal.accent, Mathf.absin(5f, 1f)) : Color.white);
-            }));
+        }else{
+            parent.fill(c -> c.bottom().left().button("@schematics", Icon.paste, ui.schematics::show).size(180, 60).name("schematics"));
+            if(becontrol.active()){
+                parent.fill(c -> c.bottom().right().button("@be.check", Icon.refresh, () -> {
+                    ui.loadfrag.show();
+                    becontrol.checkUpdate(result -> {
+                        ui.loadfrag.hide();
+                        if(!result){
+                            ui.showInfo("@be.noupdates");
+                        }
+                    });
+                }).size(200, 60).name("becheck").update(t -> {
+                    t.getLabel().setColor(becontrol.isUpdateAvailable() ? Tmp.c1.set(Color.white).lerp(Pal.accent, Mathf.absin(5f, 1f)) : Color.white);
+                }));
+            }
         }
 
         String versionText = ((Version.build == -1) ? "[#fc8140aa]" : "[#ffffffba]") + Version.combined();
@@ -165,8 +168,6 @@ public class MenuFragment extends Fragment{
                 ),
                 new Buttoni("@editor", Icon.terrain, () -> checkPlay(ui.maps::show)), steam ? new Buttoni("@workshop", Icon.steam, platform::openWorkshop) : null,
                 new Buttoni("@mods", Icon.book, ui.mods::show),
-                //not enough space for this button
-                //new Buttoni("@schematics", Icon.paste, ui.schematics::show),
                 new Buttoni("@settings", Icon.settings, ui.settings::show),
                 new Buttoni("@about.button", Icon.info, ui.about::show),
                 new Buttoni("@quit", Icon.exit, Core.app::exit)


### PR DESCRIPTION
I saw the disabled "**schematics**" button in `menuFragment.java` while I'm browsing the source code, commented "**not enough space**", and so I move it to the bottom left of the screen, the button is quite small, but big enough that text fits.

the bottom left may be the candidate place for discord button, and I just... stole it... now discord button has no place to go in desktop now, sadge :( (I tried placing the discord button next to the schematic button, didn't work, can't modify the exact placement of the button, I can only modify what edge it goes)

![full](https://user-images.githubusercontent.com/85090668/130436636-9e6b69a5-be03-4e53-98a1-3513524206db.png)
![button](https://user-images.githubusercontent.com/85090668/130436734-e6a3f1c5-23be-4c80-902c-fe641b2d535d.png)
**Note:** didn't add it to mobile (stull the same), as it'd be ugly and not symmetrical with odd number of 9 buttons, and I don't want to bother waste several hours to download android apk compile things just to test, ~~and I play on desktop~~


~~my grammar is broken today, and so do my braincells.~~

---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
