### PR TITLE
Fix some small annoyances in projector drawing

### DIFF
--- a/core/src/mindustry/world/blocks/defense/MendProjector.java
+++ b/core/src/mindustry/world/blocks/defense/MendProjector.java
@@ -121,10 +121,10 @@ public class MendProjector extends Block{
             float f = 1f - (Time.time / 100f) % 1f;
 
             Draw.color(baseColor, phaseColor, phaseHeat);
-            Draw.alpha(heat * Mathf.absin(Time.time, 10f, 1f) * 0.5f);
+            Draw.alpha(heat * Mathf.absin(Time.time, 50f / Mathf.PI2, 1f) * 0.5f);
             Draw.rect(topRegion, x, y);
             Draw.alpha(1f);
-            Lines.stroke((2f * f + 0.2f) * heat);
+            Lines.stroke(2f * f * heat);
             Lines.square(x, y, Math.min(1f + (1f - f) * size * tilesize / 2f, size * tilesize/2f));
 
             Draw.reset();

--- a/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
+++ b/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
@@ -142,7 +142,7 @@ public class OverdriveProjector extends Block{
             Draw.alpha(1f);
             Lines.stroke(2f * f * heat);
 
-            float r = Math.max(0f, Mathf.clamp(2f - f * 2f) * size * tilesize / 2f - f - 0.2f), w = Mathf.clamp(0.5f - f) * size * tilesize;
+            float r = Math.max(0f, Mathf.clamp(2f - f * 2f) * size * tilesize / 2f - f), w = Mathf.clamp(0.5f - f) * size * tilesize;
             Lines.beginLine();
             for(int i = 0; i < 4; i++){
                 Lines.linePoint(x + Geometry.d4(i).x * r + Geometry.d4(i).y * w, y + Geometry.d4(i).y * r - Geometry.d4(i).x * w);

--- a/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
+++ b/core/src/mindustry/world/blocks/defense/OverdriveProjector.java
@@ -137,10 +137,10 @@ public class OverdriveProjector extends Block{
             float f = 1f - (Time.time / 100f) % 1f;
 
             Draw.color(baseColor, phaseColor, phaseHeat);
-            Draw.alpha(heat * Mathf.absin(Time.time, 10f, 1f) * 0.5f);
+            Draw.alpha(heat * Mathf.absin(Time.time, 50f / Mathf.PI2, 1f) * 0.5f);
             Draw.rect(topRegion, x, y);
             Draw.alpha(1f);
-            Lines.stroke((2f * f + 0.1f) * heat);
+            Lines.stroke(2f * f * heat);
 
             float r = Math.max(0f, Mathf.clamp(2f - f * 2f) * size * tilesize / 2f - f - 0.2f), w = Mathf.clamp(0.5f - f) * size * tilesize;
             Lines.beginLine();


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/54301439/141233181-fe5595e0-f7d8-4a2a-8627-3442aa7dc5e0.mp4

After:

https://user-images.githubusercontent.com/54301439/141233052-8fdc3520-9b44-46dd-97a7-1dfcfffae4bd.mp4

---

- The expanding line now completely disappears instead of leaving a weird border. (Removed `+ 0.1f`)
- The pulsating glow is now synced to the expanding line. (Changed `scl`)

---

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
