### PR TITLE
Liquid Drawing for non-`LiquidTurret`s

### DIFF
--- a/core/src/mindustry/world/blocks/defense/turrets/LiquidTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/LiquidTurret.java
@@ -25,7 +25,6 @@ public class LiquidTurret extends Turret{
         shootSound = Sounds.none;
         smokeEffect = Fx.none;
         shootEffect = Fx.none;
-        outlinedIcon = 1;
         drawLiquid = true;
     }
 

--- a/core/src/mindustry/world/blocks/defense/turrets/LiquidTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/LiquidTurret.java
@@ -2,12 +2,10 @@ package mindustry.world.blocks.defense.turrets;
 
 import arc.graphics.g2d.*;
 import arc.struct.*;
-import mindustry.annotations.Annotations.*;
 import mindustry.content.*;
 import mindustry.entities.*;
 import mindustry.entities.bullet.*;
 import mindustry.gen.*;
-import mindustry.graphics.*;
 import mindustry.type.*;
 import mindustry.world.*;
 import mindustry.world.consumers.*;
@@ -17,8 +15,6 @@ import static mindustry.Vars.*;
 
 public class LiquidTurret extends Turret{
     public ObjectMap<Liquid, BulletType> ammoTypes = new ObjectMap<>();
-    public @Load("@-liquid") TextureRegion liquidRegion;
-    public @Load("@-top") TextureRegion topRegion;
     public boolean extinguish = true;
 
     public LiquidTurret(String name){
@@ -30,6 +26,7 @@ public class LiquidTurret extends Turret{
         smokeEffect = Fx.none;
         shootEffect = Fx.none;
         outlinedIcon = 1;
+        drawLiquid = true;
     }
 
     /** Initializes accepted ammo map. Format: [liquid1, bullet1, liquid2, bullet2...] */
@@ -73,16 +70,6 @@ public class LiquidTurret extends Turret{
     }
 
     public class LiquidTurretBuild extends TurretBuild{
-        @Override
-        public void draw(){
-            super.draw();
-            
-            if(liquidRegion.found()){
-                Drawf.liquid(liquidRegion, x + tr2.x, y + tr2.y, liquids.total() / liquidCapacity, liquids.current().color, rotation - 90);
-            }
-            if(topRegion.found()) Draw.rect(topRegion, x + tr2.x, y + tr2.y, rotation - 90);
-        }
-
         @Override
         public boolean shouldActiveSound(){
             return wasShooting && enabled;

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -83,6 +83,9 @@ public class Turret extends ReloadTurret{
 
     public @Load(value = "@-base", fallback = "block-@size") TextureRegion baseRegion;
     public @Load("@-heat") TextureRegion heatRegion;
+    public @Load("@-liquid") TextureRegion liquidRegion;
+    public @Load("@-top") TextureRegion topRegion;
+    public boolean drawLiquid;
     public float elevation = -1f;
 
     public Cons<TurretBuild> drawer = tile -> Draw.rect(region, tile.x + tr2.x, tile.y + tr2.y, tile.rotation - 90);
@@ -132,6 +135,7 @@ public class Turret extends ReloadTurret{
 
     @Override
     public TextureRegion[] icons(){
+        if(drawLiquid && topRegion.found()) return new TextureRegion[]{baseRegion, region, topRegion};
         return new TextureRegion[]{baseRegion, region};
     }
 
@@ -255,6 +259,13 @@ public class Turret extends ReloadTurret{
 
             if(heatRegion != Core.atlas.find("error")){
                 heatDrawer.get(this);
+            }
+
+            if(drawLiquid){
+                if(liquidRegion.found()){
+                    Drawf.liquid(liquidRegion, x + tr2.x, y + tr2.y, liquids.total() / liquidCapacity, liquids.current().color, rotation - 90);
+                }
+                if(topRegion.found()) Draw.rect(topRegion, x + tr2.x, y + tr2.y, rotation - 90);
             }
         }
 

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -102,6 +102,7 @@ public class Turret extends ReloadTurret{
     public Turret(String name){
         super(name);
         liquidCapacity = 20f;
+        outlinedIcon = 1;
     }
 
     @Override


### PR DESCRIPTION
Moves liquid drawing from `LiquidTurret` to `Turret` so that you can draw coolant on non-`LiquidTurret`s.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
