### PR TITLE
fix rare crash when someone spawns a lot of units

### DIFF
--- a/core/src/mindustry/async/PhysicsProcess.java
+++ b/core/src/mindustry/async/PhysicsProcess.java
@@ -38,7 +38,7 @@ public class PhysicsProcess implements AsyncProcess{
 
         //find Unit without bodies and assign them
         for(Unit entity : group){
-            if(entity.type == null) continue;
+            if(entity == null || entity.type == null) continue;
 
             if(entity.physref == null){
                 PhysicsBody body = new PhysicsBody();


### PR DESCRIPTION
This seems to rarely ever happen, but it does, so might as well patch it.
The error:
```
[10-28-2021 00:26:49] [E] java.lang.NullPointerException: Cannot read field "type" because "entity" is null
	at mindustry.async.PhysicsProcess.begin(PhysicsProcess.java:41)
	at mindustry.async.AsyncCore.begin(AsyncCore.java:43)
	at mindustry.server.ServerLauncher$2.update(ServerLauncher.java:68)
	at arc.backend.headless.HeadlessApplication.mainLoop(HeadlessApplication.java:88)
	at arc.backend.headless.HeadlessApplication$1.run(HeadlessApplication.java:53)
```

---

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
