### PR TITLE
View contents of payload blocks

### DIFF
--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -992,11 +992,12 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         }
 
         //consume tap event if necessary
+        var invBuild = (!build.block.hasItems || build.items.total() == 0) && build.getPayload() instanceof BuildPayload pay ? pay.build : build;
         if(build.interactable(player.team()) && build.block.consumesTap){
             consumed = true;
-        }else if(build.interactable(player.team()) && build.block.synthetic() && (!consumed || build.block.allowConfigInventory)){
-            if(build.block.hasItems && build.items.total() > 0){
-                frag.inv.showFor(build);
+        }else if(invBuild.interactable(player.team()) && invBuild.block.synthetic() && (!consumed || invBuild.block.allowConfigInventory)){
+            if(invBuild.block.hasItems && invBuild.items.total() > 0){
+                frag.inv.showFor(invBuild);
                 consumed = true;
                 showedInventory = true;
             }

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1187,7 +1187,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
     }
 
     public void tryDropItems(@Nullable Building build, float x, float y){
-        if(!droppingItem || player.unit().stack.amount <= 0 || canTapPlayer(x, y) || state.isPaused() ){
+        if(!droppingItem || player.unit().stack.amount <= 0 || canTapPlayer(x, y) || state.isPaused()){
             droppingItem = false;
             return;
         }

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1196,8 +1196,9 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
 
         ItemStack stack = player.unit().stack;
 
-        if(build != null && build.acceptStack(stack.item, stack.amount, player.unit()) > 0 && build.interactable(player.team()) && build.block.hasItems && player.unit().stack().amount > 0 && build.interactable(player.team())){
-            Call.transferInventory(player, build);
+        var invBuild = build != null && !build.block.hasItems && build.getPayload() instanceof BuildPayload pay && pay.build.block.hasItems ? pay.build : build;
+        if(invBuild != null && invBuild.acceptStack(stack.item, stack.amount, player.unit()) > 0 && invBuild.interactable(player.team()) && invBuild.block.hasItems && player.unit().stack().amount > 0 && invBuild.interactable(player.team())){
+            Call.transferInventory(player, invBuild);
         }else{
             Call.dropItem(player.angleTo(x, y));
         }

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -54,17 +54,15 @@ if(!project.ext.hasSprites() && System.getenv("JITPACK") != "true"){
     dist.dependsOn ":tools:pack"
 }
 
-//this is only for local testing
 task steamtest(dependsOn: dist){
     doLast{
         copy{
             from "build/libs/Mindustry.jar"
-            if(System.properties["os.name"].contains("Mac")){
-                into "/Users/anuke/Library/Application Support/Steam/steamapps/common/Mindustry/Mindustry.app/Contents/Resources"
-            }else{
-                into "/home/anuke/.steam/steam/steamapps/common/Mindustry/jre"
-            }
-            rename("Mindustry.jar", "desktop.jar")
+            into System.getenv("destination") ?: System.properties["os.name"].contains("Mac") ?
+                "/Users/anuke/Library/Application Support/Steam/steamapps/common/Mindustry/Mindustry.app/Contents/Resources" :
+                "/home/anuke/.steam/steam/steamapps/common/Mindustry/jre"
+
+            rename("Mindustry.jar", System.getenv("outfile") ?:  "desktop.jar")
         }
     }
 }


### PR DESCRIPTION
Allows players to view the contents of blocks on payload conveyors as well as take and remove items from them. Additionally introduces a Shift + Click to take full stack when taking items from a block. Also adds env vars for steamtest's move destination and out file name. 

Heres an example of it in action: https://mee6.is-terrible.com/5dd4e51OD.webm
This item display might be worth changing now? Idk, probably not.
![](https://aethex.is-a.fail/5dcQqESJR.png )

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
