### PR TITLE
switch to GFM markdown renderer for github pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+#Jekyll
+markdown: GFM


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

Table at the bottom of README.md does not render properly in github pages, as the markdown renderer (kramdown) has some weird behaviour around tables.
![image](https://user-images.githubusercontent.com/50847107/143517213-3695774c-6a9e-43bb-98b0-6980086ddee3.png)

Config file switches the renderer to GFM, which renders the table properly
![image](https://user-images.githubusercontent.com/50847107/143517292-8ff1cfa9-e0f1-426f-a296-f9b7311fa4e1.png)
GFM is the renderer natively used on github (e.g. rendering the README on the repository site.)