### PR TITLE
Update required MinGameVersion for mods

### DIFF
--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -782,7 +782,7 @@ public class Mods implements Loadable{
                 !skipModLoading() &&
                 Core.settings.getBool("mod-" + baseName + "-enabled", true) &&
                 Version.isAtLeast(meta.minGameVersion) &&
-                (meta.getMinMajor() >= 105 || headless)
+                (meta.getMinMajor() >= 130 || headless)
             ){
                 if(ios){
                     throw new ModLoadException("Java class mods are not supported on iOS.");
@@ -913,8 +913,8 @@ public class Mods implements Loadable{
 
         /** @return whether this mod is outdated, e.g. not compatible with v6. */
         public boolean isOutdated(){
-            //must be at least 105 to indicate v6 compat
-            return getMinMajor() < 105;
+            //must be at least 130 to indicate v7 compat
+            return getMinMajor() < 130;
         }
 
         public int getMinMajor(){


### PR DESCRIPTION
The internal variables changed in v7 break most (if not all) v6 mods; updating the minimum game version requirement for mods must now happen.


Summary of a conversation I had with someone on Discord about it concerning one of my mods...
![image](https://user-images.githubusercontent.com/19158169/132414507-559b48c3-ce54-44f6-a2b9-84ad585571e9.png)
![image](https://user-images.githubusercontent.com/19158169/132414535-3f2f7c2d-49a1-4bbb-a3df-9b88f5bf616e.png)
![image](https://user-images.githubusercontent.com/19158169/132414572-3664be24-e425-40db-ac27-e01082a456f6.png)
![image](https://user-images.githubusercontent.com/19158169/132414630-849d0063-9a0f-4ba5-91b8-395ad86dbd77.png)


- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
