### PR TITLE
Wave UI 2: Electric Boogaloo

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -396,6 +396,7 @@ waves.invalid = Invalid waves in clipboard.
 waves.copied = Waves copied.
 waves.none = No enemies defined.\nNote that empty wave layouts will automatically be replaced with the default layout.
 waves.sort = Sort By
+waves.sort.reverse = Reverse Sort
 waves.sort.begin = Begin
 waves.sort.totals = Totals
 waves.sort.health = Health

--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -655,6 +655,7 @@ status.sapped.name = Sapped
 status.electrified.name = Electrified
 status.spore-slowed.name = Spore Slowed
 status.tarred.name = Tarred
+status.overdrive.name = Overdrive
 status.overclock.name = Overclock
 status.shocked.name = Shocked
 status.blasted.name = Blasted

--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -395,6 +395,11 @@ waves.load = Load from Clipboard
 waves.invalid = Invalid waves in clipboard.
 waves.copied = Waves copied.
 waves.none = No enemies defined.\nNote that empty wave layouts will automatically be replaced with the default layout.
+waves.sort = Sort By
+waves.sort.begin = Begin
+waves.sort.totals = Totals
+waves.sort.health = Health
+waves.sort.type = Type
 
 #these are intentionally in lower case
 wavemode.counts = counts

