### PR TITLE
Update WaveSpawner.java - make ground units not spawn on deep water

### DIFF
--- a/core/src/mindustry/ai/WaveSpawner.java
+++ b/core/src/mindustry/ai/WaveSpawner.java
@@ -74,7 +74,13 @@ public class WaveSpawner{
                     for(int i = 0; i < spawned; i++){
                         Unit unit = group.createUnit(state.rules.waveTeam, state.wave - 1);
                         unit.set(spawnX + Mathf.range(spread), spawnY + Mathf.range(spread));
-                        spawnEffect(unit);
+                        
+                        Tile on = world.tileWorld(spawnX, spawnY);
+                        if(!(unit instanceof WaterMovec) && on != null && on.floor().isDeep()) {
+                            unit.remove();
+                        }else{
+                            spawnEffect(unit);
+                        }
                     }
                 });
             }else{


### PR DESCRIPTION
expected behavior:
 - water units spawn on deep water without issue
 - ground units do not spawn on deep water

current behaviour:
 - ground units spawn on deep water and drown immediately

 this makes so ground units do not spawn on deep water at all ( tested )

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
