### PR TITLE
Wave graph y axis refactor

### DIFF
--- a/core/src/mindustry/editor/WaveGraph.java
+++ b/core/src/mindustry/editor/WaveGraph.java
@@ -38,8 +38,14 @@ public class WaveGraph extends Table{
 
             lay.setText(font, "1");
 
+            int maxY = switch(mode){
+                case counts -> nextStep(max);
+                case health -> nextStep((int) maxHealth);
+                case totals -> nextStep(maxTotal);
+            };
+
             float fh = lay.height;
-            float offsetX = Scl.scl(30f), offsetY = Scl.scl(22f) + fh + Scl.scl(5f);
+            float offsetX = Scl.scl(lay.width * (maxY + "").length() * 2), offsetY = Scl.scl(22f) + fh + Scl.scl(5f);
 
             float graphX = x + offsetX, graphY = y + offsetY, graphW = width - offsetX, graphH = height - offsetY;
             float spacing = graphW / (values.length - 1);
@@ -53,7 +59,7 @@ public class WaveGraph extends Table{
 
                     for(int i = 0; i < values.length; i++){
                         int val = values[i][type.id];
-                        float cx = graphX + i*spacing, cy = graphY + val * graphH / max;
+                        float cx = graphX + i * spacing, cy = graphY + val * graphH / maxY;
                         Lines.linePoint(cx, cy);
                     }
 
@@ -69,7 +75,7 @@ public class WaveGraph extends Table{
                         sum += values[i][type.id];
                     }
 
-                    float cx = graphX + i*spacing, cy = graphY + sum * graphH / maxTotal;
+                    float cx = graphX + i * spacing, cy = graphY + sum * graphH / maxY;
                     Lines.linePoint(cx, cy);
                 }
 
@@ -84,7 +90,7 @@ public class WaveGraph extends Table{
                         sum += (type.health) * values[i][type.id];
                     }
 
-                    float cx = graphX + i*spacing, cy = graphY + sum * graphH / maxHealth;
+                    float cx = graphX + i * spacing, cy = graphY + sum * graphH / maxY;
                     Lines.linePoint(cx, cy);
                 }
 
@@ -92,19 +98,23 @@ public class WaveGraph extends Table{
             }
 
             //how many numbers can fit here
-            float totalMarks = (graphH - getMarginBottom() *2f) / (lay.height * 2);
+            float totalMarks = Mathf.clamp(maxY, 1, 10);
 
-            int markSpace = Math.max(1, Mathf.ceil(max / totalMarks));
+            int markSpace = Math.max(1, Mathf.ceil(maxY / totalMarks));
 
             Draw.color(Color.lightGray);
-            for(int i = 0; i < max; i += markSpace){
-                float cy = graphY + i * graphH / max, cx = graphX;
-                //Lines.line(cx, cy, cx + len, cy);
+            Draw.alpha(0.1f);
+
+            for(int i = 0; i < maxY; i += markSpace){
+                float cy = graphY + i * graphH / maxY, cx = graphX;
+
+                Lines.line(cx, cy, cx + graphW, cy);
 
                 lay.setText(font, "" + i);
 
                 font.draw("" + i, cx, cy + lay.height/2f, Align.right);
             }
+            Draw.alpha(1f);
 
             float len = Scl.scl(4f);
             font.setColor(Color.lightGray);
@@ -198,6 +208,23 @@ public class WaveGraph extends Table{
 
     Color color(UnitType type){
         return Tmp.c1.fromHsv(type.id / (float)Vars.content.units().size * 360f, 0.7f, 1f);
+    }
+
+    int nextStep(float value){
+        int order = 1;
+        while (order < value){
+            if (order * 2 > value) {
+                return order * 2;
+            }
+            if (order * 5 > value) {
+                return order * 5;
+            }
+            if (order * 10 > value){
+                return order * 10;
+            }
+            order *= 10;
+        }
+        return order;
     }
 
     enum Mode{

--- a/core/src/mindustry/editor/WaveGraph.java
+++ b/core/src/mindustry/editor/WaveGraph.java
@@ -40,7 +40,7 @@ public class WaveGraph extends Table{
 
             int maxY = switch(mode){
                 case counts -> nextStep(max);
-                case health -> nextStep((int) maxHealth);
+                case health -> nextStep((int)maxHealth);
                 case totals -> nextStep(maxTotal);
             };
 
@@ -212,14 +212,14 @@ public class WaveGraph extends Table{
 
     int nextStep(float value){
         int order = 1;
-        while (order < value){
-            if (order * 2 > value) {
+        while(order < value){
+            if(order * 2 > value){
                 return order * 2;
             }
-            if (order * 5 > value) {
+            if(order * 5 > value){
                 return order * 5;
             }
-            if (order * 10 > value){
+            if(order * 10 > value){
                 return order * 10;
             }
             order *= 10;

--- a/core/src/mindustry/editor/WaveGraph.java
+++ b/core/src/mindustry/editor/WaveGraph.java
@@ -112,7 +112,7 @@ public class WaveGraph extends Table{
 
                 lay.setText(font, "" + i);
 
-                font.draw("" + i, cx, cy + lay.height/2f, Align.right);
+                font.draw("" + i, cx, cy + lay.height / 2f, Align.right);
             }
             Draw.alpha(1f);
 
@@ -123,7 +123,7 @@ public class WaveGraph extends Table{
                 float cy = y + fh, cx = graphX + graphW / (values.length - 1) * i;
 
                 Lines.line(cx, cy, cx, cy + len);
-                if(i == values.length/2){
+                if(i == values.length / 2){
                     font.draw("" + (i + from + 1), cx, cy - Scl.scl(2f), Align.center);
                 }
             }
@@ -174,7 +174,7 @@ public class WaveGraph extends Table{
                 sum += spawned;
             }
             maxTotal = Math.max(maxTotal, sum);
-            maxHealth = Math.max(maxHealth,healthsum);
+            maxHealth = Math.max(maxHealth, healthsum);
         }
 
         ObjectSet<UnitType> usedCopy = new ObjectSet<>(used);


### PR DESCRIPTION
The main change is that the health and total graphs actually show the health and total amounts, as opposed to keeping the count amounts.

Preview:
![graph](https://user-images.githubusercontent.com/62061444/131951510-16f1d168-85fb-496e-8df5-2db47c238cf6.jpg)
Full changelog:
- `nextStep` obtains the next step in a `1 -> 2 -> 5 -> 10 -> 20...` sequence for cleaner graph intervals.
- `maxY` determines the maximum amount the Y value should reach.
- `maxY` also determines the amount of padding for the axis labels.
- The number of vertical sections in the graph are clamped to 10, which should be reasonable, as opposed to the relatively large amounts it reaches if the graph size is used.
- There is a mostly transparent horizontal line on each graph mark, for reference. It does not interfere with the graph itself much, but provides a nicer reference point compared to trying to guess where it is.
- Minor formatting fixes because spacing was strange for some reason.

---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
