### PR TITLE
ArtilleryBulletType is missing some draw stuff

### DIFF
--- a/core/src/mindustry/entities/bullet/ArtilleryBulletType.java
+++ b/core/src/mindustry/entities/bullet/ArtilleryBulletType.java
@@ -1,6 +1,9 @@
 package mindustry.entities.bullet;
 
+import arc.graphics.*;
 import arc.graphics.g2d.*;
+import arc.math.*;
+import arc.util.*;
 import mindustry.content.*;
 import mindustry.gen.*;
 
@@ -58,12 +61,19 @@ public class ArtilleryBulletType extends BasicBulletType{
     @Override
     public void draw(Bullet b){
         drawTrail(b);
-        float xscale = (1f - shrinkX + b.fslope() * (shrinkX)), yscale = (1f - shrinkY + b.fslope() * (shrinkY)), rot = b.rotation();
+        float xscale = 1f - shrinkX + b.fslope() * shrinkX;
+        float yscale = 1f - shrinkY + b.fslope() * shrinkY;
+        float offset = -90 + (spin != 0 ? Mathf.randomSeed(b.id, 360f) + b.time * spin : 0f);
+
+        Color mix = Tmp.c1.set(mixColorFrom).lerp(mixColorTo, b.fin());
+
+        Draw.mixcol(mix, mix.a);
 
         Draw.color(backColor);
-        Draw.rect(backRegion, b.x, b.y, width * xscale, height * yscale, rot - 90);
+        Draw.rect(backRegion, b.x, b.y, width * xscale, height * yscale, b.rotation() - offset);
         Draw.color(frontColor);
-        Draw.rect(frontRegion, b.x, b.y, width * xscale, height * yscale, rot - 90);
-        Draw.color();
+        Draw.rect(frontRegion, b.x, b.y, width * xscale, height * yscale, b.rotation() - offset);
+
+        Draw.reset();
     }
 }

--- a/core/src/mindustry/entities/bullet/ArtilleryBulletType.java
+++ b/core/src/mindustry/entities/bullet/ArtilleryBulletType.java
@@ -70,9 +70,9 @@ public class ArtilleryBulletType extends BasicBulletType{
         Draw.mixcol(mix, mix.a);
 
         Draw.color(backColor);
-        Draw.rect(backRegion, b.x, b.y, width * xscale, height * yscale, b.rotation() - offset);
+        Draw.rect(backRegion, b.x, b.y, width * xscale, height * yscale, b.rotation() + offset);
         Draw.color(frontColor);
-        Draw.rect(frontRegion, b.x, b.y, width * xscale, height * yscale, b.rotation() - offset);
+        Draw.rect(frontRegion, b.x, b.y, width * xscale, height * yscale, b.rotation() + offset);
 
         Draw.reset();
     }

--- a/core/src/mindustry/entities/bullet/BasicBulletType.java
+++ b/core/src/mindustry/entities/bullet/BasicBulletType.java
@@ -52,9 +52,9 @@ public class BasicBulletType extends BulletType{
         Draw.mixcol(mix, mix.a);
 
         Draw.color(backColor);
-        Draw.rect(backRegion, b.x, b.y, width * xscale, height * yscale, b.rotation() - offset);
+        Draw.rect(backRegion, b.x, b.y, width * xscale, height * yscale, b.rotation() + offset);
         Draw.color(frontColor);
-        Draw.rect(frontRegion, b.x, b.y, width * xscale, height * yscale, b.rotation() - offset);
+        Draw.rect(frontRegion, b.x, b.y, width * xscale, height * yscale, b.rotation() + offset);
 
         Draw.reset();
     }

--- a/core/src/mindustry/entities/bullet/BasicBulletType.java
+++ b/core/src/mindustry/entities/bullet/BasicBulletType.java
@@ -43,8 +43,8 @@ public class BasicBulletType extends BulletType{
     @Override
     public void draw(Bullet b){
         super.draw(b);
-        float height = this.height * ((1f - shrinkY) + shrinkY * b.fout());
-        float width = this.width * ((1f - shrinkX) + shrinkX * b.fout());
+        float xscale = 1f - shrinkX * b.fin();
+        float yscale = 1f - shrinkY * b.fin();
         float offset = -90 + (spin != 0 ? Mathf.randomSeed(b.id, 360f) + b.time * spin : 0f);
 
         Color mix = Tmp.c1.set(mixColorFrom).lerp(mixColorTo, b.fin());
@@ -52,9 +52,9 @@ public class BasicBulletType extends BulletType{
         Draw.mixcol(mix, mix.a);
 
         Draw.color(backColor);
-        Draw.rect(backRegion, b.x, b.y, width, height, b.rotation() + offset);
+        Draw.rect(backRegion, b.x, b.y, width * xscale, height * yscale, b.rotation() - offset);
         Draw.color(frontColor);
-        Draw.rect(frontRegion, b.x, b.y, width, height, b.rotation() + offset);
+        Draw.rect(frontRegion, b.x, b.y, width * xscale, height * yscale, b.rotation() - offset);
 
         Draw.reset();
     }


### PR DESCRIPTION
`ArtilleryBulletType` is missing both spin and mix color because it overrides `BasicBulletType`'s draw code, so I added them. Also little format things.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.

~~Ignore the deleted newlines, I have IntelliJ set to automatically remove trailing newlines.~~