### PR TITLE
Add item selection for drills

### DIFF
--- a/core/src/mindustry/world/blocks/production/Drill.java
+++ b/core/src/mindustry/world/blocks/production/Drill.java
@@ -4,6 +4,7 @@ import arc.*;
 import arc.graphics.*;
 import arc.graphics.g2d.*;
 import arc.math.*;
+import arc.scene.ui.layout.Table;
 import arc.struct.*;
 import arc.util.*;
 import arc.util.io.*;
@@ -18,6 +19,7 @@ import mindustry.logic.*;
 import mindustry.type.*;
 import mindustry.ui.*;
 import mindustry.world.*;
+import mindustry.world.blocks.ItemSelection;
 import mindustry.world.blocks.environment.*;
 import mindustry.world.meta.*;
 
@@ -71,6 +73,15 @@ public class Drill extends Block{
         hasItems = true;
         ambientSound = Sounds.drill;
         ambientSoundVolume = 0.018f;
+        saveConfig = true;
+        configurable = true;
+
+        config(Item.class, (DrillBuild tile, Item item) -> {
+            countOre(tile.tile);
+            if(!itemArray.contains(item)) return; // ignore processor-configured invalid items
+            tile.dominantItem = item;
+        });
+        configClear((DrillBuild tile) -> tile.dominantItem = returnItem);
     }
 
     @Override
@@ -208,6 +219,30 @@ public class Drill extends Block{
 
         public int dominantItems;
         public Item dominantItem;
+
+        @Override
+        public boolean interactable(Team team){
+            if(!super.interactable(team)){
+                return false;
+            }
+            countOre(tile);
+            return itemArray.size > 1;
+        }
+
+        @Override
+        public boolean onConfigureTileTapped(Building other){
+            if(this == other){
+                deselect();
+                configure(null);
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public void buildConfiguration(Table table){
+            ItemSelection.buildTable(table, itemArray, () -> dominantItem, this::configure);
+        }
 
         @Override
         public boolean shouldConsume(){


### PR DESCRIPTION
Adds an interface for selecting the output drill item in cases when output ore variant count >1

![amogus](https://user-images.githubusercontent.com/55407440/131029159-d4912deb-c7be-4eb7-9f36-e5e1118c022b.gif)

---

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