--- a/core/src/mindustry/editor/WaveInfoDialog.java
+++ b/core/src/mindustry/editor/WaveInfoDialog.java
@@ -33,6 +33,7 @@ public class WaveInfoDialog extends BaseDialog{
     private UnitType lastType = UnitTypes.dagger;
     private StatusEffect lastEffect = StatusEffects.none;
     private Sort sort = Sort.begin;
+    private boolean reverseSort = false;
     private float updateTimer, updatePeriod = 1f;
     private WaveGraph graph = new WaveGraph();
 
@@ -45,7 +46,7 @@ public class WaveInfoDialog extends BaseDialog{
         addCloseListener();
 
         onResize(this::setup);
-        buttons.button(Icon.filterSmall, () -> {
+        buttons.button(Icon.filter, () -> {
             BaseDialog dialog = new BaseDialog("@waves.sort");
             dialog.setFillParent(false);
             dialog.cont.defaults().size(210f, 64f);
@@ -69,6 +70,11 @@ public class WaveInfoDialog extends BaseDialog{
                 dialog.hide();
                 buildGroups();
             });
+            dialog.row();
+            dialog.check("@waves.sort.reverse", b -> reverseSort = (b ? true : false)).padTop(4).update(b -> {
+                b.setChecked(reverseSort == true);
+                buildGroups();
+            }).padBottom(8f);
             dialog.addCloseButton();
             dialog.show();
             buildGroups();
@@ -198,10 +204,14 @@ public class WaveInfoDialog extends BaseDialog{
         table.margin(10f);
 
         if(groups != null){
-            if(sort == Sort.begin) groups.sort(g -> g.begin);
-            if(sort == Sort.totals) groups.sort(g -> g.unitAmount);
-            if(sort == Sort.health) groups.sort(g -> g.type.health);
-            if(sort == Sort.type) groups.sort(Comparator.comparing(g -> g.type));
+            if(sort == Sort.begin) groups.sort(g -> g.begin * (reverseSort ? -1 : 1));
+            if(sort == Sort.totals) groups.sort(g -> g.unitAmount * (reverseSort ? -1 : 1));
+            if(sort == Sort.health) groups.sort(g -> g.type.health * (reverseSort ? -1 : 1));
+            if(sort == Sort.type && reverseSort){
+                groups.sortComparing(g -> g.type).reverse();
+            }else if(sort == Sort.type){
+                 groups.sortComparing(g -> g.type);
+            }
 
             for(SpawnGroup group : groups){
                 table.table(Tex.button, t -> {

--- a/core/src/mindustry/editor/WaveInfoDialog.java
+++ b/core/src/mindustry/editor/WaveInfoDialog.java
@@ -18,8 +18,6 @@ import mindustry.type.*;
 import mindustry.ui.*;
 import mindustry.ui.dialogs.*;
 
-import java.util.*;
-
 import static mindustry.Vars.*;
 import static mindustry.game.SpawnGroup.*;
 
@@ -50,26 +48,13 @@ public class WaveInfoDialog extends BaseDialog{
             BaseDialog dialog = new BaseDialog("@waves.sort");
             dialog.setFillParent(false);
             dialog.cont.defaults().size(210f, 64f);
-            dialog.cont.button("@waves.sort.begin", () -> {
-                sort = Sort.begin;
-                dialog.hide();
-                buildGroups();
-            });
-            dialog.cont.button("@waves.sort.totals", () -> {
-                sort = Sort.totals;
-                dialog.hide();
-                buildGroups();
-            });
-            dialog.cont.button("@waves.sort.health", () -> {
-                sort = Sort.health;
-                dialog.hide();
-                buildGroups();
-            });
-            dialog.cont.button("@waves.sort.type", () -> {
-                sort = Sort.type;
-                dialog.hide();
-                buildGroups();
-            });
+            for(Sort s : Sort.values()){
+                dialog.cont.button("@waves.sort." + s, () -> {
+                    sort = s;
+                    dialog.hide();
+                    buildGroups();
+                });
+            }
             dialog.row();
             dialog.check("@waves.sort.reverse", b -> reverseSort = (b ? true : false)).padTop(4).update(b -> {
                 b.setChecked(reverseSort == true);
@@ -204,14 +189,11 @@ public class WaveInfoDialog extends BaseDialog{
         table.margin(10f);
 
         if(groups != null){
-            if(sort == Sort.begin) groups.sort(g -> g.begin * (reverseSort ? -1 : 1));
-            if(sort == Sort.totals) groups.sort(g -> g.unitAmount * (reverseSort ? -1 : 1));
-            if(sort == Sort.health) groups.sort(g -> g.type.health * (reverseSort ? -1 : 1));
-            if(sort == Sort.type && reverseSort){
-                groups.sortComparing(g -> g.type).reverse();
-            }else if(sort == Sort.type){
-                 groups.sortComparing(g -> g.type);
-            }
+            if(sort == Sort.begin) groups.sort(g -> g.begin);
+            if(sort == Sort.totals) groups.sort(g -> g.unitAmount);
+            if(sort == Sort.health) groups.sort(g -> g.type.health);
+            if(sort == Sort.type) groups.sortComparing(g -> g.type);
+            if(reverseSort) groups.reverse();
 
             for(SpawnGroup group : groups){
                 table.table(Tex.button, t -> {


### PR DESCRIPTION
Unofficial Sequel of #5837, Improved wave UI again... for good(?), added a status effect chooser, which will applies the chosen status effect to that wave group in all waves.
also added filter button, for filtering units in _**Begin, Health, Totals and Type**_, which gives mapmakers a nice time-saving choice.

![full](https://user-images.githubusercontent.com/85090668/130610577-623a286d-9792-4f20-8471-aad826cd57e1.png)
full pic

![button1](https://user-images.githubusercontent.com/85090668/130610625-9cf2eab4-0941-44cb-ba1d-6ec2eb115e9f.png)
status effect chooser, presented in the pic as logic icon.

![button2](https://user-images.githubusercontent.com/85090668/130610854-836a64db-d408-42c5-a4cc-0dea15dba8ad.png)
sorting filter, presented in the pic as filter icon.

![Screenshot (79)](https://user-images.githubusercontent.com/85090668/130611105-14d76492-8dc5-4769-ad3f-8114cc8a48c4.png)
full unit bar. the crawler in the pic has **Overclock** status effect, that's why there's overclock icon next to the unit icon.

https://user-images.githubusercontent.com/85090668/130610523-4a842dee-3985-4c50-817b-09bb54a1ec04.mp4

NOTE: idk why in the video, the guardian icon is missing, might be my computer being weird.

obviously, the code is not the best, to be honest, hence why I made this PR as a draft.
might post updates here later when some progresses is done

TODO and ideas:
- [x] make the code more compact and reduce the amount of space-eating if/else if possible, abuse ternary ? : operator.
- [x] add the "**Overdrive**" status effect back, as it fits right in for this PR.
- [ ] try to make the filter icon stay next to or near the "**add...**" button if possible, I tried but it's very buggy smh.
- [ ] If possible, try to fix/improve the other mechanics in the wave dialog.
 _
- [x] maybe use big filter icon for easier identification?
- [x] maybe option for filter to reverse sorting?

---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
