### PR TITLE
AdoptOpenJDK -> Adoptium

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See [CONTRIBUTING](CONTRIBUTING.md).
 Bleeding-edge builds are generated automatically for every commit. You can see them [here](https://github.com/Anuken/MindustryBuilds/releases).
 
 If you'd rather compile on your own, follow these instructions.
-First, make sure you have [JDK 16-17](https://adoptopenjdk.net/archive.html?variant=openjdk16&jvmVariant=hotspot) installed. **Other JDK versions will not work.** Open a terminal in the Mindustry directory and run the following commands:
+First, make sure you have [JDK 16-17](https://adoptium.net/archive.html?variant=openjdk17&jvmVariant=hotspot) installed. **Other JDK versions will not work.** Open a terminal in the Mindustry directory and run the following commands:
 
 ### Windows
 


### PR DESCRIPTION
AdoptOpenJDK has been replaced by adoptium

This probably shouldnt be merged until gradle 7.3 is used as 7.2 doesnt support jdk 16

Maybe its also worth introducing a gradle toolchain which automatically downloads the correct version if needed?