### PR TITLE
Added unit index to radar statement

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -1731,12 +1731,14 @@ radar.target = Filter for units to sense.
 radar.and = Additional filters.
 radar.order = Sorting order. 0 to reverse.
 radar.sort = Metric to sort results by.
+radar.index = Index of unit to output
 radar.output = Variable to write output unit to.
 
 unitradar.target = Filter for units to sense.
 unitradar.and = Additional filters.
 unitradar.order = Sorting order. 0 to reverse.
 unitradar.sort = Metric to sort results by.
+unitradar.index = Index of unit to output
 unitradar.output = Variable to write output unit to.
 
 control.of = Building to control.

--- a/core/assets/contributors
+++ b/core/assets/contributors
@@ -128,3 +128,4 @@ SAMBUYYA
 genNAowl
 TranquillyUnpleasant
 Darkness6030
+SingularityT3

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -739,6 +739,10 @@ public class LExecutor{
 
                     lastTarget = targeted = best;
                 }else{
+                    //return from cached units if possible
+                    if(idx < units.size){
+                        lastTarget = units.get(idx);
+                    }
                     targeted = lastTarget;
                 }
 
@@ -762,7 +766,7 @@ public class LExecutor{
                 if(!valid) return;
 
                 float val = sort.func.get(b, u) * sortDir;
-                for(int i = 0; i <= idx; i++){
+                for(int i = 0; i <= values.size; i++){
                     if(i >= values.size){
                         values.add(val);
                         units.add(u);

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -390,7 +390,7 @@ public class LStatements{
     public static class RadarStatement extends LStatement{
         public RadarTarget target1 = RadarTarget.enemy, target2 = RadarTarget.any, target3 = RadarTarget.any;
         public RadarSort sort = RadarSort.distance;
-        public String radar = "turret1", sortOrder = "1", output = "result";
+        public String radar = "turret1", sortOrder = "1", index = "0", output = "result";
 
         @Override
         public void build(Table table){
@@ -437,6 +437,10 @@ public class LStatements{
                 }, 2, cell -> cell.size(100, 50)));
             }, Styles.logict, () -> {}).size(90, 40).color(table.color).left().padLeft(2);
 
+            table.add(" index ").self(this::param);
+
+            fields(table, index, v -> index = v);
+
             table.add(" output ").self(this::param);
 
             fields(table, output, v -> output = v);
@@ -453,7 +457,7 @@ public class LStatements{
 
         @Override
         public LInstruction build(LAssembler builder){
-            return new RadarI(target1, target2, target3, sort, builder.var(radar), builder.var(sortOrder), builder.var(output));
+            return new RadarI(target1, target2, target3, sort, builder.var(radar), builder.var(sortOrder), builder.var(index), builder.var(output));
         }
     }
 
@@ -923,7 +927,7 @@ public class LStatements{
 
         @Override
         public LInstruction build(LAssembler builder){
-            return new RadarI(target1, target2, target3, sort, LExecutor.varUnit, builder.var(sortOrder), builder.var(output));
+            return new RadarI(target1, target2, target3, sort, LExecutor.varUnit, builder.var(sortOrder), builder.var(index), builder.var(output));
         }
     }
 


### PR DESCRIPTION
The radar statement now returns a unit based on the index after sorting. For example, when index is 0(and sort is distance and sortOrder is 1), the closest unit is returned. When the index is 1, the second closest unit is returned and so on. If the index is higher than the number of units nearby, the result is null.

Demo program:
![logic](https://user-images.githubusercontent.com/44658109/133881495-fc5de036-1b6c-4516-9840-5b45556c0bc7.png)
![demo](https://user-images.githubusercontent.com/44658109/133881500-19c62dcc-c2cd-4e7b-ad95-2c4a73adbd07.gif)


If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
