### PR TITLE
Better Mod/Plugin dependencies handling

### DIFF
--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -355,10 +355,13 @@ public class Mods implements Loadable{
 
     /** Loads all mods from the folder, but does not call any methods on them.*/
     public void load(){
-        for(Fi file : modDirectory.list()){
-            if(!file.extension().equals("jar") && !file.extension().equals("zip") && !(file.isDirectory() && (file.child("mod.json").exists() || file.child("mod.hjson").exists()))) continue;
+        var files = resolveDependencies(modDirectory.findAll(f ->
+            f.extension().equals("jar") || f.extension().equals("zip") || (f.isDirectory() && (f.child("mod.json").exists() || f.child("mod.hjson").exists()))
+        ));
 
+        for(Fi file : files){
             Log.debug("[Mods] Loading mod @", file);
+
             try{
                 LoadedMod mod = loadMod(file);
                 mods.add(mod);
@@ -373,7 +376,7 @@ public class Mods implements Loadable{
         }
 
         //load workshop mods now
-        for(Fi file : platform.getWorkshopContent(LoadedMod.class)){
+        for(Fi file : resolveDependencies(platform.getWorkshopContent(LoadedMod.class))){
             try{
                 LoadedMod mod = loadMod(file);
                 mods.add(mod);
@@ -708,6 +711,80 @@ public class Mods implements Loadable{
         }
     }
 
+    /** Tries to find the config file... */
+    private ModMeta findMeta(Fi file){
+        Fi metaFile =
+            file.child("mod.json").exists() ?       file.child("mod.json") :
+            file.child("mod.hjson").exists() ?      file.child("mod.hjson") :
+            file.child("plugin.json").exists() ?    file.child("plugin.json") :
+            file.child("plugin.hjson");
+
+        if(!metaFile.exists()){
+            Log.warn("Mod @ doesn't have a '[mod/plugin].[h]json' file, skipping.", file);
+            throw new ModLoadException("Invalid file: No mod.json found.");
+        }
+
+        ModMeta meta = json.fromJson(ModMeta.class, Jval.read(metaFile.readString()).toString(Jformat.plain));
+        meta.cleanup();
+        return meta;
+    }
+
+    /** Resolves the loading order of the mods for dependencies using their internal names */
+    public Seq<Fi> resolveDependencies(Seq<Fi> files){
+        ObjectMap<String, Fi> fileMapping = new ObjectMap<>(files.size);
+        ObjectMap<String, Seq<String>> dependencies = new ObjectMap<>(files.size);
+
+        for(Fi file : files){
+            Fi zip = file.isDirectory() ? file : new ZipFi(file);
+
+            if(zip.list().length == 1 && zip.list()[0].isDirectory()){
+                zip = zip.list()[0];
+            }
+
+            ModMeta meta = findMeta(zip);
+
+            dependencies.put(meta.name, meta.dependencies);
+            fileMapping.put(meta.name, file);
+        }
+
+        ObjectSet<String> visited = new ObjectSet<>();
+        OrderedSet<String> ordered = new OrderedSet<>();
+
+        for(String modName : dependencies.keys()){
+            if(!ordered.contains(modName)){
+                // Adds the loaded mods at the beginning of the list
+                ordered.add(modName, 0);
+                resolveDependencies(modName, dependencies, ordered, visited);
+                visited.clear();
+            }
+        }
+
+        Seq<Fi> resolved = ordered.orderedItems().map(fileMapping::get);
+        // Since the resolver explores the dependencies from leaves to the root, reverse the seq
+        resolved.reverse();
+        return resolved;
+    }
+
+    /** Recursive search of dependencies */
+    public void resolveDependencies(String modName, ObjectMap<String, Seq<String>> dependencies, OrderedSet<String> ordered, ObjectSet<String> visited){
+        visited.add(modName);
+
+        for(String dependency : dependencies.get(modName)){
+            if(visited.contains(dependency)){
+                // What should I do ? throw or skip ?
+                // throw new ModLoadException("@ has circular dependencies.", modName);
+            }else if(dependencies.containsKey(dependency)){
+                // Skips if the dependency was already explored in a separate tree
+                if(ordered.contains(dependency)) continue;
+                ordered.add(dependency);
+                resolveDependencies(dependency, dependencies, ordered, visited);
+            }else{
+                // What should I do ? throw or skip ?
+                // throw new ModLoadException("@ is missing for @.", dependency, modName);
+            }
+        }
+    }
+
     /** Loads a mod file+meta, but does not add it to the list.
      * Note that directories can be loaded as mods. */
     private LoadedMod loadMod(Fi sourceFile) throws Exception{
@@ -727,19 +804,8 @@ public class Mods implements Loadable{
                 zip = zip.list()[0];
             }
 
-            Fi metaf =
-                zip.child("mod.json").exists() ? zip.child("mod.json") :
-                zip.child("mod.hjson").exists() ? zip.child("mod.hjson") :
-                zip.child("plugin.json").exists() ? zip.child("plugin.json") :
-                zip.child("plugin.hjson");
+            ModMeta meta = findMeta(zip);
 
-            if(!metaf.exists()){
-                Log.warn("Mod @ doesn't have a '[mod/plugin].[h]json' file, skipping.", sourceFile);
-                throw new ModLoadException("Invalid file: No mod.json found.");
-            }
-
-            ModMeta meta = json.fromJson(ModMeta.class, Jval.read(metaf.readString()).toString(Jformat.plain));
-            meta.cleanup();
             String camelized = meta.name.replace(" ", "");
             String mainClass = meta.main == null ? camelized.toLowerCase(Locale.ROOT) + "." + camelized + "Mod" : meta.main;
             String baseName = meta.name.toLowerCase(Locale.ROOT).replace(" ", "-");
@@ -1041,8 +1107,8 @@ public class Mods implements Loadable{
     }
 
     public static class ModLoadException extends RuntimeException{
-        public ModLoadException(String message){
-            super(message);
+        public ModLoadException(String message, Object ...args){
+            super(Strings.format(message, args));
         }
     }
 

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -355,7 +355,7 @@ public class Mods implements Loadable{
 
     /** Loads all mods from the folder, but does not call any methods on them.*/
     public void load(){
-        var files = resolveDependencies(modDirectory.findAll(f ->
+        var files = resolveDependencies(Seq.with(modDirectory.list()).filter(f ->
             f.extension().equals("jar") || f.extension().equals("zip") || (f.isDirectory() && (f.child("mod.json").exists() || f.child("mod.hjson").exists()))
         ));
 
@@ -732,8 +732,8 @@ public class Mods implements Loadable{
     /** Resolves the loading order of a list mods/plugins using their internal names.
      * It also skips non-mods files or folders. */
     public Seq<Fi> resolveDependencies(Seq<Fi> files){
-        ObjectMap<String, Fi> fileMapping = new ObjectMap<>(files.size);
-        ObjectMap<String, Seq<String>> dependencies = new ObjectMap<>(files.size);
+        ObjectMap<String, Fi> fileMapping = new ObjectMap<>();
+        ObjectMap<String, Seq<String>> dependencies = new ObjectMap<>();
 
         for(Fi file : files){
             Fi zip = file.isDirectory() ? file : new ZipFi(file);
@@ -742,9 +742,13 @@ public class Mods implements Loadable{
                 zip = zip.list()[0];
             }
 
-            ModMeta meta = findMeta(zip);
-            if(meta == null) continue;
+            ModMeta meta = null;
+            try{
+                meta = findMeta(zip);
+            }catch(Exception ignored){
+            }
 
+            if(meta == null) continue;
             dependencies.put(meta.name, meta.dependencies);
             fileMapping.put(meta.name, file);
         }

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -712,6 +712,7 @@ public class Mods implements Loadable{
     }
 
     /** Tries to find the config file... */
+    @Nullable
     private ModMeta findMeta(Fi file){
         Fi metaFile =
             file.child("mod.json").exists() ?       file.child("mod.json") :
@@ -720,8 +721,7 @@ public class Mods implements Loadable{
             file.child("plugin.hjson");
 
         if(!metaFile.exists()){
-            Log.warn("Mod @ doesn't have a '[mod/plugin].[h]json' file, skipping.", file);
-            throw new ModLoadException("Invalid file: No mod.json found.");
+            return null;
         }
 
         ModMeta meta = json.fromJson(ModMeta.class, Jval.read(metaFile.readString()).toString(Jformat.plain));
@@ -742,6 +742,7 @@ public class Mods implements Loadable{
             }
 
             ModMeta meta = findMeta(zip);
+            if(meta == null) continue;
 
             dependencies.put(meta.name, meta.dependencies);
             fileMapping.put(meta.name, file);
@@ -805,6 +806,11 @@ public class Mods implements Loadable{
             }
 
             ModMeta meta = findMeta(zip);
+
+            if(meta == null){
+                Log.warn("Mod @ doesn't have a '[mod/plugin].[h]json' file, skipping.", zip);
+                throw new ModLoadException("Invalid file: No mod.json found.");
+            }
 
             String camelized = meta.name.replace(" ", "");
             String mainClass = meta.main == null ? camelized.toLowerCase(Locale.ROOT) + "." + camelized + "Mod" : meta.main;

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -1118,8 +1118,8 @@ public class Mods implements Loadable{
     }
 
     public static class ModLoadException extends RuntimeException{
-        public ModLoadException(String message, Object ...args){
-            super(Strings.format(message, args));
+        public ModLoadException(String message){
+            super(message);
         }
     }
 


### PR DESCRIPTION
Currently, all plugins are loaded, instantiated and then sorted, this leads to `ClassNotFound` exceptions if you dare to use static classes of other Plugins outside the `init` or if you try to create a general purpose `Plugin` classes like a `AbstractGamemodePlugin` for example that may be optimized for game mode plugins.

The solution is simple, resolving dependencies before loading anything, it features:
- more complex dependency trees
- detecting missing dependencies
- preventing circular dependencies

The code is tested and it works fine, It's just that the structure of `Mods` is a bit hard to follow, so I need your opinion on how the missing/circular dependencies should be handled and what to do with the `dependencies` and `missingDependencies` fields of `LoadedMod`.

Thanks for reading.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
