### PR TITLE
Reorder weapon firing effects & chargeEffect

### DIFF
--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -465,7 +465,7 @@ public class UnitTypes implements ContentList{
                     despawnEffect = Fx.smokeCloud;
                     smokeEffect = Fx.none;
 
-                    shootEffect = Fx.greenLaserChargeSmall;
+                    chargeEffect = Fx.greenLaserChargeSmall;
 
                     incendChance = 0.1f;
                     incendSpread = 5f;
@@ -554,7 +554,7 @@ public class UnitTypes implements ContentList{
                     largeHit = true;
                     lightColor = lightningColor = Pal.heal;
 
-                    shootEffect = Fx.greenLaserCharge;
+                    chargeEffect = Fx.greenLaserCharge;
 
                     healPercent = 25f;
                     collidesTeam = true;

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -49,8 +49,8 @@ public class BulletType extends Content implements Cloneable{
     public Effect despawnEffect = Fx.hitBulletSmall;
     /** Effect created when shooting. */
     public Effect shootEffect = Fx.shootSmall;
-    /** Effect created when charging completes; only usable in single-shot weapons with a firstShotDelay / shotDelay. */
-    public Effect chargeShootEffect = Fx.none;
+    /** Effect created when charging starts; only usable in single-shot weapons with a firstShotDelay / shotDelay. */
+    public Effect chargeEffect = Fx.none;
     /** Extra smoke effect created when shooting. */
     public Effect smokeEffect = Fx.shootSmallSmoke;
     /** Sound made when hitting something or getting removed.*/

--- a/core/src/mindustry/type/Weapon.java
+++ b/core/src/mindustry/type/Weapon.java
@@ -347,6 +347,7 @@ public class Weapon implements Cloneable{
         boolean parentize = ammo.keepVelocity || parentizeEffects;
 
         if(delay){
+            ammo.chargeEffect.at(shootX, shootY, rotation, parentize ? unit : null);
             Time.run(firstShotDelay, () -> {
                 if(!unit.isAdded()) return;
 
@@ -357,18 +358,21 @@ public class Weapon implements Cloneable{
                 if(!continuous){
                     shootSound.at(shootX, shootY, Mathf.random(soundPitchMin, soundPitchMax));
                 }
-                ammo.chargeShootEffect.at(shootX + unit.x - baseX, shootY + unit.y - baseY, rotation, parentize ? unit : null);
+                ammo.shootEffect.at(shootX + unit.x - baseX, shootY + unit.y - baseY, rotation, parentize ? unit : null);
+                ammo.smokeEffect.at(shootX, shootY, rotation, parentize ? unit : null);
+                ejectEffect.at(mountX, mountY, rotation * side);
             });
         }else{
             unit.vel.add(Tmp.v1.trns(rotation + 180f, ammo.recoil));
             Effect.shake(shake, shake, shootX, shootY);
             mount.recoil = recoil;
             mount.heat = 1f;
+
+            ammo.shootEffect.at(shootX, shootY, rotation, parentize ? unit : null);
+            ammo.smokeEffect.at(shootX, shootY, rotation, parentize ? unit : null);
+            ejectEffect.at(mountX, mountY, rotation * side);
         }
 
-        ejectEffect.at(mountX, mountY, rotation * side);
-        ammo.shootEffect.at(shootX, shootY, rotation, parentize ? unit : null);
-        ammo.smokeEffect.at(shootX, shootY, rotation, parentize ? unit : null);
         unit.apply(shootStatus, shootStatusDuration);
     }
 


### PR DESCRIPTION
makes `chargeEffect` (formerly `chargeShootEffect`) get called when the weapon starts charging and calls `shootEffect`, `smokeEffect` and `ejectEffect` after charging. Vela and Corvus changed to conform with these changes.

*will* break a lot of mod units, at least graphically.

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
