### PR TITLE
Bigger Schematic select limit by Shifting

### DIFF
--- a/core/src/mindustry/game/Schematics.java
+++ b/core/src/mindustry/game/Schematics.java
@@ -333,7 +333,7 @@ public class Schematics implements Loadable{
 
     /** Creates a schematic from a world selection. */
     public Schematic create(int x, int y, int x2, int y2){
-        NormalizeResult result = Placement.normalizeArea(x, y, x2, y2, 0, false, maxSchematicSize);
+        NormalizeResult result = Placement.normalizeArea(x, y, x2, y2, 0, false, maxSchematicSize * (Core.input.keyDown(Binding.boost) ? 3 : 1));
         x = result.x;
         y = result.y;
         x2 = result.x2;

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -111,7 +111,7 @@ public class DesktopInput extends InputHandler{
         }
 
         if(Core.input.keyDown(Binding.schematic_select) && !Core.scene.hasKeyboard() && mode != breaking){
-            drawSelection(schemX, schemY, cursorX, cursorY, Vars.maxSchematicSize);
+            drawSelection(schemX, schemY, cursorX, cursorY, Vars.maxSchematicSize * (Core.input.keyDown(Binding.boost) ? 3 : 1));
         }
 
         Draw.reset();
@@ -488,6 +488,10 @@ public class DesktopInput extends InputHandler{
                 mode = none;
             }else if(!selectRequests.isEmpty()){
                 flushRequests(selectRequests);
+                if(selectRequests.size >= Vars.maxSchematicSize * Vars.maxSchematicSize){
+                    selectRequests.clear();
+                    lastSchematic = null;
+                }
             }else if(isPlacing()){
                 selectX = cursorX;
                 selectY = cursorY;


### PR DESCRIPTION
people complain about the max schematic size a lot, and so I implemented it the way without touching other things(?)
to increase the limit, simply pressing shift (boost keybind) and it will increase from 32 to 96 (x3)
the maximum unshifted limit is still 32, tho.

and schematics that is bigger (have more blocks) than 32x32 will not be selected again after placing, like in mobile, to 
prevent CPU destruction (yes, I tried, my fps reduced significantly from 300+ to 10 fps)
32x32 is counted in blocks, that means hollow schems will be selected again, even if it's bigger than solid schems

https://user-images.githubusercontent.com/85090668/130995311-af3cb9aa-9380-4bf3-b78d-661b9ca1e858.mp4

this one is solid, so the selection is not carried over.

https://user-images.githubusercontent.com/85090668/130995849-4eb84ab5-4bd1-455e-9408-fe7ce8b43f6f.mp4

this one is hollow, so the selection is carried over to the next one.

---
### **_For Mobile:_** I have a plan for it, just that I can't test the code, but I'll try, if possible.

---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
