### PR TITLE
Fix the memory leak when light rendering is disabled

### DIFF
--- a/core/src/mindustry/graphics/LightRenderer.java
+++ b/core/src/mindustry/graphics/LightRenderer.java
@@ -182,6 +182,7 @@ public class LightRenderer{
     public void draw(){
         if(!Vars.enableLight){
             lights.clear();
+            circleIndex = 0;
             return;
         }
 


### PR DESCRIPTION
When *Vars.enableLight* is set to false, memory leaks will occur in maps with unit lighting enabled.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
