### PR TITLE
Vela Rebalance

### DIFF
--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -487,7 +487,7 @@ public class UnitTypes implements ContentList{
                 y = -30f / 4f;
                 shootY = 6f;
                 beamWidth = 0.8f;
-                repairSpeed = 1.4f;
+                repairSpeed = 0.7f;
 
                 bullet = new BulletType(){{
                     maxRange = 120f;


### PR DESCRIPTION
After getting enhanced in damage/speed/repair point, vela has become an ultimate unit.
3 velas can hold a cryofluided-alloy-cyclone, 9 velas can hold up to 5 foreshadows(with proper logic)
And the main cause is suggestion-flooding and bad-balancing. Vela shouldn’t be so strong.
My solution is to cut the repair efficiency in half, which means 42/s per repair point.
You know, the truth of the universe.
 
- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.