### PR TITLE
Move `powerUse` to `Turret` + fix turret power consumption conditions

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -1829,6 +1829,7 @@ public class Blocks implements ContentList{
 
             maxAmmo = 40;
             ammoPerShot = 5;
+            powerUse = 10f;
             rotateSpeed = 2f;
             reloadTime = 200f;
             ammoUseEffect = Fx.casing3Double;
@@ -1846,8 +1847,6 @@ public class Blocks implements ContentList{
 
             health = 150 * size * size;
             coolantUsage = 1f;
-
-            consumes.powerCond(10f, TurretBuild::isActive);
         }};
 
         spectre = new ItemTurret("spectre"){{

--- a/core/src/mindustry/world/blocks/defense/turrets/LaserTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/LaserTurret.java
@@ -25,7 +25,7 @@ public class LaserTurret extends PowerTurret{
 
     @Override
     public void init(){
-        consumes.powerCond(powerUse, entity -> ((LaserTurretBuild)entity).bullet != null || ((LaserTurretBuild)entity).target != null);
+        consumes.powerCond(powerUse, entity -> ((LaserTurretBuild)entity).bullet != null || ((LaserTurretBuild)entity).isActive());
         super.init();
     }
 

--- a/core/src/mindustry/world/blocks/defense/turrets/PowerTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/PowerTurret.java
@@ -7,11 +7,10 @@ import mindustry.world.meta.*;
 
 public class PowerTurret extends Turret{
     public BulletType shootType;
-    public float powerUse = 1f;
 
     public PowerTurret(String name){
         super(name);
-        hasPower = true;
+        powerUse = 1f;
         envEnabled |= Env.space;
     }
 
@@ -19,12 +18,6 @@ public class PowerTurret extends Turret{
     public void setStats(){
         super.setStats();
         stats.add(Stat.ammo, StatValues.ammo(ObjectMap.of(this, shootType)));
-    }
-
-    @Override
-    public void init(){
-        consumes.powerCond(powerUse, TurretBuild::isActive);
-        super.init();
     }
 
     public class PowerTurretBuild extends TurretBuild{

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -156,7 +156,7 @@ public class Turret extends ReloadTurret{
         public @Nullable Posc target;
         public Vec2 targetPos = new Vec2();
         public BlockUnitc unit = (BlockUnitc)UnitTypes.block.create(team);
-        public boolean wasShooting, charging;
+        public boolean wasRotating, wasShooting, charging;
 
         @Override
         public boolean canControl(){
@@ -219,7 +219,7 @@ public class Turret extends ReloadTurret{
         }
 
         public boolean isActive(){
-            return (target != null || wasShooting) && enabled;
+            return (wasRotating || wasShooting) && enabled;
         }
 
         public void targetPosition(Posc pos){
@@ -261,6 +261,7 @@ public class Turret extends ReloadTurret{
         public void updateTile(){
             if(!validateTarget()) target = null;
 
+            wasRotating = false;
             wasShooting = false;
 
             recoil = Mathf.lerpDelta(recoil, 0f, restitution);
@@ -344,6 +345,7 @@ public class Turret extends ReloadTurret{
 
         protected void turnToTarget(float targetRot){
             rotation = Angles.moveToward(rotation, targetRot, rotateSpeed * delta() * baseReloadSpeed());
+            wasRotating = Mathf.mod(rotation, 360f) != Mathf.mod(targetRot, 360f);
         }
 
         public boolean shouldTurn(){

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -53,6 +53,7 @@ public class Turret extends ReloadTurret{
     public float restitution = 0.02f;
     public float cooldown = 0.02f;
     public float coolantUsage = 0.2f;
+    public float powerUse;
     public float shootCone = 8f;
     public float shootShake = 0f;
     public float shootLength = -1;
@@ -119,6 +120,11 @@ public class Turret extends ReloadTurret{
 
     @Override
     public void init(){
+        if(powerUse > 0){
+            hasPower = true;
+            consumes.powerCond(powerUse, TurretBuild::isActive);
+        }
+
         if(acceptCoolant && !consumes.has(ConsumeType.liquid)){
             hasLiquids = true;
             consumes.add(new ConsumeCoolant(coolantUsage)).update(false).boost();


### PR DESCRIPTION
- Moved `powerUse` from `PowerTurret` to `Turret` so that json mods can use it, since using `consumes` make it constantly consume power.
- Fixed the conditions on when it should consume power.
  - The turret would consume power when it has a target, but is not shooting due to logic or player control.

https://user-images.githubusercontent.com/54301439/153058894-6d02e444-e56e-4a41-be62-1f5977d4b0ea.mp4

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
