### PR TITLE
Shoot/smoke color

### DIFF
--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -49,10 +49,16 @@ public class BulletType extends Content implements Cloneable{
     public Effect despawnEffect = Fx.hitBulletSmall;
     /** Effect created when shooting. */
     public Effect shootEffect = Fx.shootSmall;
+    /** Shooting effect color. */
+    public Color shootColor;
     /** Effect created when charging completes; only usable in single-shot weapons with a firstShotDelay / shotDelay. */
     public Effect chargeShootEffect = Fx.none;
+    /** Charging completion effect color */
+    public Color chargeShootColor;
     /** Extra smoke effect created when shooting. */
     public Effect smokeEffect = Fx.shootSmallSmoke;
+    /** Smoke effect color */
+    public Color smokeColor;
     /** Sound made when hitting something or getting removed.*/
     public Sound hitSound = Sounds.none;
     /** Sound made when hitting something or getting removed.*/
@@ -422,7 +428,12 @@ public class BulletType extends Content implements Cloneable{
         if(lightRadius == -1){
             lightRadius = Math.max(18, hitSize * 5f);
         }
+
         drawSize = Math.max(drawSize, trailLength * speed * 2f);
+
+        if(shootColor == null) shootColor = Color.white;
+        if(chargeShootColor == null) chargeShootColor = Color.white;
+        if(smokeColor == null) smokeColor = Color.white;
     }
 
     @Override

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -127,6 +127,14 @@ public class BulletType extends Content implements Cloneable{
 
     //additional effects
 
+    /**
+     * Should status and despawnHit should be automatically set.
+     *
+     * By default, status is set to StatusEffect.shocked when lightning > 0,
+     * and despawnHit is set to true if there's splash damage, frag, or lightning
+     */
+    public boolean autoDefaults = true;
+
     public float fragCone = 360f;
     public float fragAngle = 0f;
     public int fragBullets = 9;
@@ -411,18 +419,20 @@ public class BulletType extends Content implements Cloneable{
             //pierceBuilding is not enabled by default, because a bullet may want to *not* pierce buildings
         }
 
-        if(lightning > 0){
-            if(status == StatusEffects.none){
-                status = StatusEffects.shocked;
+        if(autoDefaults){
+            if(lightning > 0){
+                if(status == StatusEffects.none){
+                    status = StatusEffects.shocked;
+                }
+            }
+
+            if(fragBullet != null || splashDamageRadius > 0 || lightning > 0){
+                despawnHit = true;
             }
         }
 
         if(lightningType == null){
             lightningType = !collidesAir ? Bullets.damageLightningGround : Bullets.damageLightning;
-        }
-
-        if(fragBullet != null || splashDamageRadius > 0 || lightning > 0){
-            despawnHit = true;
         }
 
         if(lightRadius == -1){

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -50,15 +50,15 @@ public class BulletType extends Content implements Cloneable{
     /** Effect created when shooting. */
     public Effect shootEffect = Fx.shootSmall;
     /** Shooting effect color. */
-    public Color shootColor;
+    public @Nullable Color shootColor;
     /** Effect created when charging completes; only usable in single-shot weapons with a firstShotDelay / shotDelay. */
     public Effect chargeShootEffect = Fx.none;
     /** Charging completion effect color */
-    public Color chargeShootColor;
+    public @Nullable Color chargeShootColor;
     /** Extra smoke effect created when shooting. */
     public Effect smokeEffect = Fx.shootSmallSmoke;
     /** Smoke effect color */
-    public Color smokeColor;
+    public @Nullable Color smokeColor;
     /** Sound made when hitting something or getting removed.*/
     public Sound hitSound = Sounds.none;
     /** Sound made when hitting something or getting removed.*/

--- a/core/src/mindustry/entities/bullet/LiquidBulletType.java
+++ b/core/src/mindustry/entities/bullet/LiquidBulletType.java
@@ -44,6 +44,15 @@ public class LiquidBulletType extends BulletType{
     }
 
     @Override
+    public void init(){
+        if(shootColor == null) shootColor = liquid.color;
+        if(chargeShootColor == null) chargeShootColor = liquid.color;
+        if(smokeColor == null) smokeColor = liquid.color;
+
+        super.init();
+    }
+
+    @Override
     public void update(Bullet b){
         super.update(b);
 

--- a/core/src/mindustry/type/Weapon.java
+++ b/core/src/mindustry/type/Weapon.java
@@ -357,7 +357,7 @@ public class Weapon implements Cloneable{
                 if(!continuous){
                     shootSound.at(shootX, shootY, Mathf.random(soundPitchMin, soundPitchMax));
                 }
-                ammo.chargeShootEffect.at(shootX + unit.x - baseX, shootY + unit.y - baseY, rotation, parentize ? unit : null);
+                ammo.chargeShootEffect.at(shootX + unit.x - baseX, shootY + unit.y - baseY, rotation, ammo.chargeShootColor, parentize ? unit : null);
             });
         }else{
             unit.vel.add(Tmp.v1.trns(rotation + 180f, ammo.recoil));
@@ -367,8 +367,8 @@ public class Weapon implements Cloneable{
         }
 
         ejectEffect.at(mountX, mountY, rotation * side);
-        ammo.shootEffect.at(shootX, shootY, rotation, parentize ? unit : null);
-        ammo.smokeEffect.at(shootX, shootY, rotation, parentize ? unit : null);
+        ammo.shootEffect.at(shootX, shootY, rotation, ammo.shootColor, parentize ? unit : null);
+        ammo.smokeEffect.at(shootX, shootY, rotation, ammo.smokeColor, parentize ? unit : null);
         unit.apply(shootStatus, shootStatusDuration);
     }
 

--- a/core/src/mindustry/world/blocks/defense/turrets/LiquidTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/LiquidTurret.java
@@ -127,24 +127,6 @@ public class LiquidTurret extends Turret{
         }
 
         @Override
-        protected void effects(){
-            BulletType type = peekAmmo();
-
-            Effect fshootEffect = shootEffect == Fx.none ? type.shootEffect : shootEffect;
-            Effect fsmokeEffect = smokeEffect == Fx.none ? type.smokeEffect : smokeEffect;
-
-            fshootEffect.at(x + tr.x, y + tr.y, rotation, liquids.current().color);
-            fsmokeEffect.at(x + tr.x, y + tr.y, rotation, liquids.current().color);
-            shootSound.at(tile);
-
-            if(shootShake > 0){
-                Effect.shake(shootShake, shootShake, tile.build);
-            }
-
-            recoil = recoilAmount;
-        }
-
-        @Override
         public BulletType useAmmo(){
             if(cheating()) return ammoTypes.get(liquids.current());
             BulletType type = ammoTypes.get(liquids.current());

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -460,11 +460,13 @@ public class Turret extends ReloadTurret{
         }
 
         protected void effects(){
-            Effect fshootEffect = shootEffect == Fx.none ? peekAmmo().shootEffect : shootEffect;
-            Effect fsmokeEffect = smokeEffect == Fx.none ? peekAmmo().smokeEffect : smokeEffect;
+            BulletType b = peekAmmo();
 
-            fshootEffect.at(x + tr.x, y + tr.y, rotation);
-            fsmokeEffect.at(x + tr.x, y + tr.y, rotation);
+            Effect fshootEffect = shootEffect == Fx.none ? b.shootEffect : shootEffect;
+            Effect fsmokeEffect = smokeEffect == Fx.none ? b.smokeEffect : smokeEffect;
+
+            fshootEffect.at(x + tr.x, y + tr.y, rotation, b.shootColor);
+            fsmokeEffect.at(x + tr.x, y + tr.y, rotation, b.smokeColor);
             shootSound.at(x + tr.x, y + tr.y, Mathf.random(0.9f, 1.1f));
 
             if(shootShake > 0){


### PR DESCRIPTION
Adds `shootColor`, `chargeShootColor`, and `smokeColor` to `BulletType`. Shooting will use these colors for their effects. `Color.white` by default on most bullets, `liquid.color` on `LiquidBulletType`s.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
