### PR TITLE
Fixed incorrect work of TextureRegion.found() when creating icons

### DIFF
--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -226,7 +226,7 @@ public class Mods implements Loadable{
             //dummy texture atlas that returns the 'shadow' regions; used for mod loading
             Core.atlas = new TextureAtlas(){
                 {
-                    //needed for the correct method of the found() method in the TextureRegion
+                    //needed for the correct operation of the found() method in the TextureRegion
                     error = shadow.find("error");
                 }
 


### PR DESCRIPTION
At the moment, due to the incorrect operation of the found method, team regions are generated in AtlasRegion for all mod blocks.
![image](https://user-images.githubusercontent.com/58040045/131146093-68b5c05a-bf19-44e4-b677-6dba35962444.png)

###### (the screenshot was taken using my mod and it shows a cropped page from the atlas) ######
Because before running createIcons, a new TextureAtlas is set in Mods.loadSync () and its error region is null, then the TextureRegion method.
found () always returns true regardless of whether the region was actually found or not.


- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.