### PR TITLE
Input liquid drawing for `DrawLiquid` and `DrawMixer`

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -609,7 +609,7 @@ public class Blocks implements ContentList{
             rotate = false;
             solid = true;
             outputsLiquid = true;
-            drawer = new DrawMixer();
+            drawer = new DrawMixer(true);
 
             consumes.power(1f);
             consumes.item(Items.titanium);

--- a/core/src/mindustry/world/draw/DrawLiquid.java
+++ b/core/src/mindustry/world/draw/DrawLiquid.java
@@ -3,17 +3,35 @@ package mindustry.world.draw;
 import arc.*;
 import arc.graphics.g2d.*;
 import mindustry.graphics.*;
+import mindustry.type.*;
 import mindustry.world.*;
 import mindustry.world.blocks.production.*;
 import mindustry.world.blocks.production.GenericCrafter.*;
+import mindustry.world.consumers.*;
 
 public class DrawLiquid extends DrawBlock{
-    public TextureRegion liquid, top;
+    public TextureRegion inLiquid, liquid, top;
+    public boolean useOutputSprite = false;
+
+    public DrawLiquid(){
+    }
+
+    public DrawLiquid(boolean useOutputSprite){
+        this.useOutputSprite = useOutputSprite;
+    }
 
     @Override
     public void draw(GenericCrafterBuild build){
         Draw.rect(build.block.region, build.x, build.y);
         GenericCrafter type = (GenericCrafter)build.block;
+
+        if((inLiquid.found() || useOutputSprite) && type.consumes.has(ConsumeType.liquid)){
+            Liquid input = type.consumes.<ConsumeLiquid>get(ConsumeType.liquid).liquid;
+            Drawf.liquid(useOutputSprite ? liquid : inLiquid, build.x, build.y,
+                build.liquids.get(input) / type.liquidCapacity,
+                input.color
+            );
+        }
 
         if(type.outputLiquid != null && build.liquids.get(type.outputLiquid.liquid) > 0){
             Drawf.liquid(liquid, build.x, build.y,
@@ -29,6 +47,7 @@ public class DrawLiquid extends DrawBlock{
     public void load(Block block){
         top = Core.atlas.find(block.name + "-top");
         liquid = Core.atlas.find(block.name + "-liquid");
+        inLiquid = Core.atlas.find(block.name + "-input-liquid");
     }
 
     @Override

--- a/core/src/mindustry/world/draw/DrawMixer.java
+++ b/core/src/mindustry/world/draw/DrawMixer.java
@@ -2,18 +2,36 @@ package mindustry.world.draw;
 
 import arc.*;
 import arc.graphics.g2d.*;
+import mindustry.graphics.*;
+import mindustry.type.*;
 import mindustry.world.*;
 import mindustry.world.blocks.production.*;
 import mindustry.world.blocks.production.GenericCrafter.*;
+import mindustry.world.consumers.*;
 
 public class DrawMixer extends DrawBlock{
-    public TextureRegion liquid, top, bottom;
+    public TextureRegion inLiquid, liquid, top, bottom;
+    public boolean useOutputSprite;
+
+    public DrawMixer(){
+    }
+
+    public DrawMixer(boolean useOutputSprite){
+        this.useOutputSprite = useOutputSprite;
+    }
 
     @Override
     public void draw(GenericCrafterBuild build){
         float rotation = build.block.rotate ? build.rotdeg() : 0;
-
         Draw.rect(bottom, build.x, build.y, rotation);
+
+        if((inLiquid.found() || useOutputSprite) && build.block.consumes.has(ConsumeType.liquid)){
+            Liquid input = build.block.consumes.<ConsumeLiquid>get(ConsumeType.liquid).liquid;
+            Drawf.liquid(useOutputSprite ? liquid : inLiquid, build.x, build.y,
+                build.liquids.get(input) / build.block.liquidCapacity,
+                input.color
+            );
+        }
 
         if(build.liquids.total() > 0.001f){
             Draw.color(((GenericCrafter)build.block).outputLiquid.liquid.color);
@@ -27,6 +45,7 @@ public class DrawMixer extends DrawBlock{
 
     @Override
     public void load(Block block){
+        inLiquid = Core.atlas.find(block.name + "-input-liquid");
         liquid = Core.atlas.find(block.name + "-liquid");
         top = Core.atlas.find(block.name + "-top");
         bottom = Core.atlas.find(block.name + "-bottom");


### PR DESCRIPTION
Allows for adding a `-input-liquid` sprite to make a crafter show both input and output liquid. Set `useOutputSprite` to true if you want the input and output to use the same sprite.

For once I wasn't enslaved to make a pr.

https://user-images.githubusercontent.com/54301439/131385860-e697e0a8-5c45-400b-ba33-a81cefeb1eb0.mp4

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.

_omg a pr meep didn't just do on github and actually tested for once?_