### PR TITLE
Fix assertion message

### DIFF
--- a/tests/src/test/java/GenericModTest.java
+++ b/tests/src/test/java/GenericModTest.java
@@ -27,6 +27,6 @@ public class GenericModTest{
     static void checkExistence(String modName){
         assertNotEquals(Vars.mods, null);
         assertNotEquals(Vars.mods.list().size, 0, "At least one mod must be loaded.");
-        assertEquals(Vars.mods.list().first().name, modName, modName + " must be loaded.");
+        assertEquals(modName, Vars.mods.list().first().name, modName + " must be loaded.");
     }
 }


### PR DESCRIPTION
It previously said `exotic-mod must be loaded. ==> expected: <betamindy> but was: <exotic-mod>` when it failed which makes absolutely no sense.

On the subject of tests, how would you feel about running them in parallel? They finish a bit faster and the only code that needs tweaking is the line this PR changes.

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
