### PR TITLE
Add a copy button to spawn groups

### DIFF
--- a/core/src/mindustry/editor/WaveInfoDialog.java
+++ b/core/src/mindustry/editor/WaveInfoDialog.java
@@ -222,7 +222,7 @@ public class WaveInfoDialog extends BaseDialog{
                             groups.remove(group);
                             table.getCell(t).pad(0f);
                             t.remove();
-                            updateWaves();
+                            buildGroups();
                         }).pad(-6).size(46f).padRight(-12f);
                     }, () -> {
                         expandedGroup = expandedGroup == group ? null : group;

--- a/core/src/mindustry/editor/WaveInfoDialog.java
+++ b/core/src/mindustry/editor/WaveInfoDialog.java
@@ -207,14 +207,10 @@ public class WaveInfoDialog extends BaseDialog{
                         b.label(() -> (group.begin + 1) + "").color(Color.lightGray).minWidth(45f).labelAlign(Align.left).left();
 
                         b.button(Icon.copySmall, Styles.emptyi, () -> {
-                            try{
-                                SpawnGroup newGroup = group.clone();
-                                expandedGroup = newGroup;
-                                groups.add(newGroup);
-                                buildGroups();
-                            }catch(CloneNotSupportedException e){
-                                Log.err(e);
-                            }
+                            SpawnGroup newGroup = group.copy();
+                            expandedGroup = newGroup;
+                            groups.add(newGroup);
+                            buildGroups();
                         }).pad(-6).size(46f);
 
                         b.button(group.effect != null && group.effect != StatusEffects.none ?

--- a/core/src/mindustry/editor/WaveInfoDialog.java
+++ b/core/src/mindustry/editor/WaveInfoDialog.java
@@ -205,6 +205,13 @@ public class WaveInfoDialog extends BaseDialog{
 
                         b.label(() -> (group.begin + 1) + "").color(Color.lightGray).minWidth(45f).labelAlign(Align.left).left();
 
+                        b.button(Icon.copySmall, Styles.emptyi, () -> {
+                            SpawnGroup newGroup = group.copy();
+                            expandedGroup = newGroup;
+                            groups.add(newGroup);
+                            buildGroups();
+                        }).pad(-6).size(46f);
+
                         b.button(group.effect != null && group.effect != StatusEffects.none ?
                             new TextureRegionDrawable(group.effect.uiIcon) :
                             Icon.logicSmall,

--- a/core/src/mindustry/editor/WaveInfoDialog.java
+++ b/core/src/mindustry/editor/WaveInfoDialog.java
@@ -207,10 +207,14 @@ public class WaveInfoDialog extends BaseDialog{
                         b.label(() -> (group.begin + 1) + "").color(Color.lightGray).minWidth(45f).labelAlign(Align.left).left();
 
                         b.button(Icon.copySmall, Styles.emptyi, () -> {
-                            SpawnGroup newGroup = group.copy();
-                            expandedGroup = newGroup;
-                            groups.add(newGroup);
-                            buildGroups();
+                            try{
+                                SpawnGroup newGroup = group.clone();
+                                expandedGroup = newGroup;
+                                groups.add(newGroup);
+                                buildGroups();
+                            }catch(CloneNotSupportedException e){
+                                Log.err(e);
+                            }
                         }).pad(-6).size(46f);
 
                         b.button(group.effect != null && group.effect != StatusEffects.none ?

--- a/core/src/mindustry/editor/WaveInfoDialog.java
+++ b/core/src/mindustry/editor/WaveInfoDialog.java
@@ -1,7 +1,6 @@
 package mindustry.editor;
 
 import arc.*;
-import arc.func.*;
 import arc.graphics.*;
 import arc.math.*;
 import arc.scene.event.*;
@@ -19,6 +18,8 @@ import mindustry.io.*;
 import mindustry.type.*;
 import mindustry.ui.*;
 import mindustry.ui.dialogs.*;
+
+import java.util.*;
 
 import static mindustry.Vars.*;
 import static mindustry.game.SpawnGroup.*;
@@ -381,15 +382,15 @@ public class WaveInfoDialog extends BaseDialog{
     }
 
     enum Sort{
-        begin(g -> g.begin),
-        health(g -> g.type.health),
-        type(g -> g.type.id);
+        begin(Structs.comps(Structs.comparingFloat(g -> g.begin), Structs.comparingFloat(g -> g.type.id))),
+        health(Structs.comps(Structs.comparingFloat(g -> g.type.health), Structs.comparingFloat(g -> g.begin))),
+        type(Structs.comps(Structs.comparingFloat(g -> g.type.id), Structs.comparingFloat(g -> g.begin)));
 
         static final Sort[] all = values();
 
-        final Floatf<SpawnGroup> sort;
+        final Comparator<SpawnGroup> sort;
 
-        Sort(Floatf<SpawnGroup> sort){
+        Sort(Comparator<SpawnGroup> sort){
             this.sort = sort;
         }
     }

--- a/core/src/mindustry/game/SpawnGroup.java
+++ b/core/src/mindustry/game/SpawnGroup.java
@@ -157,9 +157,12 @@ public class SpawnGroup implements JsonSerializable, Cloneable{
         '}';
     }
 
-    @Override
-    public SpawnGroup clone() throws CloneNotSupportedException{
-        return (SpawnGroup)super.clone();
+    public SpawnGroup copy(){
+        try {
+            return (SpawnGroup)clone();
+        }catch(CloneNotSupportedException how){
+            throw new RuntimeException("If you see this, what did you even do?", how);
+        }
     }
 
     @Override

--- a/core/src/mindustry/game/SpawnGroup.java
+++ b/core/src/mindustry/game/SpawnGroup.java
@@ -157,6 +157,22 @@ public class SpawnGroup implements JsonSerializable{
         '}';
     }
 
+    public SpawnGroup copy(){
+        SpawnGroup newGroup = new SpawnGroup();
+        newGroup.type = this.type;
+        newGroup.end = this.end;
+        newGroup.begin = this.begin;
+        newGroup.spacing = this.spacing;
+        newGroup.max = this.max;
+        newGroup.unitScaling = this.unitScaling;
+        newGroup.unitAmount = this.unitAmount;
+        newGroup.shields = this.shields;
+        newGroup.shieldScaling = this.shieldScaling;
+        newGroup.effect = this.effect;
+        newGroup.items = this.items;
+        return newGroup;
+    }
+
     @Override
     public boolean equals(Object o){
         if(this == o) return true;

--- a/core/src/mindustry/game/SpawnGroup.java
+++ b/core/src/mindustry/game/SpawnGroup.java
@@ -19,7 +19,7 @@ import static mindustry.Vars.*;
  * weapon equipped, ammo used, and status effects.
  * Each spawn group can have multiple sub-groups spawned in different areas of the map.
  */
-public class SpawnGroup implements JsonSerializable{
+public class SpawnGroup implements JsonSerializable, Cloneable{
     public static final int never = Integer.MAX_VALUE;
 
     /** The unit type spawned */
@@ -157,20 +157,9 @@ public class SpawnGroup implements JsonSerializable{
         '}';
     }
 
-    public SpawnGroup copy(){
-        SpawnGroup newGroup = new SpawnGroup();
-        newGroup.type = this.type;
-        newGroup.end = this.end;
-        newGroup.begin = this.begin;
-        newGroup.spacing = this.spacing;
-        newGroup.max = this.max;
-        newGroup.unitScaling = this.unitScaling;
-        newGroup.unitAmount = this.unitAmount;
-        newGroup.shields = this.shields;
-        newGroup.shieldScaling = this.shieldScaling;
-        newGroup.effect = this.effect;
-        newGroup.items = this.items;
-        return newGroup;
+    @Override
+    public SpawnGroup clone() throws CloneNotSupportedException{
+        return (SpawnGroup)super.clone();
     }
 
     @Override


### PR DESCRIPTION
It does exactly what you expect it to:
![image](https://user-images.githubusercontent.com/62061444/132419416-e52ffebe-8bb8-43c3-be1c-0cefacdf5ef5.png)

Other changes:
- Made sorting use comps and have a secondary sorting parameter to prevent this weird group jumping when copying groups with similar sorting parameters:

https://user-images.githubusercontent.com/62061444/132419627-46db39e4-d32e-4dc3-95ec-85131ad04502.mp4

- `buildGroups()` is called instead of `updateWaves()` when removing a spawn group to prevent desyncs between the UI and the value of expanded group, otherwise you can run into situations where clicking a group doesn't expand it and you have to click again:

https://user-images.githubusercontent.com/62061444/132419773-f52a6e01-1df7-418d-8511-f8b4e7ef9609.mp4

(This was already an issue but it didn't matter before since identical groups were basically non-existant before)


If this is too many items for the bar i still have the other layout for copying groups i can make a pr for.

---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
