### PR TITLE
server usid group prototype

### DIFF
--- a/core/src/mindustry/Vars.java
+++ b/core/src/mindustry/Vars.java
@@ -74,6 +74,8 @@ public class Vars implements Loadable{
     /** URL to the JSON file containing all the stable servers.  */
     //TODO merge with v6 list upon release
     public static final String serverJsonURL = "https://raw.githubusercontent.com/Anuken/Mindustry/master/servers_v7.json";
+    /** Key the usid by domain instead of ip:port for these servers. */
+    public static final Seq<String> serverUsidGroups = Seq.with("mindustry.nydus.app");
     /** URL of the github issue report template.*/
     public static final String reportIssueURL = "https://github.com/Anuken/Mindustry/issues/new?labels=bug&template=bug_report.md";
     /** list of built-in servers.*/

--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -623,7 +623,14 @@ public class NetClient implements ApplicationListener{
     String getUsid(String ip){
         //consistently use the latter part of an IP, if possible
         if(ip.contains("/")){
-            ip = ip.substring(ip.indexOf("/") + 1);
+            String domain = ip.substring(0, ip.indexOf("/"));
+            String group = serverUsidGroups.find(domain::endsWith);
+
+            if(group == null){
+                ip = ip.substring(ip.indexOf("/") + 1);
+            } else {
+                ip = group;
+            }
         }
 
         if(Core.settings.getString("usid-" + ip, null) != null){


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

first pr since a long while, but one that touches a long standing issue: each ip:port having their own usid.

if you admin people ingame while they are connected or by uuid manually it works just fine, but if you have multiple servers under your wing every (player &) admin will have a different usid on each server, which makes it quite "hard" to properly check/track player identity.

in the past there were some attempts (by others via pr here) at an account system or rsa/cryptographic verification instead of the usid system, this draft is a sort of compromise to achieve the same goal somewhat.

it will store an usid for each domain in the list added by this pr, and each server that uses a domain that starts with it (including subdomains) will share it, the usids are **not** shared between different domains on this list.

vanilla servers won't really benefit from this, but it will open up some opportunities for multi-server setups (via plugins):

- securely admin players via uuid & usid across all servers via e.g. a hub
- track player progress (stats? idk) more accurately by not having to rely on just username/ip/uuid
- being able to "whitelist" a server from the hub if they join e.g. a minigame server by whitelisting their uuid + usid & preventing direct connections

these are all things i've wanted to do in versions 5 & up but were unable to due to how the usid mechanic functions.

currently the list is in vars instead of one of the 3 server jsons (since it functions independently), i suppose this might be subject to change even thought i doubt the list would get updated more than a few times, and iirc mods can still access it as a hotfix.

note that this draft does **not** support grouping by numeric ip (empty stuff before the `/` is ignored)

some comments that didn't make the cut:
```
    /** Servers that start with these domains re-use the same (admin) usid. */
    /** Domains that cause clients to group the usid (admin) */
    /** Use domain level groups instead of ip + port keys for the usid when . */
    /** Assigns a single usid to a domain . */
    /** Domains in this list get their own usid group. */
    /** Each ip:port has their own usid, unless the server's domain is part of this list: */
    /** Servers using these domains share the same usid regardless of ip:port */
    /** Servers using these domains get their own usid regardless of ip:port */
```

> mainly done in preparation of the cool stuff shown in `#dev-previews`, getting this code in place in time :)

(disclaimer: adding servers to this list would cause all players to generate new usids for those servers, but that's intended)