### PR TITLE
ParticleEffect Rotation

### DIFF
--- a/core/src/mindustry/entities/effect/ParticleEffect.java
+++ b/core/src/mindustry/entities/effect/ParticleEffect.java
@@ -32,6 +32,8 @@ public class ParticleEffect extends Effect{
     public float spin = 0f;
     /** Controls the initial and final sprite sizes. */
     public float sizeFrom = 2f, sizeTo = 0f;
+    /** Whether the rotation adds with the parent */
+    public boolean additive = true;
     /** Rotation offset. */
     public float offset = 0;
     /** Sprite to draw. */
@@ -81,7 +83,11 @@ public class ParticleEffect extends Effect{
                 rv.trns(e.rotation + rand.range(cone), !randLength ? l : rand.random(l));
                 float x = rv.x, y = rv.y;
 
-                Draw.rect(tex, ox + x, oy + y, rad, rad, e.rotation + offset + e.time * spin);
+                if (additive){
+                    Draw.rect(tex, ox + x, oy + y, rad, rad, e.rotation + offset + e.time * spin);
+                } else{
+                    Draw.rect(tex, ox + x, oy + y, rad, rad, offset + baseRotation + e.time * spin);
+                }
                 Drawf.light(ox + x, oy + y, rad * lightScl, lightColor, lightOpacity * Draw.getColor().a);
             }
         }

--- a/core/src/mindustry/entities/effect/ParticleEffect.java
+++ b/core/src/mindustry/entities/effect/ParticleEffect.java
@@ -33,7 +33,7 @@ public class ParticleEffect extends Effect{
     /** Controls the initial and final sprite sizes. */
     public float sizeFrom = 2f, sizeTo = 0f;
     /** Whether the rotation adds with the parent */
-    public boolean additive = true;
+    public boolean useRotation = true;
     /** Rotation offset. */
     public float offset = 0;
     /** Sprite to draw. */
@@ -55,10 +55,11 @@ public class ParticleEffect extends Effect{
     public void render(EffectContainer e){
         if(tex == null) tex = Core.atlas.find(region);
 
+        float realRotation = (useRotation ? e.rotation : baseRotation);
         float rawfin = e.fin();
         float fin = e.fin(interp);
         float rad = sizeInterp.apply(sizeFrom, sizeTo, rawfin) * 2;
-        float ox = e.x + Angles.trnsx((additive ? e.rotation : baseRotation), offsetX, offsetY), oy = e.y + Angles.trnsy((additive ? e.rotation : baseRotation), offsetX, offsetY);
+        float ox = e.x + Angles.trnsx(realRotation, offsetX, offsetY), oy = e.y + Angles.trnsy(realRotation, offsetX, offsetY);
 
         Draw.color(colorFrom, colorTo, fin);
         Color lightColor = this.lightColor == null ? Draw.getColor() : this.lightColor;
@@ -70,7 +71,7 @@ public class ParticleEffect extends Effect{
             rand.setSeed(e.id);
             for(int i = 0; i < particles; i++){
                 float l = length * fin + baseLength;
-                rv.trns((additive ? e.rotation : baseRotation) + rand.range(cone), !randLength ? l : rand.random(l));
+                rv.trns(realRotation + rand.range(cone), !randLength ? l : rand.random(l));
                 float x = rv.x, y = rv.y;
 
                 Lines.lineAngle(ox + x, oy + y, Mathf.angle(x, y), len);
@@ -80,10 +81,10 @@ public class ParticleEffect extends Effect{
             rand.setSeed(e.id);
             for(int i = 0; i < particles; i++){
                 float l = length * fin + baseLength;
-                rv.trns((additive ? e.rotation : baseRotation) + rand.range(cone), !randLength ? l : rand.random(l));
+                rv.trns(realRotation + rand.range(cone), !randLength ? l : rand.random(l));
                 float x = rv.x, y = rv.y;
 
-                Draw.rect(tex, ox + x, oy + y, rad, rad, (additive ? e.rotation : baseRotation) + offset + e.time * spin);
+                Draw.rect(tex, ox + x, oy + y, rad, rad, realRotation + offset + e.time * spin);
                 Drawf.light(ox + x, oy + y, rad * lightScl, lightColor, lightOpacity * Draw.getColor().a);
             }
         }

--- a/core/src/mindustry/entities/effect/ParticleEffect.java
+++ b/core/src/mindustry/entities/effect/ParticleEffect.java
@@ -58,7 +58,7 @@ public class ParticleEffect extends Effect{
         float rawfin = e.fin();
         float fin = e.fin(interp);
         float rad = sizeInterp.apply(sizeFrom, sizeTo, rawfin) * 2;
-        float ox = e.x + Angles.trnsx(e.rotation, offsetX, offsetY), oy = e.y + Angles.trnsy(e.rotation, offsetX, offsetY);
+        float ox = e.x + Angles.trnsx((additive ? e.rotation : baseRotation), offsetX, offsetY), oy = e.y + Angles.trnsy((additive ? e.rotation : baseRotation), offsetX, offsetY);
 
         Draw.color(colorFrom, colorTo, fin);
         Color lightColor = this.lightColor == null ? Draw.getColor() : this.lightColor;
@@ -70,7 +70,7 @@ public class ParticleEffect extends Effect{
             rand.setSeed(e.id);
             for(int i = 0; i < particles; i++){
                 float l = length * fin + baseLength;
-                rv.trns(e.rotation + rand.range(cone), !randLength ? l : rand.random(l));
+                rv.trns((additive ? e.rotation : baseRotation) + rand.range(cone), !randLength ? l : rand.random(l));
                 float x = rv.x, y = rv.y;
 
                 Lines.lineAngle(ox + x, oy + y, Mathf.angle(x, y), len);
@@ -80,7 +80,7 @@ public class ParticleEffect extends Effect{
             rand.setSeed(e.id);
             for(int i = 0; i < particles; i++){
                 float l = length * fin + baseLength;
-                rv.trns(e.rotation + rand.range(cone), !randLength ? l : rand.random(l));
+                rv.trns((additive ? e.rotation : baseRotation) + rand.range(cone), !randLength ? l : rand.random(l));
                 float x = rv.x, y = rv.y;
 
                 Draw.rect(tex, ox + x, oy + y, rad, rad, (additive ? e.rotation : baseRotation) + offset + e.time * spin);

--- a/core/src/mindustry/entities/effect/ParticleEffect.java
+++ b/core/src/mindustry/entities/effect/ParticleEffect.java
@@ -83,11 +83,7 @@ public class ParticleEffect extends Effect{
                 rv.trns(e.rotation + rand.range(cone), !randLength ? l : rand.random(l));
                 float x = rv.x, y = rv.y;
 
-                if (additive){
-                    Draw.rect(tex, ox + x, oy + y, rad, rad, e.rotation + offset + e.time * spin);
-                } else{
-                    Draw.rect(tex, ox + x, oy + y, rad, rad, offset + baseRotation + e.time * spin);
-                }
+                Draw.rect(tex, ox + x, oy + y, rad, rad, (additive ? e.rotation : baseRotation) + offset + e.time * spin);
                 Drawf.light(ox + x, oy + y, rad * lightScl, lightColor, lightOpacity * Draw.getColor().a);
             }
         }


### PR DESCRIPTION
Adds a field called `additive` in ParticleEffect
If true, old behaviour is applied
If false, the effect ignores rotation of the caller (i.e: a bullet)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
