### PR TITLE
Batteries can be overdrived.

### DIFF
--- a/core/src/mindustry/world/blocks/power/Battery.java
+++ b/core/src/mindustry/world/blocks/power/Battery.java
@@ -20,6 +20,7 @@ public class Battery extends PowerDistributor{
         super(name);
         outputsPower = true;
         consumesPower = true;
+        canOverdrive = false;
         flags = EnumSet.of(BlockFlag.battery);
         //TODO could be supported everywhere...
         envEnabled |= Env.space;


### PR DESCRIPTION
Set `canOverdrive` on batteries to false since overdrive does nothing for batteries.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
