### PR TITLE
Splash Damage Patch

### DIFF
--- a/core/assets/contributors
+++ b/core/assets/contributors
@@ -131,3 +131,4 @@ Darkness6030
 hortiSquash
 King-BR
 citrusMarmelade
+MrDuck557

--- a/core/src/mindustry/entities/Damage.java
+++ b/core/src/mindustry/entities/Damage.java
@@ -334,7 +334,7 @@ public class Damage{
     /** Applies a status effect to all enemy units in a range. */
     public static void status(Team team, float x, float y, float radius, StatusEffect effect, float duration, boolean air, boolean ground){
         Cons<Unit> cons = entity -> {
-            if(entity.team == team || !entity.within(x, y, radius + entity.type.hitSize) || (entity.isFlying() && !air) || (entity.isGrounded() && !ground)){
+            if(entity.team == team || !entity.within(x, y, radius + entity.type.hitSize/2) || (entity.isFlying() && !air) || (entity.isGrounded() && !ground)){
                 return;
             }
 
@@ -357,10 +357,10 @@ public class Damage{
     /** Damages all entities and blocks in a radius that are enemies of the team. */
     public static void damage(Team team, float x, float y, float radius, float damage, boolean complete, boolean air, boolean ground){
         Cons<Unit> cons = entity -> {
-            if(entity.team == team || !entity.within(x, y, radius + entity.type.hitSize) || (entity.isFlying() && !air) || (entity.isGrounded() && !ground)){
+            if(entity.team == team || !entity.within(x, y, radius + entity.type.hitSize/2) || (entity.isFlying() && !air) || (entity.isGrounded() && !ground)){
                 return;
             }
-            float realDist = Math.max(0, Mathf.dst(x, y, entity.getX(), entity.getY()) - entity.type.hitSize);
+            float realDist = Math.max(0, Mathf.dst(x, y, entity.getX(), entity.getY()) - entity.type.hitSize/2);
             float amount = calculateDamage(realDist, radius, damage);
             entity.damage(amount);
             //TODO better velocity displacement

--- a/core/src/mindustry/entities/Damage.java
+++ b/core/src/mindustry/entities/Damage.java
@@ -372,7 +372,7 @@ public class Damage{
             }
         };
 
-        //100 is over any existing hitSizes, but modded units may be a problem
+        //100 is over any existing hitSize, but modded units may be a problem
         rect.setSize((radius + 100) * 2).setCenter(x, y);
         if(team != null){
             Units.nearbyEnemies(team, rect, cons);
@@ -477,7 +477,7 @@ public class Damage{
 
     private static float calculateDamage(float x, float y, float tx, float ty, float radius, float damage){
         float dist = Mathf.dst(x, y, tx, ty);
-        return calculateDamage(dist, radius, damage)
+        return calculateDamage(dist, radius, damage);
     }
 
     private static float calculateDamage(float dist, float radius, float damage){

--- a/core/src/mindustry/entities/Damage.java
+++ b/core/src/mindustry/entities/Damage.java
@@ -341,7 +341,7 @@ public class Damage{
             entity.apply(effect, duration);
         };
 
-        rect.setSize((radius + 100) * 2).setCenter(x, y);
+        rect.setSize(radius * 2).setCenter(x, y);
         if(team != null){
             Units.nearbyEnemies(team, rect, cons);
         }else{
@@ -373,7 +373,7 @@ public class Damage{
         };
 
         //100 is over any existing hitSize, but modded units may be a problem
-        rect.setSize((radius + 100) * 2).setCenter(x, y);
+        rect.setSize(radius * 2).setCenter(x, y);
         if(team != null){
             Units.nearbyEnemies(team, rect, cons);
         }else{


### PR DESCRIPTION
Before:
Hail failed to damage navanax even after visually hitting it
![navanax](https://user-images.githubusercontent.com/48808663/145218190-01a5b1d7-896d-4296-bf1d-c30e68c05e05.png)
Scatter splash damage fails to damage antumbra properly, and the base damage is cut down by armor

https://user-images.githubusercontent.com/48808663/145219294-94bded66-6b1c-4e26-8c93-cc313e8e2cec.mp4

After:
This actually works
![navanax](https://user-images.githubusercontent.com/48808663/145219442-0abd8814-f864-4acd-8c55-9057bf5c7dd7.png)
Antumbra dies properly, taking the 40 dmg splash

https://user-images.githubusercontent.com/48808663/145219541-f1d98241-af0e-43e3-8029-b11b14f3cdd6.mp4

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
