### PR TITLE
playerControllable for turrets

### DIFF
--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -66,6 +66,7 @@ public class Turret extends ReloadTurret{
     public boolean targetAir = true;
     public boolean targetGround = true;
     public boolean targetHealing = false;
+    public boolean playerControllable = true;
 
     //charging
     public float chargeTime = -1f;
@@ -155,6 +156,11 @@ public class Turret extends ReloadTurret{
         public void created(){
             unit = (BlockUnitc)UnitTypes.block.create(team);
             unit.tile(this);
+        }
+
+        @Override
+        public boolean canControl(){
+            return playerControllable;
         }
 
         @Override


### PR DESCRIPTION
add `playerControllable` for turrets, basically if player can control/possess the turret or not.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
