### PR TITLE
Deselectable Content Selection UI

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -2163,14 +2163,12 @@ public class Blocks implements ContentList{
             requirements(Category.units, BuildVisibility.sandboxOnly, with());
             size = 5;
             alwaysUnlocked = true;
-            group = BlockGroup.units;
         }};
 
         payloadVoid = new PayloadVoid("payload-void"){{
             requirements(Category.units, BuildVisibility.sandboxOnly, with());
             size = 5;
             alwaysUnlocked = true;
-            group = BlockGroup.units;
         }};
 
         //TODO move

--- a/core/src/mindustry/world/blocks/payloads/Constructor.java
+++ b/core/src/mindustry/world/blocks/payloads/Constructor.java
@@ -6,6 +6,7 @@ import arc.scene.ui.layout.*;
 import arc.util.*;
 import arc.util.io.*;
 import mindustry.*;
+import mindustry.gen.*;
 import mindustry.world.*;
 import mindustry.world.blocks.*;
 import mindustry.world.blocks.storage.*;
@@ -55,6 +56,17 @@ public class Constructor extends BlockProducer{
         @Override
         public void buildConfiguration(Table table){
             ItemSelection.buildTable(table, content.blocks().select(Constructor.this::canProduce), () -> recipe, this::configure);
+        }
+
+        @Override
+        public boolean onConfigureTileTapped(Building other){
+            if(this == other){
+                deselect();
+                configure(null);
+                return false;
+            }
+
+            return true;
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/payloads/PayloadSource.java
+++ b/core/src/mindustry/world/blocks/payloads/PayloadSource.java
@@ -92,6 +92,17 @@ public class PayloadSource extends PayloadBlock{
         }
 
         @Override
+        public boolean onConfigureTileTapped(Building other){
+            if(this == other){
+                deselect();
+                configure(null);
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
         public Object config(){
             return unit == null ? block : unit;
         }

--- a/core/src/mindustry/world/blocks/units/UnitFactory.java
+++ b/core/src/mindustry/world/blocks/units/UnitFactory.java
@@ -167,6 +167,17 @@ public class UnitFactory extends UnitBlock{
         }
 
         @Override
+        public boolean onConfigureTileTapped(Building other){
+            if(this == other){
+                deselect();
+                configure(null);
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
         public boolean acceptPayload(Building source, Payload payload){
             return false;
         }


### PR DESCRIPTION
currently many configurable blocks like Payload Source, Constructors, Unit Factories etc. can be tapped to open the configuration, but unlike the Item/Liquid Source or core, it doesn't hide the selection pane on another tapping, the only way you can hide it is to click anywhere else, which is hard for when you're controlling suicide units. 

also removed blockflag for payload source/void, to use the default and more widespread payloads flag.

---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
