### PR TITLE
Preserve conveyors end rotation on placement

### DIFF
--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1269,18 +1269,23 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         }
 
         int endRotation = -1;
+        var start = world.build(startX, startY);
+        var end = world.build(endX, endY);
         if(diagonal){
-            var start = world.build(startX, startY);
-            var end = world.build(endX, endY);
             if(block != null && start instanceof ChainedBuilding && end instanceof ChainedBuilding
                     && block.canReplace(end.block) && block.canReplace(start.block)){
                 points = Placement.upgradeLine(startX, startY, endX, endY);
-                endRotation = end.rotation;
             }else{
                 points = Placement.pathfindLine(block != null && block.conveyorPlacement, startX, startY, endX, endY);
             }
         }else{
             points = Placement.normalizeLine(startX, startY, endX, endY);
+        }
+        if(points.size > 1 && end instanceof ChainedBuilding){
+            Point2 secondToLast = points.get(points.size - 2);
+            if (!(world.build(secondToLast.x, secondToLast.y) instanceof ChainedBuilding)) {
+                endRotation = end.rotation;
+            }
         }
 
         if(block != null){

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1283,7 +1283,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         }
         if(points.size > 1 && end instanceof ChainedBuilding){
             Point2 secondToLast = points.get(points.size - 2);
-            if (!(world.build(secondToLast.x, secondToLast.y) instanceof ChainedBuilding)) {
+            if (!(world.build(secondToLast.x, secondToLast.y) instanceof ChainedBuilding)){
                 endRotation = end.rotation;
             }
         }


### PR DESCRIPTION
When I usually play and want to connect some conveyor chain to another, it gets a little tricky as I need to point end placement not to where I want to connect to but somewhere close, and it doesn't always work as the end rotation of placement is not determined.

PR Changes this:
![fix_conveyors_end_rotation_before](https://user-images.githubusercontent.com/4199082/149617919-12744e88-9877-40d4-92a0-04faf5aaf8d1.gif)

To this:
![fix_conveyors_end_rotation_after](https://user-images.githubusercontent.com/4199082/149617922-7766abfe-e6af-4b38-b19b-14dcf0a83a34.gif)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
