### PR TITLE
Allow to sensor building type through flag

### DIFF
--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -1472,6 +1472,7 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
     public Object senseObject(LAccess sensor){
         return switch(sensor){
             case type -> block;
+            case flag -> block.flags.size() == 0 ? null : block.flags.iterator().next().toString();
             case firstItem -> items == null ? null : items.first();
             case config -> block.configSenseable() ? config() : null;
             case payloadType -> getPayload() instanceof UnitPayload p1 ? p1.unit.type : getPayload() instanceof BuildPayload p2 ? p2.block() : null;


### PR DESCRIPTION
This could be useful for partial blueprints where processor is expected to be attached to a specific building, e.g. a turret. This change will allow to not hardcode the building name (which will require editing every time you place a blueprint) or assume that the link index will always be the same.

![code](https://user-images.githubusercontent.com/3995455/142954535-db1cdd21-bef4-409c-8a0a-816f84aedbc2.png)
![result](https://user-images.githubusercontent.com/3995455/142954544-3480cc34-5da1-4218-8e81-8bbf923feb7a.png)


- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.

