### PR TITLE
Armour damage reduction changes.

### DIFF
--- a/core/src/mindustry/Vars.java
+++ b/core/src/mindustry/Vars.java
@@ -102,8 +102,6 @@ public class Vars implements Loadable{
     public static final float baseInvasionChance = 1f / 100f;
     /** how many minutes have to pass before invasions in a *captured* sector start */
     public static final float invasionGracePeriod = 20;
-    /** min armor fraction damage; e.g. 0.05 = at least 5% damage */
-    public static final float minArmorDamage = 0.1f;
     /** land/launch animation duration */
     public static final float coreLandDuration = 160f;
     /** size of tiles in units */

--- a/core/src/mindustry/entities/comp/ShieldComp.java
+++ b/core/src/mindustry/entities/comp/ShieldComp.java
@@ -25,7 +25,7 @@ abstract class ShieldComp implements Healthc, Posc{
     @Override
     public void damage(float amount){
         //apply armor
-        amount = Math.max(amount - armor, minArmorDamage * amount);
+        amount = amount - (1f/(1f/amount+0.6f/armor));
         amount /= healthMultiplier;
 
         rawDamage(amount);

--- a/core/src/mindustry/entities/comp/ShieldComp.java
+++ b/core/src/mindustry/entities/comp/ShieldComp.java
@@ -25,7 +25,7 @@ abstract class ShieldComp implements Healthc, Posc{
     @Override
     public void damage(float amount){
         //apply armor
-        amount = amount - (1f/(1f/amount+0.6f/armor));
+        amount = amount - (1f / (1f / amount + 0.6f / armor));
         amount /= healthMultiplier;
 
         rawDamage(amount);


### PR DESCRIPTION
This change makes armour damage reduction more fluent and less bashy, balancing armour for low damage events without the need to make sure the damage dealt is >= a certain value.

- [ X ] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
