### PR TITLE
Do not the overlap.

### DIFF
--- a/core/src/mindustry/core/UI.java
+++ b/core/src/mindustry/core/UI.java
@@ -303,6 +303,7 @@ public class UI implements ApplicationListener, Loadable{
         Table table = new Table();
         table.touchable = Touchable.disabled;
         table.setFillParent(true);
+        table.marginTop(Core.scene.find("coreinfo").getPrefHeight() / Scl.scl() / 2);
         table.actions(Actions.fadeOut(7f, Interp.fade), Actions.remove());
         table.top().add(info).style(Styles.outlineLabel).padTop(10);
         Core.scene.add(table);
@@ -311,8 +312,9 @@ public class UI implements ApplicationListener, Loadable{
     /** Shows a fading label at the top of the screen. */
     public void showInfoToast(String info, float duration){
         Table table = new Table();
-        table.setFillParent(true);
         table.touchable = Touchable.disabled;
+        table.setFillParent(true);
+        table.marginTop(Core.scene.find("coreinfo").getPrefHeight() / Scl.scl() / 2);
         table.update(() -> {
             if(state.isMenu()) table.remove();
         });


### PR DESCRIPTION
I got sick of waiting for this to get patched in vanilla so I did it myself.
All this does is move toasts and info fades below the ui, doesn't do much in vanilla but is handy for modders and people

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
