### PR TITLE
Separate the Draw Z of Units and their Outlines

### DIFF
--- a/core/src/mindustry/type/UnitType.java
+++ b/core/src/mindustry/type/UnitType.java
@@ -605,7 +605,7 @@ public class UnitType extends UnlockableContent{
             drawShadow(unit);
         }
 
-        Draw.z(z - 0.02f);
+        Draw.z(z - 0.03f);
 
         if(mech != null){
             drawMech(mech);
@@ -623,7 +623,7 @@ public class UnitType extends UnlockableContent{
             drawLegs((Unit & Legsc)unit);
         }
 
-        Draw.z(Math.min(z - 0.01f, Layer.bullet - 1f));
+        Draw.z(Math.min(z - 0.02f, Layer.bullet - 1f));
 
         if(unit instanceof Payloadc){
             drawPayload((Unit & Payloadc)unit);
@@ -631,10 +631,13 @@ public class UnitType extends UnlockableContent{
 
         drawSoftShadow(unit);
 
-        Draw.z(z);
+        Draw.z(z - 0.1f);
 
         if(drawBody) drawOutline(unit);
         drawWeaponOutlines(unit);
+
+        Draw.z(z);
+
         if(engineSize > 0) drawEngine(unit);
         if(drawBody) drawBody(unit);
         if(drawCell) drawCell(unit);


### PR DESCRIPTION
With a separation of layer between outlines and the rest of the unit, this allows for `layerOffset` on weapons to actually be able to put the weapon between the main body and the outline.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
