### PR TITLE
Enemy drop zone indicators

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -909,6 +909,7 @@ setting.smoothcamera.name = Smooth Camera
 setting.vsync.name = VSync
 setting.pixelate.name = Pixelate
 setting.minimap.name = Show Minimap
+setting.dropzoneindicators.name = Drop Zone Map Indicators
 setting.coreitems.name = Display Core Items
 setting.position.name = Show Player Position
 setting.musicvol.name = Music Volume

--- a/core/src/mindustry/graphics/MinimapRenderer.java
+++ b/core/src/mindustry/graphics/MinimapRenderer.java
@@ -75,6 +75,31 @@ public class MinimapRenderer{
         region = new TextureRegion(texture);
     }
 
+    public void drawSpawns(float x, float y, float w, float h, float scaling){
+        if(!Core.settings.getBool("dropzoneindicators", false) || !state.hasSpawns()) return;
+
+        TextureRegion icon = Icon.units.getRegion();
+
+        Lines.stroke(3f * scaling);
+
+        Tmp.c2.set(state.rules.waveTeam.color).value(1.2f);
+        Draw.color(state.rules.waveTeam.color, Tmp.c2, Mathf.absin(Time.time, 16f, 1f));
+
+        for(Tile tile : spawner.getSpawns()){
+            float tx = ((tile.x + 0.5f) / world.width()) * w;
+            float ty = ((tile.y + 0.5f) / world.height()) * h;
+
+            float rad = (state.rules.dropZoneRadius / (baseSize / 2f)) * 5f * scaling;
+            float curve = Mathf.curve(Time.time % 240f, 120f, 240f);
+
+            Draw.rect(icon,x + tx, y + ty, icon.width, icon.height);
+            Lines.circle(x + tx, y + ty, rad);
+            if(curve > 0f) Lines.circle(x + tx, y + ty, rad * Interp.pow3Out.apply(curve));
+        }
+
+        Draw.reset();
+    }
+
     public void drawEntities(float x, float y, float w, float h, float scaling, boolean withLabels){
         if(!withLabels){
             updateUnitArray();
@@ -98,6 +123,7 @@ public class MinimapRenderer{
             Draw.mixcol(unit.team().color, 1f);
             float scale = Scl.scl(1f) / 2f * scaling * 32f;
             var region = unit.icon();
+            Fill.circle(x + rx, y + ry, 5f);
             Draw.rect(region, x + rx, y + ry, scale, scale * (float)region.height / region.width, unit.rotation() - 90);
             Draw.reset();
         }

--- a/core/src/mindustry/graphics/MinimapRenderer.java
+++ b/core/src/mindustry/graphics/MinimapRenderer.java
@@ -76,7 +76,7 @@ public class MinimapRenderer{
     }
 
     public void drawSpawns(float x, float y, float w, float h, float scaling){
-        if(!Core.settings.getBool("dropzoneindicators", false) || !state.hasSpawns()) return;
+        if(!Core.settings.getBool("dropzoneindicators", true) || !state.hasSpawns()) return;
 
         TextureRegion icon = Icon.units.getRegion();
 

--- a/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
+++ b/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
@@ -409,6 +409,7 @@ public class SettingsMenuDialog extends BaseDialog{
             graphics.checkPref("coreitems", true);
         }
         graphics.checkPref("minimap", !mobile);
+        graphics.checkPref("dropzoneindicators", true);
         graphics.checkPref("smoothcamera", true);
         graphics.checkPref("position", false);
         graphics.checkPref("fps", false);

--- a/core/src/mindustry/ui/fragments/MinimapFragment.java
+++ b/core/src/mindustry/ui/fragments/MinimapFragment.java
@@ -36,6 +36,7 @@ public class MinimapFragment extends Fragment{
                 TextureRegion reg = Draw.wrap(renderer.minimap.getTexture());
                 Draw.rect(reg, w/2f + panx*zoom, h/2f + pany*zoom, size, size * ratio);
                 renderer.minimap.drawEntities(w/2f + panx*zoom - size/2f, h/2f + pany*zoom - size/2f * ratio, size, size * ratio, zoom, true);
+                renderer.minimap.drawSpawns(w/2f + panx*zoom - size/2f, h/2f + pany*zoom - size/2f * ratio, size, size * ratio, zoom);
             }
 
             Draw.reset();


### PR DESCRIPTION
Indicators for enemy drop zones that appear in the minimap dialog (not the HUD minimap)

![](https://cdn.discordapp.com/attachments/598799443373850657/905387104102658058/20211103_162414.gif)

The conversion from world units to minimap """units""" is kinda weird, but the inaccuracies are negligible and barely noticeable.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
