### PR TITLE
Censoring swear words on multiplayers + PlayerSwearEvent

### DIFF
--- a/core/src/mindustry/game/EventType.java
+++ b/core/src/mindustry/game/EventType.java
@@ -157,6 +157,16 @@ public class EventType{
         }
     }
 
+    public static class PlayerSwearEvent{
+        public final Player player;
+        public final String message;
+
+        public PlayerSwearEvent(Player player, String message){
+            this.player = player;
+            this.message = message;
+        }
+    }
+
     /** Called when a sector is conquered, e.g. a boss or base is defeated. */
     public static class SectorCaptureEvent{
         public final Sector sector;
@@ -432,7 +442,7 @@ public class EventType{
     public static class UnitSpawnEvent{
         public final Unit unit;
 
-        public UnitSpawnEvent(Unit unit) {
+        public UnitSpawnEvent(Unit unit){
             this.unit = unit;
         }
     }

--- a/core/src/mindustry/net/Administration.java
+++ b/core/src/mindustry/net/Administration.java
@@ -173,6 +173,10 @@ public class Administration{
         return Config.strict.bool();
     }
 
+    public boolean censorSwearWords(){
+        return Config.censorSwearing.bool();
+    }
+
     public boolean allowsCustomClients(){
         return Config.allowCustomClients.bool();
     }
@@ -464,6 +468,7 @@ public class Administration{
         logging("Whether to log everything to files.", true),
         strict("Whether strict mode is on - corrects positions and prevents duplicate UUIDs.", true),
         antiSpam("Whether spammers are automatically kicked and rate-limited.", headless),
+        censorSwearing("Whether swear words will be censored when messaging.", true),
         interactRateWindow("Block interaction rate limit window, in seconds.", 6),
         interactRateLimit("Block interaction rate limit.", 25),
         interactRateKick("How many times a player must interact inside the window to get kicked.", 60),


### PR DESCRIPTION
add a regex for censoring swear words in multiplayer (by default, you can turn censoring off, but why tho)
also add `PlayerSwearEvent` for future stats counting and plugin? hmm.
Feedback are welcome :D
if you want to add more censors, just add more words in the regex.

TODO & thoughts:
- [ ] numbers and symbols will be removed from the message if the message has swear words, gonna fix that.
- [ ] what about language/server-specific swear censor words? how would that work though
- [ ] censoring symbol should be based on swearing word's length

_**FILE CONTAINS EXPLICIT CONTENT, LOOK AT YOUR OWN RISK.**_

---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
