### PR TITLE
Unit based default controllers

### DIFF
--- a/core/src/mindustry/entities/comp/CommanderComp.java
+++ b/core/src/mindustry/entities/comp/CommanderComp.java
@@ -115,7 +115,7 @@ abstract class CommanderComp implements Entityc, Posc{
         //reset controlled units
         for(Unit unit : controlling){
             if(unit.controller().isBeingControlled(self())){
-                unit.controller(unit.type.createController());
+                unit.controller(unit.type.createController(unit));
             }
         }
 

--- a/core/src/mindustry/entities/comp/PlayerComp.java
+++ b/core/src/mindustry/entities/comp/PlayerComp.java
@@ -82,7 +82,7 @@ abstract class PlayerComp implements UnitController, Entityc, Syncc, Timerc, Dra
         textFadeTime = 0f;
         x = y = 0f;
         if(!dead()){
-            unit.controller(unit.type.createController());
+            unit.controller(unit.type.createController(unit));
             unit = Nulls.unit;
         }
     }
@@ -203,7 +203,7 @@ abstract class PlayerComp implements UnitController, Entityc, Syncc, Timerc, Dra
 
         if(this.unit != Nulls.unit){
             //un-control the old unit
-            this.unit.controller(this.unit.type.createController());
+            this.unit.controller(this.unit.type.createController(this.unit));
         }
         this.unit = unit;
         if(unit != Nulls.unit){

--- a/core/src/mindustry/entities/comp/UnitComp.java
+++ b/core/src/mindustry/entities/comp/UnitComp.java
@@ -254,7 +254,7 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
     }
 
     public void resetController(){
-        controller(type.createController());
+        controller(type.createController(self()));
     }
 
     @Override
@@ -302,7 +302,7 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
         this.hitSize = type.hitSize;
         this.hovering = type.hovering;
 
-        if(controller == null) controller(type.createController());
+        if(controller == null) controller(type.createController(self()));
         if(mounts().length != type.weapons.size) setupWeapons(type);
         if(abilities.size != type.abilities.size){
             abilities = type.abilities.map(Ability::copy);
@@ -320,7 +320,7 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
     public void afterRead(){
         afterSync();
         //reset controller state
-        controller(type.createController());
+        controller(type.createController(self()));
     }
 
     @Override

--- a/core/src/mindustry/mod/ContentParser.java
+++ b/core/src/mindustry/mod/ContentParser.java
@@ -341,6 +341,11 @@ public class ContentParser{
                     value.remove("controller");
                 }
 
+                if(value.has("unitBasedController")){
+                    unit.unitBasedDefaultController = transform(resolve(value.getString("unitBasedController"), FlyingAI.class), Unit.class);
+                    value.remove("unitBasedController");
+                }
+
                 //read extra default waves
                 if(value.has("waves")){
                     JsonValue waves = value.remove("waves");
@@ -621,6 +626,21 @@ public class ContentParser{
             return () -> {
                 try{
                     return cons.newInstance();
+                }catch(Exception e){
+                    throw new RuntimeException(e);
+                }
+            };
+        }catch(Exception e){
+            throw new RuntimeException(e);
+        }
+    }
+
+    private <U, T> Func<U, T> transform(Class<T> type, Class<U> arg){
+        try{
+            Constructor<T> cons = type.getDeclaredConstructor(arg);
+            return u -> {
+                try{
+                    return cons.newInstance(u);
                 }catch(Exception e){
                     throw new RuntimeException(e);
                 }

--- a/core/src/mindustry/type/UnitType.java
+++ b/core/src/mindustry/type/UnitType.java
@@ -48,6 +48,8 @@ public class UnitType extends UnlockableContent{
     public Prov<? extends Unit> constructor;
     /** The default AI controller to assign on creation. */
     public Prov<? extends UnitController> defaultController = () -> !flying ? new GroundAI() : new FlyingAI();
+    /** Function that chooses AI controller based on unit entity. */
+    public Func<Unit, ? extends UnitController> unitBasedDefaultController = u -> defaultController.get();
 
     /** Environmental flags that are *all* required for this unit to function. 0 = any environment */
     public int envRequired = 0;
@@ -153,8 +155,8 @@ public class UnitType extends UnlockableContent{
         constructor = EntityMapping.map(this.name);
     }
 
-    public UnitController createController(){
-        return defaultController.get();
+    public UnitController createController(Unit unit){
+        return unitBasedDefaultController.get(unit);
     }
 
     public Unit create(Team team){


### PR DESCRIPTION
### Why

In a plugin, I want to write a more concise piece of code that relates to that specific unit AI, or to any property it has (team, for instance, but could also depend on type of weapons for ground units or anything else).

One special example is: I want base building team's AI's of daggers to make a formation before pathfinding to players' base, while this is unnessesary for players' daggers. Currenty it would take `if (unit.team == state.rules.waveTeam)` check on each update call and would only bloat the implementation of AI.

I have checked the implementation by replacing default controller for Monos and with NewHorizon mod which uses some custom AIs already. Any notes about `ContentParser.java` changes would be much appreciated.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
