### PR TITLE
Unit.type is nullable

### DIFF
--- a/core/src/mindustry/entities/comp/UnitComp.java
+++ b/core/src/mindustry/entities/comp/UnitComp.java
@@ -41,7 +41,7 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
     @Import WeaponMount[] mounts;
 
     private UnitController controller;
-    UnitType type;
+    @Nullable UnitType type;
     boolean spawnedByCore;
     double flag;
 


### PR DESCRIPTION
I don't know why its not marked as such when it clearly is: https://discord.com/channels/391020510269669376/807692120160337981/898588334023139348

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
