### PR TITLE
`payloadRotation` field in buildings

### DIFF
--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -61,6 +61,7 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
     transient boolean updateFlow;
     transient byte cdump;
     transient int rotation;
+    transient float payloadRotation;
     transient boolean enabled = true;
     transient float enabledControlTime;
     transient String lastAccessed;

--- a/core/src/mindustry/world/blocks/payloads/BuildPayload.java
+++ b/core/src/mindustry/world/blocks/payloads/BuildPayload.java
@@ -80,6 +80,7 @@ public class BuildPayload implements Payload{
     @Override
     public void set(float x, float y, float rotation){
         build.set(x, y);
+        build.payloadRotation = rotation;
     }
 
     @Override


### PR DESCRIPTION
Unused within the game code, but script modding could access it to make those blocks rotate when they're payloads.

Simplification of #6292.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
