### PR TITLE
Allows for different Pixels/Area

### DIFF
--- a/core/src/mindustry/world/blocks/logic/LogicDisplay.java
+++ b/core/src/mindustry/world/blocks/logic/LogicDisplay.java
@@ -29,7 +29,7 @@ public class LogicDisplay extends Block{
     public int maxSides = 25;
 
     public int displaySize = 64;
-    public float scaleFactor = 1f
+    public float scaleFactor = 1f;
 
     public LogicDisplay(String name){
         super(name);

--- a/core/src/mindustry/world/blocks/logic/LogicDisplay.java
+++ b/core/src/mindustry/world/blocks/logic/LogicDisplay.java
@@ -102,7 +102,7 @@ public class LogicDisplay extends Block{
             Draw.blend(Blending.disabled);
             Draw.draw(Draw.z(), () -> {
                 if(buffer != null){
-                    Draw.rect(Draw.wrap(buffer.getTexture()), x, y, buffer.getWidth() * Draw.scl, -buffer.getHeight() * Draw.scl);
+                    Draw.rect(Draw.wrap(buffer.getTexture()), x, y, size * 32 * Draw.scl - 4, -(size * 32 * Draw.scl - 4));
                 }
             });
             Draw.blend();

--- a/core/src/mindustry/world/blocks/logic/LogicDisplay.java
+++ b/core/src/mindustry/world/blocks/logic/LogicDisplay.java
@@ -29,6 +29,7 @@ public class LogicDisplay extends Block{
     public int maxSides = 25;
 
     public int displaySize = 64;
+    public float scaleFactor = 1f
 
     public LogicDisplay(String name){
         super(name);
@@ -102,7 +103,7 @@ public class LogicDisplay extends Block{
             Draw.blend(Blending.disabled);
             Draw.draw(Draw.z(), () -> {
                 if(buffer != null){
-                    Draw.rect(Draw.wrap(buffer.getTexture()), x, y, size * 32 * Draw.scl - 4, -(size * 32 * Draw.scl - 4));
+                    Draw.rect(Draw.wrap(buffer.getTexture()), x, y, scaleFactor * Draw.scl, -scaleFactor * Draw.scl);
                 }
             });
             Draw.blend();

--- a/core/src/mindustry/world/blocks/logic/LogicDisplay.java
+++ b/core/src/mindustry/world/blocks/logic/LogicDisplay.java
@@ -103,7 +103,7 @@ public class LogicDisplay extends Block{
             Draw.blend(Blending.disabled);
             Draw.draw(Draw.z(), () -> {
                 if(buffer != null){
-                    Draw.rect(Draw.wrap(buffer.getTexture()), x, y, buffer.getWidth() * scaleFactor * Draw.scl, -buffer.getWidth() * scaleFactor * Draw.scl);
+                    Draw.rect(Draw.wrap(buffer.getTexture()), x, y, buffer.getWidth() * scaleFactor * Draw.scl, -buffer.getHeight() * scaleFactor * Draw.scl);
                 }
             });
             Draw.blend();

--- a/core/src/mindustry/world/blocks/logic/LogicDisplay.java
+++ b/core/src/mindustry/world/blocks/logic/LogicDisplay.java
@@ -103,7 +103,7 @@ public class LogicDisplay extends Block{
             Draw.blend(Blending.disabled);
             Draw.draw(Draw.z(), () -> {
                 if(buffer != null){
-                    Draw.rect(Draw.wrap(buffer.getTexture()), x, y, scaleFactor * Draw.scl, -scaleFactor * Draw.scl);
+                    Draw.rect(Draw.wrap(buffer.getTexture()), x, y, buffer.getWidth() * scaleFactor * Draw.scl, -buffer.getWidth() * scaleFactor * Draw.scl);
                 }
             });
             Draw.blend();


### PR DESCRIPTION
Spent the entire day asking people if they knew of any mod that change would break, the answer is negative

modders, if you want the screen to take the entire space, remove both the -4

test : doesnt break current displays, automatically does borders, left one is 512x512 9x9 tiles
![image](https://user-images.githubusercontent.com/45213805/153079060-cff0d901-6393-498c-9eed-0307b15ab5c3.png)


- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
