### PR TITLE
Option to not hardcode a bullet's `status` and `despawnHit`

### DIFF
--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -120,6 +120,9 @@ public class BulletType extends Content implements Cloneable{
     public boolean despawnHit = false;
 
     //additional effects
+    
+    /** Whether status and despawnHit should automatically be set. */
+    public boolean setDefaults = true;
 
     public float fragCone = 360f;
     public float fragAngle = 0f;
@@ -405,9 +408,15 @@ public class BulletType extends Content implements Cloneable{
             //pierceBuilding is not enabled by default, because a bullet may want to *not* pierce buildings
         }
 
-        if(lightning > 0){
-            if(status == StatusEffects.none){
-                status = StatusEffects.shocked;
+        if(setDefaults){
+            if(lightning > 0){
+                if(status == StatusEffects.none){
+                    status = StatusEffects.shocked;
+                }
+            }
+
+            if(fragBullet != null || splashDamageRadius > 0 || lightning > 0){
+                despawnHit = true;
             }
         }
 
@@ -415,13 +424,10 @@ public class BulletType extends Content implements Cloneable{
             lightningType = !collidesAir ? Bullets.damageLightningGround : Bullets.damageLightning;
         }
 
-        if(fragBullet != null || splashDamageRadius > 0 || lightning > 0){
-            despawnHit = true;
-        }
-
         if(lightRadius == -1){
             lightRadius = Math.max(18, hitSize * 5f);
         }
+        
         drawSize = Math.max(drawSize, trailLength * speed * 2f);
     }
 

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -424,7 +424,7 @@ public class BulletType extends Content implements Cloneable{
             lightningType = !collidesAir ? Bullets.damageLightningGround : Bullets.damageLightning;
         }
 
-        if(lightRadius == -1){
+        if(lightRadius <= -1){
             lightRadius = Math.max(18, hitSize * 5f);
         }
         


### PR DESCRIPTION
Yes this is something I had to do in PM so that despawning does not create lightning.
![bruh](https://user-images.githubusercontent.com/54301439/152291092-5952ba01-27a8-4cf9-9793-b64daa80f9ab.png)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
