### PR TITLE
Restoring the natural order of things

### DIFF
--- a/servers_v6.json
+++ b/servers_v6.json
@@ -1,15 +1,15 @@
 [
   {
-    "name": "Infection",
-    "address": ["n3.mindustry.me:5555", "n3.mindustry.me:5004"]
+    "name": "{AA}",
+    "address": ["aamindustry.play.ai", "aamindustry.play.ai:6571", "aamindustry.play.ai:6572", "aamindustry.play.ai:6573", "aamindustry.play.ai:6574"]
+  },
+  {
+    "name": "Yeet Hosting",
+    "address": ["n3.mindustry.me:5004"]
   },
   {
     "name": "RCM",
     "address": ["185.104.248.61", "easyplay.su"]
-  },
-  {
-    "name": "{AA}",
-    "address": ["aamindustry.play.ai", "aamindustry.play.ai:6571", "aamindustry.play.ai:6572", "aamindustry.play.ai:6573", "aamindustry.play.ai:6574"]
   },
   {
     "name": "Atanner",


### PR DESCRIPTION
Renamed Infection to Yeet Hosting, as Infection has dissolved due to recessive's return, and Yeet Hosting was our hosts when it was up. Also removed an unused YH port from the list and shifted AA up to honor Recessive's return.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [ ] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
