### PR TITLE
Incorrect NaN check reset

### DIFF
--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -269,7 +269,7 @@ public class Turret extends ReloadTurret{
             }
 
             if(hasAmmo()){
-                if(Float.isNaN(reload)) rotation = 0;
+                if(Float.isNaN(reload)) reload = 0;
 
                 if(timer(timerTarget, targetInterval)){
                     findTarget();


### PR DESCRIPTION
The check for if `reload` is NaN on a turret resets `rotation` to 0 instead of `reload`.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
