### PR TITLE
Map Search by author and descriptions

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -382,6 +382,7 @@ editor.center = Center
 editor.search = Search Maps...
 editor.filters = Filter Maps
 editor.showAll = Show Default Maps
+editor.searchDescription = Search Descriptions
 workshop = Workshop
 waves.title = Waves
 waves.remove = Remove


### PR DESCRIPTION
This PR implements searching map by not only name, but also by author and descriptions, description would probably make the search too much, so I added a button for disabling search by it, true by default, and by only name would make the search too specific too, though, so without description search you can still search for names and author.

https://user-images.githubusercontent.com/85090668/135302521-819246ff-022d-45be-b76b-21f787830b25.mp4

also cleanup a bit and changed the "show default maps" button to a check, because it looks kinda... weird being a toggle button.

Forgot on video; this is the search description toggle button
![image](https://user-images.githubusercontent.com/85090668/135302672-a7b73b0e-ccfd-4c0e-9548-6c7486dc1d14.png)
when it's off
![image](https://user-images.githubusercontent.com/85090668/135303271-2382d166-a8ab-4e7d-8512-0797ad037627.png)

---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
