### PR TITLE
Fix editor camera panning

### DIFF
--- a/core/src/mindustry/editor/MapView.java
+++ b/core/src/mindustry/editor/MapView.java
@@ -181,8 +181,8 @@ public class MapView extends Element implements GestureListener{
         if(Core.scene.getKeyboardFocus() == null || !(Core.scene.getKeyboardFocus() instanceof TextField) && !Core.input.keyDown(KeyCode.controlLeft)){
             float ax = Core.input.axis(Binding.move_x);
             float ay = Core.input.axis(Binding.move_y);
-            offsetx -= ax * 15f / zoom;
-            offsety -= ay * 15f / zoom;
+            offsetx -= ax * 15 * Time.delta / zoom;
+            offsety -= ay * 15 * Time.delta / zoom;
         }
 
         if(Core.input.keyTap(KeyCode.shiftLeft)){


### PR DESCRIPTION
VSync being disabled will make the camera move unbearably fast currently as it isnt tied to frame time.

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
