### PR TITLE
Save fires from being colored

### DIFF
--- a/core/src/mindustry/entities/comp/FireComp.java
+++ b/core/src/mindustry/entities/comp/FireComp.java
@@ -1,6 +1,7 @@
 package mindustry.entities.comp;
 
 import arc.*;
+import arc.graphics.*;
 import arc.graphics.g2d.*;
 import arc.math.*;
 import arc.math.geom.*;
@@ -115,7 +116,7 @@ abstract class FireComp implements Timedc, Posc, Syncc, Drawc{
             }
         }
 
-        Draw.alpha(Mathf.clamp(warmup / warmupDuration));
+        Draw.color(Color.white, Mathf.clamp(warmup / warmupDuration));
         Draw.z(Layer.effect);
         Draw.rect(regions[Math.min((int)animation, regions.length - 1)], x + Mathf.randomSeedRange((int)y, 2), y + Mathf.randomSeedRange((int)x, 2));
         Draw.reset();


### PR DESCRIPTION
Fires are critically endangered.
For some reason, fires soak up colors from bullets...?

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
