### PR TITLE
Fix MenuOptionChooseEvent not being fired from client

### DIFF
--- a/core/src/mindustry/ui/Menus.java
+++ b/core/src/mindustry/ui/Menus.java
@@ -31,9 +31,11 @@ public class Menus{
 
     @Remote(targets = Loc.both, called = Loc.both)
     public static void menuChoose(@Nullable Player player, int menuId, int option){
-        if(player != null && menuId >= 0 && menuId < menuListeners.size){
+        if(player != null){
             Events.fire(new MenuOptionChooseEvent(player, menuId, option));
-            menuListeners.get(menuId).get(player, option);
+            if(menuId >= 0 && menuId < menuListeners.size){
+                menuListeners.get(menuId).get(player, option);
+            }
         }
     }
 


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

Client shouldn't really care of menu listeners being present on server, so event will always fire.