### PR TITLE
Add hide all button for unit graphs

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -400,6 +400,7 @@ waves.sort.reverse = Reverse Sort
 waves.sort.begin = Begin
 waves.sort.health = Health
 waves.sort.type = Type
+waves.units.hide = Hide All
 
 #these are intentionally in lower case
 wavemode.counts = counts

--- a/core/src/mindustry/editor/WaveGraph.java
+++ b/core/src/mindustry/editor/WaveGraph.java
@@ -53,7 +53,7 @@ public class WaveGraph extends Table{
 
                     for(int i = 0; i < values.length; i++){
                         int val = values[i][type.id];
-                        float cx = graphX + i*spacing, cy = graphY + val * graphH / max;
+                        float cx = graphX + i * spacing, cy = graphY + val * graphH / max;
                         Lines.linePoint(cx, cy);
                     }
 
@@ -69,7 +69,7 @@ public class WaveGraph extends Table{
                         sum += values[i][type.id];
                     }
 
-                    float cx = graphX + i*spacing, cy = graphY + sum * graphH / maxTotal;
+                    float cx = graphX + i * spacing, cy = graphY + sum * graphH / maxTotal;
                     Lines.linePoint(cx, cy);
                 }
 
@@ -84,7 +84,7 @@ public class WaveGraph extends Table{
                         sum += (type.health) * values[i][type.id];
                     }
 
-                    float cx = graphX + i*spacing, cy = graphY + sum * graphH / maxHealth;
+                    float cx = graphX + i * spacing, cy = graphY + sum * graphH / maxHealth;
                     Lines.linePoint(cx, cy);
                 }
 
@@ -92,7 +92,7 @@ public class WaveGraph extends Table{
             }
 
             //how many numbers can fit here
-            float totalMarks = (graphH - getMarginBottom() *2f) / (lay.height * 2);
+            float totalMarks = (graphH - getMarginBottom() * 2f) / (lay.height * 2);
 
             int markSpace = Math.max(1, Mathf.ceil(max / totalMarks));
 
@@ -103,7 +103,7 @@ public class WaveGraph extends Table{
 
                 lay.setText(font, "" + i);
 
-                font.draw("" + i, cx, cy + lay.height/2f, Align.right);
+                font.draw("" + i, cx, cy + lay.height / 2f, Align.right);
             }
 
             float len = Scl.scl(4f);
@@ -113,7 +113,7 @@ public class WaveGraph extends Table{
                 float cy = y + fh, cx = graphX + graphW / (values.length - 1) * i;
 
                 Lines.line(cx, cy, cx, cy + len);
-                if(i == values.length/2){
+                if(i == values.length / 2){
                     font.draw("" + (i + from + 1), cx, cy - Scl.scl(2f), Align.center);
                 }
             }
@@ -164,7 +164,7 @@ public class WaveGraph extends Table{
                 sum += spawned;
             }
             maxTotal = Math.max(maxTotal, sum);
-            maxHealth = Math.max(maxHealth,healthsum);
+            maxHealth = Math.max(maxHealth, healthsum);
         }
 
         ObjectSet<UnitType> usedCopy = new ObjectSet<>(used);
@@ -172,10 +172,9 @@ public class WaveGraph extends Table{
         colors.clear();
         colors.left();
         colors.button("@waves.units.hide", Styles.fullTogglet, () -> {
-            if (hidden.size == usedCopy.size){
+            if(hidden.size == usedCopy.size){
                 hidden.clear();
-            }
-            else{
+            }else{
                 hidden.addAll(usedCopy);
             }
 

--- a/core/src/mindustry/editor/WaveGraph.java
+++ b/core/src/mindustry/editor/WaveGraph.java
@@ -171,6 +171,18 @@ public class WaveGraph extends Table{
 
         colors.clear();
         colors.left();
+        colors.button("@waves.units.hide", Styles.fullTogglet, () -> {
+            if (hidden.size == usedCopy.size){
+                hidden.clear();
+            }
+            else{
+                hidden.addAll(usedCopy);
+            }
+
+            used.clear();
+            used.addAll(usedCopy);
+            for(UnitType o : hidden) used.remove(o);
+        }).update(b -> b.setChecked(hidden.size == usedCopy.size)).height(32f).width(130f);
         colors.pane(t -> {
             t.left();
             for(UnitType type : used){


### PR DESCRIPTION
Add a button to hide all units. If all units are already hidden the button shows them instead. saves having to click each and every unit if you just want the graph for one unit:

https://user-images.githubusercontent.com/62061444/132044068-05057efc-5c41-4fe4-83ee-51d6bb3ea401.mp4

---
- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
