### PR TITLE
onConfigureClosed

### DIFF
--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -1249,6 +1249,11 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
         return self() != other;
     }
 
+    /**
+     * Called when this block's config menu is closed
+     */
+    public void onConfigureClosed(){}
+
     /** Returns whether this config menu should show when the specified player taps it. */
     public boolean shouldShowConfigure(Player player){
         return true;

--- a/core/src/mindustry/ui/fragments/BlockConfigFragment.java
+++ b/core/src/mindustry/ui/fragments/BlockConfigFragment.java
@@ -49,6 +49,7 @@ public class BlockConfigFragment extends Fragment{
     }
 
     public void showConfig(Building tile){
+        if(configTile != null) configTile.onConfigureClosed();
         if(tile.configTapped()){
             configTile = tile;
 

--- a/core/src/mindustry/ui/fragments/BlockConfigFragment.java
+++ b/core/src/mindustry/ui/fragments/BlockConfigFragment.java
@@ -82,6 +82,7 @@ public class BlockConfigFragment extends Fragment{
     }
 
     public void hideConfig(){
+        if(configTile != null) configTile.onConfigureClosed();
         configTile = null;
         table.actions(Actions.scaleTo(0f, 1f, 0.06f, Interp.pow3Out), Actions.visible(false));
     }


### PR DESCRIPTION
Just so that you can run something when a block's config menu is closed.
~~Don't ask why I need this.~~

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
