### PR TITLE
Fix strange behavior of MinerAI

### DIFF
--- a/core/src/mindustry/ai/BlockIndexer.java
+++ b/core/src/mindustry/ai/BlockIndexer.java
@@ -78,8 +78,6 @@ public class BlockIndexer{
                 var drop = tile.drop();
 
                 if(drop != null){
-                    allOres.put(drop, 0);
-
                     int qx = (tile.x / quadrantSize);
                     int qy = (tile.y / quadrantSize);
 

--- a/core/src/mindustry/ai/BlockIndexer.java
+++ b/core/src/mindustry/ai/BlockIndexer.java
@@ -33,7 +33,7 @@ public class BlockIndexer{
     /** Stores all damaged tile entities by team. */
     private Seq<Building>[] damagedTiles = new Seq[Team.all.length];
     /** All ores available on this map. */
-    private ObjectSet<Item> allOres = new ObjectSet<>();
+    private ObjectIntMap<Item> allOres = new ObjectIntMap<>();
     /** Stores teams that are present here as tiles. */
     private Seq<Team> activeTeams = new Seq<>(Team.class);
     /** Maps teams to a map of flagged tiles by flag. */
@@ -78,7 +78,7 @@ public class BlockIndexer{
                 var drop = tile.drop();
 
                 if(drop != null){
-                    allOres.add(drop);
+                    allOres.put(drop, 0);
 
                     int qx = (tile.x / quadrantSize);
                     int qy = (tile.y / quadrantSize);
@@ -92,6 +92,7 @@ public class BlockIndexer{
                             ores[drop.id][qx][qy] = new IntSeq(false, 16);
                         }
                         ores[drop.id][qx][qy].add(tile.pos());
+                        allOres.increment(drop);
                     }
                 }
             }
@@ -150,9 +151,11 @@ public class BlockIndexer{
             //when the drop can be mined, record the ore position
             if(tile.block() == Blocks.air && !seq.contains(pos)){
                 seq.add(pos);
+                allOres.increment(drop);
             }else{
                 //otherwise, it likely became blocked, remove it (even if it wasn't there)
                 seq.removeValue(pos);
+                allOres.increment(drop, -1);
             }
         }
 
@@ -177,7 +180,7 @@ public class BlockIndexer{
 
     /** @return whether this item is present on this map. */
     public boolean hasOre(Item item){
-        return allOres.contains(item);
+        return allOres.get(item) > 0;
     }
 
     /** Returns all damaged tiles by team. */


### PR DESCRIPTION
See: https://discord.com/channels/391020510269669376/396416151032299521/925110542216073216

> Anuke, is the current behavior of miner ai where it wont mine anything if the item that the core has the fewest of has all of its ores covered?
The only place the hasOre code is used is miner ai so i assume thats a bug?

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
