### PR TITLE
Fix ammo of one item transforming into another.

### DIFF
--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -420,7 +420,7 @@ public class Turret extends ReloadTurret{
                     Time.run(burstSpacing * i, () -> {
                         if(dead || !hasAmmo()) return;
                         tr.trns(rotation, shootLength, Mathf.range(xRand));
-                        bullet(peekAmmo(), rotation + Mathf.range(inaccuracy + type.inaccuracy) + (ii - (int)(shots / 2f)) * spread);
+                        bullet(peekAmmo(), rotation + Mathf.range(inaccuracy + peekAmmo().inaccuracy) + (ii - (int)(shots / 2f)) * spread);
                         effects();
                         useAmmo();
                         recoil = recoilAmount;
@@ -435,12 +435,12 @@ public class Turret extends ReloadTurret{
                     float i = (shotCounter % shots) - (shots-1)/2f;
 
                     tr.trns(rotation - 90, spread * i + Mathf.range(xRand), shootLength);
-                    bullet(peekAmmo(), rotation + Mathf.range(inaccuracy + type.inaccuracy));
+                    bullet(type, rotation + Mathf.range(inaccuracy + type.inaccuracy));
                 }else{
                     tr.trns(rotation, shootLength, Mathf.range(xRand));
 
                     for(int i = 0; i < shots; i++){
-                        bullet(peekAmmo(), rotation + Mathf.range(inaccuracy + type.inaccuracy) + (i - (int)(shots / 2f)) * spread);
+                        bullet(peekAmmo(), rotation + Mathf.range(inaccuracy + peekAmmo().inaccuracy) + (i - (int)(shots / 2f)) * spread);
                     }
                 }
 

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -440,7 +440,7 @@ public class Turret extends ReloadTurret{
                     tr.trns(rotation, shootLength, Mathf.range(xRand));
 
                     for(int i = 0; i < shots; i++){
-                        bullet(type, rotation + Mathf.range(inaccuracy + peekAmmo().inaccuracy) + (i - (int)(shots / 2f)) * spread);
+                        bullet(type, rotation + Mathf.range(inaccuracy + type.inaccuracy) + (i - (int)(shots / 2f)) * spread);
                     }
                 }
 

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -440,7 +440,9 @@ public class Turret extends ReloadTurret{
                     tr.trns(rotation, shootLength, Mathf.range(xRand));
 
                     for(int i = 0; i < shots; i++){
-                        bullet(peekAmmo(), rotation + Mathf.range(inaccuracy + peekAmmo().inaccuracy) + (i - (int)(shots / 2f)) * spread);
+                        if(hasAmmo()){
+                            bullet(peekAmmo(), rotation + Mathf.range(inaccuracy + peekAmmo().inaccuracy) + (i - (int)(shots / 2f)) * spread);
+                        }
                     }
                 }
 

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -420,7 +420,7 @@ public class Turret extends ReloadTurret{
                     Time.run(burstSpacing * i, () -> {
                         if(dead || !hasAmmo()) return;
                         tr.trns(rotation, shootLength, Mathf.range(xRand));
-                        bullet(type, rotation + Mathf.range(inaccuracy + type.inaccuracy) + (ii - (int)(shots / 2f)) * spread);
+                        bullet(peekAmmo(), rotation + Mathf.range(inaccuracy + type.inaccuracy) + (ii - (int)(shots / 2f)) * spread);
                         effects();
                         useAmmo();
                         recoil = recoilAmount;
@@ -435,12 +435,12 @@ public class Turret extends ReloadTurret{
                     float i = (shotCounter % shots) - (shots-1)/2f;
 
                     tr.trns(rotation - 90, spread * i + Mathf.range(xRand), shootLength);
-                    bullet(type, rotation + Mathf.range(inaccuracy + type.inaccuracy));
+                    bullet(peekAmmo(), rotation + Mathf.range(inaccuracy + type.inaccuracy));
                 }else{
                     tr.trns(rotation, shootLength, Mathf.range(xRand));
 
                     for(int i = 0; i < shots; i++){
-                        bullet(type, rotation + Mathf.range(inaccuracy + type.inaccuracy) + (i - (int)(shots / 2f)) * spread);
+                        bullet(peekAmmo(), rotation + Mathf.range(inaccuracy + type.inaccuracy) + (i - (int)(shots / 2f)) * spread);
                     }
                 }
 

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -440,9 +440,7 @@ public class Turret extends ReloadTurret{
                     tr.trns(rotation, shootLength, Mathf.range(xRand));
 
                     for(int i = 0; i < shots; i++){
-                        if(hasAmmo()){
-                            bullet(peekAmmo(), rotation + Mathf.range(inaccuracy + peekAmmo().inaccuracy) + (i - (int)(shots / 2f)) * spread);
-                        }
+                        bullet(type, rotation + Mathf.range(inaccuracy + peekAmmo().inaccuracy) + (i - (int)(shots / 2f)) * spread);
                     }
                 }
 


### PR DESCRIPTION
https://user-images.githubusercontent.com/54301439/148892201-804e2c29-60bb-4040-a809-111426a75c38.mp4

What is happening in the video?

1. 1 pyratite is put into the swarmer. This adds 5 pyratite ammo.
2. 4 pyratite ammo are shot. 1 is left
3. 1 blast compound is put into the swarmer. Now there is 1 pyratite ammo and 5 blast compound ammo.
4. 4 blast compound ammo are shot. 1 is left
5. The final 2 shots should be 1 blast compound bullet and 1 pyratite bullet, however 2 blast compound bullets come out instead.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
