### PR TITLE
[Need Help] Add hostname for discovery and connect

### DIFF
--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -94,8 +94,9 @@ public class NetClient implements ApplicationListener{
             c.mobile = mobile;
             c.versionType = Version.type;
             c.color = player.color.rgba();
-            c.usid = getUsid(packet.addressTCP);
+            c.usid = getUsid(packet.hostName);
             c.uuid = platform.getUUID();
+            c.host = packet.hostName;
 
             if(c.uuid == null){
                 ui.showErrorMessage("@invalidid");

--- a/core/src/mindustry/net/Packets.java
+++ b/core/src/mindustry/net/Packets.java
@@ -46,6 +46,7 @@ public class Packets{
     /** Generic client connection event. */
     public static class Connect extends Packet{
         public String addressTCP;
+        public String hostName;
 
         @Override
         public int getPriority(){
@@ -112,7 +113,7 @@ public class Packets{
         public int version;
         public String versionType;
         public Seq<String> mods;
-        public String name, locale, uuid, usid;
+        public String name, locale, uuid, usid, host;
         public boolean mobile;
         public int color;
 
@@ -123,6 +124,7 @@ public class Packets{
             TypeIO.writeString(buffer, name);
             TypeIO.writeString(buffer, locale);
             TypeIO.writeString(buffer, usid);
+            TypeIO.writeString(buffer, host);
 
             byte[] b = Base64Coder.decode(uuid);
             buffer.b(b);
@@ -145,6 +147,7 @@ public class Packets{
             name = TypeIO.readString(buffer);
             locale = TypeIO.readString(buffer);
             usid = TypeIO.readString(buffer);
+            host = TypeIO.readString(buffer);
             byte[] idbytes =  buffer.b(16);
             uuid = new String(Base64Coder.encode(idbytes));
             mobile = buffer.b() == 1;


### PR DESCRIPTION
## Aim
Add hostname for discovery and connect
through the hostname can know the server the client tried to connect to.
May like [Minecraft](https://wiki.vg/Protocol#Handshake)

## Usecase
- Can show different info for different host discovery
  - many in one with ping through
  - notify the player to change to new address
- Implement jump server
  - through the hostname, can redirect player to different back servers.
  - In this jump server, can check player uuid and usid, provide auth info to back servers

## Need Help
modify arc-net discoveryHost packet and discovery handler.
For compatibility, the extend field can be optional, check the length in packet to determine.

## More
- may add `version` field to discoveryHost packet
- may add `locale` field to discoveryHost packet
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.