### PR TITLE
Make navals able to be wet by Liquid Turrets

### DIFF
--- a/core/src/mindustry/entities/comp/StatusComp.java
+++ b/core/src/mindustry/entities/comp/StatusComp.java
@@ -109,7 +109,7 @@ abstract class StatusComp implements Posc, Flyingc{
     @Override
     public void update(){
         Floor floor = floorOn();
-        if(isGrounded() && !type.hovering){
+        if(this instanceof WaterMovec ? floor.status != StatusEffects.wet : isGrounded() && !type.hovering){
             //apply effect
             apply(floor.status, floor.statusDuration);
         }

--- a/core/src/mindustry/type/UnitType.java
+++ b/core/src/mindustry/type/UnitType.java
@@ -316,7 +316,6 @@ public class UnitType extends UnlockableContent{
         if(example instanceof WaterMovec){
             canDrown = false;
             omniMovement = false;
-            immunities.add(StatusEffects.wet);
         }
 
         if(lightRadius == -1){


### PR DESCRIPTION
this PR removes wet immunity from naval units and make floors not apply status effect on naval units if the floor status effect is wet. 
but why? because the bottom part of the ship is touching the water, but the top part isn't, and obviously, not designed to be in touch with water. Wave/Tsunami/any Liquid turret sprays through the top part of the ship, which obviously, would damage the system inside.

nonsense explaining aside, this would make arc + wave combo viable on naval units.

---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
