### PR TITLE
Make Drills don't show ores when under solid blocks

### DIFF
--- a/core/src/mindustry/world/blocks/production/Drill.java
+++ b/core/src/mindustry/world/blocks/production/Drill.java
@@ -122,7 +122,7 @@ public class Drill extends Block{
 
         countOre(tile);
 
-        if(returnItem != null){
+        if(returnItem != null && !tile.solid()){
             float width = drawPlaceText(Core.bundle.formatFloat("bar.drillspeed", 60f / (drillTime + hardnessDrillMultiplier * returnItem.hardness) * returnCount, 2), x, y, valid);
             float dx = x * tilesize + offset - width/2f - 4f, dy = y * tilesize + offset + size * tilesize / 2f + 5, s = iconSmall / 4f;
             Draw.mixcol(Color.darkGray, 1f);


### PR DESCRIPTION
ok quick PR
nothing interesting here, just some quick fix to the annoying drill speed that show ores even when under solid blocks.
the pic below is not that misleading, though in other maps...

### _**before**_
![before](https://user-images.githubusercontent.com/85090668/131013631-fb1487da-3b00-4e6f-8e2d-ed470433074a.png)

### _**after**_
![after](https://user-images.githubusercontent.com/85090668/131013787-75571c62-a29a-440f-93dd-05906052cce0.png)



If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
