### PR TITLE
Fix unreachable messages in script console

### DIFF
--- a/core/src/mindustry/ui/fragments/ScriptConsoleFragment.java
+++ b/core/src/mindustry/ui/fragments/ScriptConsoleFragment.java
@@ -72,11 +72,7 @@ public class ScriptConsoleFragment extends Table{
                 }
             }
 
-            int newLines = -1;
-            for(int i = scrollPos; i < messages.size && i < messagesShown + scrollPos; i++){
-                newLines += Strings.count(messages.get(i), '\n');
-            }
-            scrollPos = (int)Mathf.clamp(scrollPos + input.axis(Binding.chat_scroll), 0, Math.max(0, messages.size - messagesShown + newLines));
+            scrollPos = (int)Mathf.clamp(scrollPos + input.axis(Binding.chat_scroll), 0, Math.max(0, messages.size));
         });
 
         history.insert(0, "");

--- a/core/src/mindustry/ui/fragments/ScriptConsoleFragment.java
+++ b/core/src/mindustry/ui/fragments/ScriptConsoleFragment.java
@@ -72,7 +72,11 @@ public class ScriptConsoleFragment extends Table{
                 }
             }
 
-            scrollPos = (int)Mathf.clamp(scrollPos + input.axis(Binding.chat_scroll), 0, Math.max(0, messages.size - messagesShown));
+            int newLines = -1;
+            for(int i = scrollPos; i < messages.size && i < messagesShown + scrollPos; i++){
+                newLines += Strings.count(messages.get(i), '\n');
+            }
+            scrollPos = (int)Mathf.clamp(scrollPos + input.axis(Binding.chat_scroll), 0, Math.max(0, messages.size - messagesShown + newLines));
         });
 
         history.insert(0, "");


### PR DESCRIPTION
The current implementation doesn't take newlines into account which means that text can sometimes be unreachable as you have already scrolled as far as is allowed. The solution to this problem is simple, increase the scrollPos by the number of newLines in the messages on screen. This wont work if there's only one message on screen and it has over a screen worth of newLines but the old implementation didn't either and I cant be bothered to split the messages into individual lines.

The chat fragment has the same issue but it is not worth fixing as the chat doesn't normally fill the whole screen anyways.

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
