### PR TITLE
Make water ai not get stuck on long bending paths

### DIFF
--- a/core/src/mindustry/ai/Pathfinder.java
+++ b/core/src/mindustry/ai/Pathfinder.java
@@ -54,9 +54,9 @@ public class Pathfinder implements Runnable{
             (PathTile.solid(tile) ? 5 : 0),
 
         //water
-        (team, tile) -> PathTile.solid(tile) || !PathTile.liquid(tile) ? 200 : 2 +
+        (team, tile) -> (PathTile.solid(tile) || !PathTile.liquid(tile) ? 6000 : 1) +
             (PathTile.nearGround(tile) || PathTile.nearSolid(tile) ? 14 : 0) +
-            (PathTile.deep(tile) ? -1 : 0) +
+            (PathTile.deep(tile) ? 0 : 1) +
             (PathTile.damages(tile) ? 35 : 0)
     );
 


### PR DESCRIPTION
Why does water ai prefer trying to walk (swim?) on the ground if all liquid paths have more than 200 cost? This fixes that.

Example of ai being stuck:

https://user-images.githubusercontent.com/62061444/139567374-fe468bea-2c93-47cc-b97e-2a49ed69b0c3.mp4

After fix:

https://user-images.githubusercontent.com/62061444/139567375-abc41551-7613-4706-bccb-5b76f8427ae4.mp4

---

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
