### PR TITLE
Add event PlayerConnectionConfirmed

### DIFF
--- a/core/src/mindustry/core/NetServer.java
+++ b/core/src/mindustry/core/NetServer.java
@@ -757,6 +757,8 @@ public class NetServer implements ApplicationListener{
 
         player.add();
 
+        Events.fire(new PlayerConnectionConfirmed(player));
+
         if(player.con == null || player.con.hasConnected) return;
 
         player.con.hasConnected = true;

--- a/core/src/mindustry/game/EventType.java
+++ b/core/src/mindustry/game/EventType.java
@@ -480,7 +480,19 @@ public class EventType{
         }
     }
 
-    /** Called after connecting; when a player receives world data and is ready to play.*/
+    /**
+     * Called after player confirmed it has received world data and is ready to play.
+     * Note that if this is the first world receival, then player.con.hasConnected is false.
+     */
+    public static class PlayerConnectionConfirmed{
+        public final Player player;
+
+        public PlayerConnectionConfirmed(Player player){
+            this.player = player;
+        }
+    }
+
+    /** Called after connecting; when a player receives world data and is ready to play. Fired only once, after initial connection. */
     public static class PlayerJoin{
         public final Player player;
 


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

This event is useful when server plugin wants to persist UI features (labels, hudText, etc.) which get reset on `/sync` or on world reloading. The latter can be handled via `WorldLoadEvent`, but that's still not the proper way since clients may be too slow.