### PR TITLE
More Delectable Selection Pane

### DIFF
--- a/core/src/mindustry/editor/WaveInfoDialog.java
+++ b/core/src/mindustry/editor/WaveInfoDialog.java
@@ -95,7 +95,7 @@ public class WaveInfoDialog extends BaseDialog{
                     dialog.hide();
                 }).marginLeft(12f).disabled(b -> Core.app.getClipboardText() == null || Core.app.getClipboardText().isEmpty()).row();
 
-               t.button("@settings.reset", Icon.upload, style, () -> ui.showConfirm("@confirm", "@settings.clear.confirm", () -> {
+                t.button("@settings.reset", Icon.upload, style, () -> ui.showConfirm("@confirm", "@settings.clear.confirm", () -> {
                     groups = JsonIO.copy(waves.get());
                     buildGroups();
                     dialog.hide();

--- a/core/src/mindustry/world/blocks/distribution/MassDriver.java
+++ b/core/src/mindustry/world/blocks/distribution/MassDriver.java
@@ -252,6 +252,7 @@ public class MassDriver extends Block{
         @Override
         public boolean onConfigureTileTapped(Building other){
             if(this == other){
+                if(link == -1) deselect();
                 configure(-1);
                 return false;
             }

--- a/core/src/mindustry/world/blocks/payloads/PayloadMassDriver.java
+++ b/core/src/mindustry/world/blocks/payloads/PayloadMassDriver.java
@@ -432,6 +432,7 @@ public class PayloadMassDriver extends PayloadBlock{
         @Override
         public boolean onConfigureTileTapped(Building other){
             if(this == other){
+                if(link == -1) deselect();
                 configure(-1);
                 return false;
             }

--- a/core/src/mindustry/world/blocks/storage/CoreBlock.java
+++ b/core/src/mindustry/world/blocks/storage/CoreBlock.java
@@ -53,7 +53,6 @@ public class CoreBlock extends StorageBlock{
 
         //support everything
         envEnabled = Env.any;
-        drawDisabled = false;
         replaceable = false;
         rebuildable = false;
     }

--- a/core/src/mindustry/world/blocks/units/CommandCenter.java
+++ b/core/src/mindustry/world/blocks/units/CommandCenter.java
@@ -119,6 +119,16 @@ public class CommandCenter extends Block{
         }
 
         @Override
+        public boolean onConfigureTileTapped(Building other){
+            if(this == other){
+                deselect();
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
         public void write(Writes write){
             super.write(write);
             write.b(team.data().command.ordinal());


### PR DESCRIPTION
did what I left off from #6205, adds `onConfigureTileTapped` to command center and make mass driver and payload propulsion tower link configurations deselectable, but only when there's no linked block (basically double-tap max to deselect the config)

https://user-images.githubusercontent.com/85090668/140764159-3f6b4b1f-90a7-4ad4-a4a0-bb2c96f260c2.mp4

oh, and also fixed some code I found.

---

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
