### PR TITLE
Now, when changing a planet, the list of planets is updated.

### DIFF
--- a/core/src/mindustry/ui/dialogs/PlanetDialog.java
+++ b/core/src/mindustry/ui/dialogs/PlanetDialog.java
@@ -518,7 +518,10 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
                             pt.button(planet.localizedName, Styles.clearTogglet, () -> {
                                 selected = null;
                                 launchSector = null;
-                                renderer.planets.planet = planet;
+                                if (renderer.planets.planet!=planet){
+                                    renderer.planets.planet = planet;
+                                    rebuildList();
+                                }
                                 settings.put("lastplanet", planet.name);
                             }).width(200).height(40).growX().update(bb -> bb.setChecked(renderer.planets.planet == planet));
                             pt.row();


### PR DESCRIPTION
At the moment, when choosing a planet, the list of sectors is not updated. I fixed it.

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
