### PR TITLE
Enable Rhino Context pre-init

### DIFF
--- a/core/src/mindustry/core/Platform.java
+++ b/core/src/mindustry/core/Platform.java
@@ -79,9 +79,10 @@ public interface Platform{
     }
 
     default Context getScriptContext(){
-        Context c = Context.enter();
-        c.setOptimizationLevel(9);
-        return c;
+        Context context = Context.getCurrentContext();
+        if(context == null) context = Context.enter();
+        context.setOptimizationLevel(9);
+        return context;
     }
 
     /** Update discord RPC. */


### PR DESCRIPTION
This change aims to give more control over the JavaScript runtime for servers by trying to use the current context instead of always creating a new one.

It works since the `Plugin` instances are created before the scripts so you just have to do funny stuff in the constructor.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
