### PR TITLE
Add `DamageSource` and `DamageEvent`

### DIFF
--- a/core/src/mindustry/ai/WaveSpawner.java
+++ b/core/src/mindustry/ai/WaveSpawner.java
@@ -98,7 +98,7 @@ public class WaveSpawner{
 
     public void doShockwave(float x, float y){
         Fx.spawnShockwave.at(x, y, state.rules.dropZoneRadius);
-        Damage.damage(state.rules.waveTeam, x, y, state.rules.dropZoneRadius, 99999999f, true);
+        Damage.damage(state.rules.waveTeam, x, y, state.rules.dropZoneRadius, 99999999f, true, DamageSource.SpawnShockwave);
     }
 
     public void eachGroundSpawn(Intc2 cons){

--- a/core/src/mindustry/content/StatusEffects.java
+++ b/core/src/mindustry/content/StatusEffects.java
@@ -4,13 +4,12 @@ import arc.*;
 import arc.graphics.*;
 import arc.math.*;
 import mindustry.ctype.*;
-import mindustry.game.*;
 import mindustry.game.EventType.*;
-import mindustry.type.*;
+import mindustry.game.*;
 import mindustry.graphics.*;
+import mindustry.type.*;
 
-
-import static mindustry.Vars.*;
+import static mindustry.Vars.state;
 
 public class StatusEffects implements ContentList{
     public static StatusEffect none, burning, freezing, unmoving, slow, wet, muddy, melting, sapped, tarred, overdrive, overclock, shielded, shocked, blasted, corroded, boss, sporeSlowed, disarmed, electrified, invincible;
@@ -28,8 +27,9 @@ public class StatusEffects implements ContentList{
 
             init(() -> {
                 opposite(wet, freezing);
+                final AffinityDamage source = new AffinityDamage(this, tarred);
                 affinity(tarred, (unit, result, time) -> {
-                    unit.damagePierce(transitionDamage);
+                    unit.damagePierce(transitionDamage, source);
                     Fx.burning.at(unit.x + Mathf.range(unit.bounds() / 2f), unit.y + Mathf.range(unit.bounds() / 2f));
                     result.set(burning, Math.min(time + result.time, 300f));
                 });
@@ -46,8 +46,9 @@ public class StatusEffects implements ContentList{
             init(() -> {
                 opposite(melting, burning);
 
+                final AffinityDamage source = new AffinityDamage(this, tarred);
                 affinity(blasted, (unit, result, time) -> {
-                    unit.damagePierce(transitionDamage);
+                    unit.damagePierce(transitionDamage, source);
                 });
             });
         }};
@@ -70,8 +71,9 @@ public class StatusEffects implements ContentList{
             transitionDamage = 14;
 
             init(() -> {
+                final AffinityDamage source = new AffinityDamage(this, shocked);
                 affinity(shocked, (unit, result, time) -> {
-                    unit.damagePierce(transitionDamage);
+                    unit.damagePierce(transitionDamage, source);
                     if(unit.team == state.rules.waveTeam){
                         Events.fire(Trigger.shock);
                     }
@@ -97,8 +99,9 @@ public class StatusEffects implements ContentList{
 
             init(() -> {
                 opposite(wet, freezing);
+                final AffinityDamage source = new AffinityDamage(this, tarred);
                 affinity(tarred, (unit, result, time) -> {
-                    unit.damagePierce(8f);
+                    unit.damagePierce(8f, source);
                     Fx.burning.at(unit.x + Mathf.range(unit.bounds() / 2f), unit.y + Mathf.range(unit.bounds() / 2f));
                     result.set(melting, Math.min(time + result.time, 200f));
                 });

--- a/core/src/mindustry/entities/Damage.java
+++ b/core/src/mindustry/entities/Damage.java
@@ -30,23 +30,31 @@ public class Damage{
     private static IntFloatMap damages = new IntFloatMap();
 
     /** Creates a dynamic explosion based on specified parameters. */
+    @Deprecated
     public static void dynamicExplosion(float x, float y, float flammability, float explosiveness, float power, float radius, boolean damage){
         dynamicExplosion(x, y, flammability, explosiveness, power, radius, damage, true, null, Fx.dynamicExplosion);
     }
 
     /** Creates a dynamic explosion based on specified parameters. */
+    @Deprecated
     public static void dynamicExplosion(float x, float y, float flammability, float explosiveness, float power, float radius, boolean damage, Effect explosionFx){
         dynamicExplosion(x, y, flammability, explosiveness, power, radius, damage, true, null, explosionFx);
     }
 
     /** Creates a dynamic explosion based on specified parameters. */
+    @Deprecated
     public static void dynamicExplosion(float x, float y, float flammability, float explosiveness, float power, float radius, boolean damage, boolean fire, @Nullable Team ignoreTeam){
         dynamicExplosion(x, y, flammability, explosiveness, power, radius, damage, fire, ignoreTeam, Fx.dynamicExplosion);
     }
 
     /** Creates a dynamic explosion based on specified parameters. */
+    @Deprecated
     public static void dynamicExplosion(float x, float y, float flammability, float explosiveness, float power, float radius, boolean damage, boolean fire, @Nullable Team ignoreTeam, Effect explosionFx){
+        dynamicExplosion(x, y, flammability, explosiveness, power, radius, damage, fire, ignoreTeam, explosionFx, DamageSource.Unknown);
+    }
+    public static void dynamicExplosion(float x, float y, float flammability, float explosiveness, float power, float radius, boolean damage, boolean fire, @Nullable Team ignoreTeam, Effect explosionFx, DamageSource source){
         if(damage){
+            final DamageSource source2 = new DamageSource.Explosion(source);
             for(int i = 0; i < Mathf.clamp(power / 700, 0, 8); i++){
                 int length = 5 + Mathf.clamp((int)(Mathf.pow(power, 0.98f) / 500), 1, 18);
                 Time.run(i * 0.8f + Mathf.random(4f), () -> Lightning.create(Team.derelict, Pal.power, 3 + Mathf.pow(power, 0.35f), x, y, Mathf.random(360f), length + Mathf.range(2)));
@@ -63,7 +71,7 @@ public class Damage{
             for(int i = 0; i < waves; i++){
                 int f = i;
                 Time.run(i * 2f, () -> {
-                    damage(ignoreTeam, x, y, Mathf.clamp(radius + explosiveness, 0, 50f) * ((f + 1f) / waves), explosiveness / 2f, false);
+                    damage(ignoreTeam, x, y, Mathf.clamp(radius + explosiveness, 0, 50f) * ((f + 1f) / waves), explosiveness / 2f, false, true, true, source2);
                     Fx.blockExplosionSmoke.at(x + Mathf.range(radius), y + Mathf.range(radius));
                 });
             }
@@ -296,7 +304,12 @@ public class Damage{
     }
 
     /** Damages all entities and blocks in a radius that are enemies of the team. */
+    @Deprecated
     public static void damageUnits(Team team, float x, float y, float size, float damage, Boolf<Unit> predicate, Cons<Unit> acceptor){
+        damageUnits(team, x, y, size, damage, predicate, acceptor, DamageSource.Unknown);
+    }
+    /** Damages all entities and blocks in a radius that are enemies of the team. */
+    public static void damageUnits(Team team, float x, float y, float size, float damage, Boolf<Unit> predicate, Cons<Unit> acceptor, DamageSource source){
         Cons<Unit> cons = entity -> {
             if(!predicate.get(entity)) return;
 
@@ -304,7 +317,7 @@ public class Damage{
             if(!hitrect.overlaps(rect)){
                 return;
             }
-            entity.damage(damage);
+            entity.damage(damage, source);
             acceptor.get(entity);
         };
 
@@ -317,18 +330,35 @@ public class Damage{
     }
 
     /** Damages everything in a radius. */
+    @Deprecated
     public static void damage(float x, float y, float radius, float damage){
-        damage(null, x, y, radius, damage, false);
+        damage(x, y, radius, damage, DamageSource.Unknown);
+    }
+    /** Damages everything in a radius. */
+    public static void damage(float x, float y, float radius, float damage, DamageSource source){
+        damage(null, x, y, radius, damage, false, source);
     }
 
     /** Damages all entities and blocks in a radius that are enemies of the team. */
+    @Deprecated
     public static void damage(Team team, float x, float y, float radius, float damage){
-        damage(team, x, y, radius, damage, false);
+        damage(team, x, y, radius, damage, DamageSource.Unknown);
     }
 
     /** Damages all entities and blocks in a radius that are enemies of the team. */
+    public static void damage(Team team, float x, float y, float radius, float damage, DamageSource source){
+        damage(team, x, y, radius, damage, false, source);
+    }
+
+    /** Damages all entities and blocks in a radius that are enemies of the team. */
+    @Deprecated
     public static void damage(Team team, float x, float y, float radius, float damage, boolean air, boolean ground){
-        damage(team, x, y, radius, damage, false, air, ground);
+        damage(team, x, y, radius, damage, air, ground, DamageSource.Unknown);
+    }
+
+    /** Damages all entities and blocks in a radius that are enemies of the team. */
+    public static void damage(Team team, float x, float y, float radius, float damage, boolean air, boolean ground, DamageSource source){
+        damage(team, x, y, radius, damage, false, air, ground, source);
     }
 
     /** Applies a status effect to all enemy units in a range. */
@@ -350,18 +380,29 @@ public class Damage{
     }
 
     /** Damages all entities and blocks in a radius that are enemies of the team. */
+    @Deprecated
     public static void damage(Team team, float x, float y, float radius, float damage, boolean complete){
-        damage(team, x, y, radius, damage, complete, true, true);
+        damage(team, x, y, radius, damage, complete, DamageSource.Unknown);
+    }
+    /** Damages all entities and blocks in a radius that are enemies of the team. */
+    public static void damage(Team team, float x, float y, float radius, float damage, boolean complete, DamageSource source){
+        damage(team, x, y, radius, damage, complete, true, true, source);
     }
 
     /** Damages all entities and blocks in a radius that are enemies of the team. */
+    @Deprecated()
     public static void damage(Team team, float x, float y, float radius, float damage, boolean complete, boolean air, boolean ground){
+        damage(team, x, y, radius, damage, complete, air, ground, DamageSource.Unknown);
+    }
+
+    /** Damages all entities and blocks in a radius that are enemies of the team. */
+    public static void damage(Team team, float x, float y, float radius, float damage, boolean complete, boolean air, boolean ground, DamageSource source){
         Cons<Unit> cons = entity -> {
             if(entity.team == team || !entity.within(x, y, radius) || (entity.isFlying() && !air) || (entity.isGrounded() && !ground)){
                 return;
             }
             float amount = calculateDamage(x, y, entity.getX(), entity.getY(), radius, damage);
-            entity.damage(amount);
+            entity.damage(amount, source);
             //TODO better velocity displacement
             float dst = tr.set(entity.getX() - x, entity.getY() - y).len();
             entity.vel.add(tr.setLength((1f - dst / radius) * 2f / entity.mass()));
@@ -380,15 +421,18 @@ public class Damage{
 
         if(ground){
             if(!complete){
-                tileDamage(team, World.toTile(x), World.toTile(y), radius / tilesize, damage);
+                tileDamage(team, World.toTile(x), World.toTile(y), radius / tilesize, damage, source);
             }else{
-                completeDamage(team, x, y, radius, damage);
+                completeDamage(team, x, y, radius, damage, source);
             }
         }
     }
 
+    @Deprecated
     public static void tileDamage(Team team, int x, int y, float baseRadius, float damage){
-
+        tileDamage(team, x, y, baseRadius, damage, DamageSource.Unknown);
+    }
+    public static void tileDamage(Team team, int x, int y, float baseRadius, float damage, DamageSource source){
         Core.app.post(() -> {
 
             var in = world.build(x, y);
@@ -397,7 +441,7 @@ public class Damage{
             //this needs to be compensated
             if(in != null && in.team != team && in.block.size > 1 && in.health > damage){
                 //deal the damage of an entire side, to be equivalent with maximum 'standard' damage
-                in.damage(team, damage * Math.min((in.block.size), baseRadius * 0.4f));
+                in.damage(damage * Math.min((in.block.size), baseRadius * 0.4f), source);
                 //no need to continue with the explosion
                 return;
             }
@@ -454,20 +498,20 @@ public class Damage{
                 int cx = Point2.x(e.key), cy = Point2.y(e.key);
                 var build = world.build(cx, cy);
                 if(build != null){
-                    build.damage(team, e.value);
+                    build.damage(e.value, source);
                 }
             }
         });
     }
 
-    private static void completeDamage(Team team, float x, float y, float radius, float damage){
+    private static void completeDamage(Team team, float x, float y, float radius, float damage, DamageSource source){
 
         int trad = (int)(radius / tilesize);
         for(int dx = -trad; dx <= trad; dx++){
             for(int dy = -trad; dy <= trad; dy++){
                 Tile tile = world.tile(Math.round(x / tilesize) + dx, Math.round(y / tilesize) + dy);
                 if(tile != null && tile.build != null && (team == null ||team.isEnemy(tile.team())) && dx*dx + dy*dy <= trad*trad){
-                    tile.build.damage(team, damage);
+                    tile.build.damage(damage, source);
                 }
             }
         }

--- a/core/src/mindustry/entities/DamageSource.java
+++ b/core/src/mindustry/entities/DamageSource.java
@@ -1,0 +1,32 @@
+package mindustry.entities;
+
+import mindustry.gen.*;
+
+public interface DamageSource{
+    DamageSource Unknown = new DamageSource(){
+    };
+    DamageSource Fire = new DamageSource(){
+    };
+    DamageSource LiquidReaction = new DamageSource(){
+    };
+    DamageSource GeneratorExplode = new DamageSource(){
+    };
+    DamageSource SpawnShockwave = new DamageSource(){
+    };
+
+    class Explosion implements DamageSource{
+        public Explosion(DamageSource realSource){
+            this.realSource = realSource;
+        }
+
+        public final DamageSource realSource;
+    }
+
+    class UnitCrash implements DamageSource{
+        public UnitCrash(Unit unit){
+            this.unit = unit;
+        }
+
+        public final Unit unit;
+    }
+}

--- a/core/src/mindustry/entities/abilities/EnergyFieldAbility.java
+++ b/core/src/mindustry/entities/abilities/EnergyFieldAbility.java
@@ -140,11 +140,7 @@ public class EnergyFieldAbility extends Ability{
                     }
                 }else{
                     anyNearby = true;
-                    if(other instanceof Building b){
-                        b.damage(unit.team, damage);
-                    }else{
-                        other.damage(damage);
-                    }
+                    other.damage(damage, unit);
                     if(other instanceof Statusc s){
                         s.apply(status, statusDuration);
                     }

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -234,7 +234,7 @@ public class BulletType extends Content implements Cloneable{
 
     public void hitEntity(Bullet b, Hitboxc entity, float health){
         if(entity instanceof Healthc h){
-            h.damage(b.damage);
+            h.damage(b.damage, b);
         }
 
         if(entity instanceof Unit unit){
@@ -280,7 +280,7 @@ public class BulletType extends Content implements Cloneable{
         }
 
         if(splashDamageRadius > 0 && !b.absorbed){
-            Damage.damage(b.team, x, y, splashDamageRadius, splashDamage * b.damageMultiplier(), collidesAir, collidesGround);
+            Damage.damage(b.team, x, y, splashDamageRadius, splashDamage * b.damageMultiplier(), collidesAir, collidesGround, b);
 
             if(status != StatusEffects.none){
                 Damage.status(b.team, x, y, splashDamageRadius, status, statusDuration, collidesAir, collidesGround);

--- a/core/src/mindustry/entities/bullet/EmpBulletType.java
+++ b/core/src/mindustry/entities/bullet/EmpBulletType.java
@@ -41,7 +41,7 @@ public class EmpBulletType extends BasicBulletType{
                     if(other.power != null && other.power.graph.getLastPowerProduced() > 0f){
                         other.timeScale = Math.min(other.timeScale, powerSclDecrease);
                         other.timeScaleDuration = timeDuration;
-                        other.damage(damage * powerDamageScl);
+                        other.damage(damage * powerDamageScl, b);
                         hitPowerEffect.at(other.x, other.y, b.angleTo(other), hitColor);
                         chainEffect.at(x, y, 0, hitColor, other);
                     }
@@ -58,7 +58,7 @@ public class EmpBulletType extends BasicBulletType{
 
                         hitPowerEffect.at(other.x, other.y, b.angleTo(other), hitColor);
                         chainEffect.at(x, y, 0, hitColor, other);
-                        other.damage(damage * unitDamageScl);
+                        other.damage(damage * unitDamageScl, b);
                         other.apply(status, statusDuration);
                     }
                 });

--- a/core/src/mindustry/entities/comp/BlockUnitComp.java
+++ b/core/src/mindustry/entities/comp/BlockUnitComp.java
@@ -2,6 +2,7 @@ package mindustry.entities.comp;
 
 import arc.graphics.g2d.*;
 import mindustry.annotations.Annotations.*;
+import mindustry.entities.*;
 import mindustry.game.*;
 import mindustry.gen.*;
 
@@ -42,8 +43,8 @@ abstract class BlockUnitComp implements Unitc{
     }
 
     @Replace
-    public void damage(float v, boolean b){
-        tile.damage(v, b);
+    public void damage(float v, boolean b, DamageSource source){
+        tile.damage(v, b, source);
     }
 
     @Replace

--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -1432,7 +1432,9 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
     @Override
     public void damage(float damage, DamageSource source){
         if(dead()) return;
-        //TODO damageEvent
+
+        damage = DamageEvent.fire(self(), damage, source);
+        if(damage <= 0) return;
 
         float dm = state.rules.blockHealth(team);
 

--- a/core/src/mindustry/entities/comp/BulletComp.java
+++ b/core/src/mindustry/entities/comp/BulletComp.java
@@ -8,6 +8,7 @@ import arc.util.*;
 import mindustry.annotations.Annotations.*;
 import mindustry.content.*;
 import mindustry.core.*;
+import mindustry.entities.*;
 import mindustry.entities.bullet.*;
 import mindustry.game.*;
 import mindustry.game.Teams.*;
@@ -20,7 +21,7 @@ import static mindustry.Vars.*;
 
 @EntityDef(value = {Bulletc.class}, pooled = true, serialize = false)
 @Component(base = true)
-abstract class BulletComp implements Timedc, Damagec, Hitboxc, Teamc, Posc, Drawc, Shielderc, Ownerc, Velc, Bulletc, Timerc{
+abstract class BulletComp implements Timedc, Damagec, Hitboxc, Teamc, Posc, Drawc, Shielderc, Ownerc, Velc, Bulletc, Timerc, DamageSource{
     @Import Team team;
     @Import Entityc owner;
     @Import float x, y, damage;

--- a/core/src/mindustry/entities/comp/FireComp.java
+++ b/core/src/mindustry/entities/comp/FireComp.java
@@ -99,11 +99,11 @@ abstract class FireComp implements Timedc, Posc, Syncc, Drawc{
             puddleFlammability = p != null ? p.getFlammability() / 3f : 0;
 
             if(damage){
-                entity.damage(tileDamage);
+                entity.damage(tileDamage, DamageSource.Fire);
             }
             Damage.damageUnits(null, tile.worldx(), tile.worldy(), tilesize, unitDamage,
             unit -> !unit.isFlying() && !unit.isImmune(StatusEffects.burning),
-            unit -> unit.apply(StatusEffects.burning, 60 * 5));
+            unit -> unit.apply(StatusEffects.burning, 60 * 5), DamageSource.Fire);
         }
     }
 

--- a/core/src/mindustry/entities/comp/HealthComp.java
+++ b/core/src/mindustry/entities/comp/HealthComp.java
@@ -3,6 +3,7 @@ package mindustry.entities.comp;
 import arc.util.*;
 import mindustry.annotations.Annotations.*;
 import mindustry.entities.*;
+import mindustry.game.EventType.*;
 import mindustry.gen.*;
 
 @Component
@@ -102,7 +103,9 @@ abstract class HealthComp implements Entityc, Posc{
     }
 
     void damage(float amount, DamageSource source){
-        //TODO damageEvent
+        amount = DamageEvent.fire(self(), amount, source);
+        if(amount <= 0) return;
+
         health -= amount;
         hitTime = 1f;
         if(health <= 0 && !dead){

--- a/core/src/mindustry/entities/comp/HealthComp.java
+++ b/core/src/mindustry/entities/comp/HealthComp.java
@@ -54,7 +54,7 @@ abstract class HealthComp implements Entityc, Posc{
      * Damage and pierce armor.
      * @deprecated use function with source
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated()
     void damagePierce(float amount, boolean withEffect){
         damagePierce(amount, withEffect, DamageSource.Unknown);
     }
@@ -63,31 +63,31 @@ abstract class HealthComp implements Entityc, Posc{
      * Damage and pierce armor.
      * @deprecated use function with source
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated()
     void damagePierce(float amount){
         damagePierce(amount, DamageSource.Unknown);
     }
 
     /** @deprecated use function with source */
-    @Deprecated(forRemoval = true)
+    @Deprecated()
     void damage(float amount){
         damage(amount, DamageSource.Unknown);
     }
 
     /** @deprecated use function with source */
-    @Deprecated(forRemoval = true)
+    @Deprecated()
     void damage(float amount, boolean withEffect){
         damage(amount, withEffect, DamageSource.Unknown);
     }
 
     /** @deprecated use function with source */
-    @Deprecated(forRemoval = true)
+    @Deprecated()
     void damageContinuous(float amount){
         damageContinuous(amount, DamageSource.Unknown);
     }
 
     /** @deprecated use function with source */
-    @Deprecated(forRemoval = true)
+    @Deprecated()
     void damageContinuousPierce(float amount){
         damageContinuousPierce(amount, DamageSource.Unknown);
     }

--- a/core/src/mindustry/entities/comp/HealthComp.java
+++ b/core/src/mindustry/entities/comp/HealthComp.java
@@ -2,6 +2,7 @@ package mindustry.entities.comp;
 
 import arc.util.*;
 import mindustry.annotations.Annotations.*;
+import mindustry.entities.*;
 import mindustry.gen.*;
 
 @Component
@@ -48,17 +49,60 @@ abstract class HealthComp implements Entityc, Posc{
         return health < maxHealth - 0.001f;
     }
 
-    /** Damage and pierce armor. */
+    /**
+     * Damage and pierce armor.
+     * @deprecated use function with source
+     */
+    @Deprecated(forRemoval = true)
     void damagePierce(float amount, boolean withEffect){
-        damage(amount, withEffect);
+        damagePierce(amount, withEffect, DamageSource.Unknown);
+    }
+
+    /**
+     * Damage and pierce armor.
+     * @deprecated use function with source
+     */
+    @Deprecated(forRemoval = true)
+    void damagePierce(float amount){
+        damagePierce(amount, DamageSource.Unknown);
+    }
+
+    /** @deprecated use function with source */
+    @Deprecated(forRemoval = true)
+    void damage(float amount){
+        damage(amount, DamageSource.Unknown);
+    }
+
+    /** @deprecated use function with source */
+    @Deprecated(forRemoval = true)
+    void damage(float amount, boolean withEffect){
+        damage(amount, withEffect, DamageSource.Unknown);
+    }
+
+    /** @deprecated use function with source */
+    @Deprecated(forRemoval = true)
+    void damageContinuous(float amount){
+        damageContinuous(amount, DamageSource.Unknown);
+    }
+
+    /** @deprecated use function with source */
+    @Deprecated(forRemoval = true)
+    void damageContinuousPierce(float amount){
+        damageContinuousPierce(amount, DamageSource.Unknown);
     }
 
     /** Damage and pierce armor. */
-    void damagePierce(float amount){
-        damagePierce(amount, true);
+    void damagePierce(float amount, boolean withEffect, DamageSource source){
+        damage(amount, withEffect, source);
     }
 
-    void damage(float amount){
+    /** Damage and pierce armor. */
+    void damagePierce(float amount, DamageSource source){
+        damagePierce(amount, true, source);
+    }
+
+    void damage(float amount, DamageSource source){
+        //TODO damageEvent
         health -= amount;
         hitTime = 1f;
         if(health <= 0 && !dead){
@@ -66,22 +110,22 @@ abstract class HealthComp implements Entityc, Posc{
         }
     }
 
-    void damage(float amount, boolean withEffect){
+    void damage(float amount, boolean withEffect, DamageSource source){
         float pre = hitTime;
 
-        damage(amount);
+        damage(amount, source);
 
         if(!withEffect){
             hitTime = pre;
         }
     }
 
-    void damageContinuous(float amount){
-        damage(amount * Time.delta, hitTime <= -10 + hitDuration);
+    void damageContinuous(float amount, DamageSource source){
+        damage(amount * Time.delta, hitTime <= -10 + hitDuration, source);
     }
 
-    void damageContinuousPierce(float amount){
-        damagePierce(amount * Time.delta, hitTime <= -20 + hitDuration);
+    void damageContinuousPierce(float amount, DamageSource source){
+        damagePierce(amount * Time.delta, hitTime <= -20 + hitDuration, source);
     }
 
     void clampHealth(){

--- a/core/src/mindustry/entities/comp/LegsComp.java
+++ b/core/src/mindustry/entities/comp/LegsComp.java
@@ -148,7 +148,7 @@ abstract class LegsComp implements Posc, Rotc, Hitboxc, Flyingc, Unitc{
                     }
 
                     if(type.legSplashDamage > 0){
-                        Damage.damage(team, l.base.x, l.base.y, type.legSplashRange, type.legSplashDamage, false, true);
+                        Damage.damage(team, l.base.x, l.base.y, type.legSplashRange, type.legSplashDamage, false, true, self());
                     }
                 }
 

--- a/core/src/mindustry/entities/comp/ShieldComp.java
+++ b/core/src/mindustry/entities/comp/ShieldComp.java
@@ -4,10 +4,11 @@ import arc.util.*;
 import mindustry.annotations.Annotations.*;
 import mindustry.content.*;
 import mindustry.entities.*;
+import mindustry.game.EventType.*;
 import mindustry.game.*;
 import mindustry.gen.*;
 
-import static mindustry.Vars.*;
+import static mindustry.Vars.minArmorDamage;
 
 @Component
 abstract class ShieldComp implements Healthc, Posc{
@@ -45,7 +46,9 @@ abstract class ShieldComp implements Healthc, Posc{
     }
 
     private void rawDamage(float amount, DamageSource source){
-        //TODO damageEvent
+        amount = DamageEvent.fire(self(), amount, source);
+        if(amount <= 0) return;
+
         boolean hadShields = shield > 0.0001f;
 
         if(hadShields){

--- a/core/src/mindustry/entities/comp/ShieldComp.java
+++ b/core/src/mindustry/entities/comp/ShieldComp.java
@@ -3,6 +3,7 @@ package mindustry.entities.comp;
 import arc.util.*;
 import mindustry.annotations.Annotations.*;
 import mindustry.content.*;
+import mindustry.entities.*;
 import mindustry.game.*;
 import mindustry.gen.*;
 
@@ -23,27 +24,28 @@ abstract class ShieldComp implements Healthc, Posc{
 
     @Replace
     @Override
-    public void damage(float amount){
+    public void damage(float amount, DamageSource source){
         //apply armor
         amount = Math.max(amount - armor, minArmorDamage * amount);
         amount /= healthMultiplier;
 
-        rawDamage(amount);
+        rawDamage(amount, source);
     }
 
     @Replace
     @Override
-    public void damagePierce(float amount, boolean withEffect){
+    public void damagePierce(float amount, boolean withEffect, DamageSource source){
         float pre = hitTime;
 
-        rawDamage(amount);
+        rawDamage(amount, source);
 
         if(!withEffect){
             hitTime = pre;
         }
     }
 
-    private void rawDamage(float amount){
+    private void rawDamage(float amount, DamageSource source){
+        //TODO damageEvent
         boolean hadShields = shield > 0.0001f;
 
         if(hadShields){

--- a/core/src/mindustry/entities/comp/UnitComp.java
+++ b/core/src/mindustry/entities/comp/UnitComp.java
@@ -31,7 +31,7 @@ import static mindustry.Vars.*;
 import static mindustry.logic.GlobalConstants.*;
 
 @Component(base = true)
-abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, Itemsc, Rotc, Unitc, Weaponsc, Drawc, Boundedc, Syncc, Shieldc, Commanderc, Displayable, Senseable, Ranged, Minerc, Builderc{
+abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, Itemsc, Rotc, Unitc, Weaponsc, Drawc, Boundedc, Syncc, Shieldc, Commanderc, Displayable, Senseable, Ranged, Minerc, Builderc, DamageSource{
 
     @Import boolean hovering, dead, disarmed;
     @Import float x, y, rotation, elevation, maxHealth, drag, armor, hitSize, health, ammo, minFormationSpeed, dragMultiplier;
@@ -443,7 +443,7 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
 
             //apply damage
             if(floor.damageTaken > 0f){
-                damageContinuous(floor.damageTaken);
+                damageContinuous(floor.damageTaken, floor);
             }
         }
 
@@ -487,7 +487,7 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
         float power = item().charge * Mathf.pow(stack().amount, 1.11f) * 160f;
 
         if(!spawnedByCore){
-            Damage.dynamicExplosion(x, y, flammability, explosiveness, power, bounds() / 2f, state.rules.damageExplosions, item().flammability > 1, team, type.deathExplosionEffect);
+            Damage.dynamicExplosion(x, y, flammability, explosiveness, power, bounds() / 2f, state.rules.damageExplosions, item().flammability > 1, team, type.deathExplosionEffect, self());
         }else{
             type.deathExplosionEffect.at(x, y, bounds() / 2f / 8f);
         }
@@ -514,7 +514,7 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
 
         //if this unit crash landed (was flying), damage stuff in a radius
         if(type.flying && !spawnedByCore){
-            Damage.damage(team, x, y, Mathf.pow(hitSize, 0.94f) * 1.25f, Mathf.pow(hitSize, 0.75f) * type.crashDamageMultiplier * 5f, true, false, true);
+            Damage.damage(team, x, y, Mathf.pow(hitSize, 0.94f) * 1.25f, Mathf.pow(hitSize, 0.75f) * type.crashDamageMultiplier * 5f, true, false, true, new UnitCrash(self()));
         }
 
         if(!headless){

--- a/core/src/mindustry/game/EventType.java
+++ b/core/src/mindustry/game/EventType.java
@@ -1,8 +1,10 @@
 package mindustry.game;
 
+import arc.*;
 import arc.util.*;
 import mindustry.core.GameState.*;
 import mindustry.ctype.*;
+import mindustry.entities.*;
 import mindustry.entities.units.*;
 import mindustry.gen.*;
 import mindustry.net.*;
@@ -565,6 +567,38 @@ public class EventType{
             this.player = player;
             this.other = other;
             this.action = action;
+        }
+    }
+
+    /**
+     * WARNING! This event's instance is reused!
+     * To cache it or use with a timer or nest damage, call {@code noReuse}
+     * Can only modify {@code damage}
+     */
+    public static class DamageEvent{
+        public Healthc unitOrBuilding;
+        public DamageSource source;
+        /** <=0, this damage will be cancelled */
+        public float damage;
+
+        private boolean reusable = true;
+
+        public void noReuse(){
+            reusable = false;
+        }
+
+        private static DamageEvent inst = new DamageEvent();
+
+        /** @return damage after handle */
+        public static float fire(Healthc unitOrBuilding, float damage, DamageSource source){
+            if(!inst.reusable)
+                inst = new DamageEvent();
+            DamageEvent inst = DamageEvent.inst;//may change nest damage
+            inst.unitOrBuilding = unitOrBuilding;
+            inst.damage = damage;
+            inst.source = source;
+            Events.fire(inst);
+            return inst.damage;
         }
     }
 }

--- a/core/src/mindustry/type/StatusEffect.java
+++ b/core/src/mindustry/type/StatusEffect.java
@@ -12,7 +12,19 @@ import mindustry.entities.units.*;
 import mindustry.gen.*;
 import mindustry.world.meta.*;
 
-public class StatusEffect extends UnlockableContent{
+public class StatusEffect extends UnlockableContent implements DamageSource{
+    public static class AffinityDamage implements DamageSource{
+        public final StatusEffect a, b;
+
+        public AffinityDamage(StatusEffect a, StatusEffect b){
+            this.a = a;
+            this.b = b;
+        }
+
+        public boolean about(StatusEffect s){
+            return a == s || b == s;
+        }
+    }
     /** Damage dealt by the unit with the effect. */
     public float damageMultiplier = 1f;
     /** Unit health multiplier. */
@@ -115,7 +127,7 @@ public class StatusEffect extends UnlockableContent{
     /** Runs every tick on the affected unit while time is greater than 0. */
     public void update(Unit unit, float time){
         if(damage > 0){
-            unit.damageContinuousPierce(damage);
+            unit.damageContinuousPierce(damage, this);
         }else if(damage < 0){ //heal unit
             unit.heal(-1f * damage * Time.delta);
         }

--- a/core/src/mindustry/world/blocks/defense/ShockMine.java
+++ b/core/src/mindustry/world/blocks/defense/ShockMine.java
@@ -58,7 +58,7 @@ public class ShockMine extends Block{
         public void unitOn(Unit unit){
             if(enabled && unit.team != team && timer(timerDamage, cooldown)){
                 triggered();
-                damage(tileDamage);
+                damage(tileDamage, this);
             }
         }
 

--- a/core/src/mindustry/world/blocks/defense/turrets/TractorBeamTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/TractorBeamTurret.java
@@ -119,7 +119,7 @@ public class TractorBeamTurret extends BaseTurret{
                 //shoot when possible
                 if(Angles.within(rotation, dest, shootCone)){
                     if(damage > 0){
-                        target.damageContinuous(damage * efficiency());
+                        target.damageContinuous(damage * efficiency(), this);
                     }
 
                     if(status != StatusEffects.none){

--- a/core/src/mindustry/world/blocks/environment/Floor.java
+++ b/core/src/mindustry/world/blocks/environment/Floor.java
@@ -18,7 +18,7 @@ import mindustry.world.*;
 
 import static mindustry.Vars.*;
 
-public class Floor extends Block{
+public class Floor extends Block implements DamageSource{
     /** edge fallback, used mainly for ores */
     public String edge = "stone";
     /** Multiplies unit velocity by this when walked on. */

--- a/core/src/mindustry/world/blocks/power/ImpactReactor.java
+++ b/core/src/mindustry/world/blocks/power/ImpactReactor.java
@@ -143,7 +143,7 @@ public class ImpactReactor extends PowerGenerator{
 
             Sounds.explosionbig.at(this);
 
-            Damage.damage(x, y, explosionRadius * tilesize, explosionDamage * 4);
+            Damage.damage(x, y, explosionRadius * tilesize, explosionDamage * 4, new Explosion(this));
 
             Effect.shake(6f, 16f, x, y);
             explodeEffect.at(x, y);

--- a/core/src/mindustry/world/blocks/power/ItemLiquidGenerator.java
+++ b/core/src/mindustry/world/blocks/power/ItemLiquidGenerator.java
@@ -148,7 +148,7 @@ public class ItemLiquidGenerator extends PowerGenerator{
                     if(randomlyExplode && state.rules.reactorExplosions && Mathf.chance(delta() * 0.06 * Mathf.clamp(explosiveness - 0.5f))){
                         //this block is run last so that in the event of a block destruction, no code relies on the block type
                         Core.app.post(() -> {
-                            damage(Mathf.random(11f));
+                            damage(Mathf.random(11f), DamageSource.GeneratorExplode);
                             explodeEffect.at(x + Mathf.range(size * tilesize / 2f), y + Mathf.range(size * tilesize / 2f));
                         });
                     }

--- a/core/src/mindustry/world/blocks/power/NuclearReactor.java
+++ b/core/src/mindustry/world/blocks/power/NuclearReactor.java
@@ -140,7 +140,7 @@ public class NuclearReactor extends PowerGenerator{
 
             Effect.shake(6f, 16f, x, y);
             // * ((float)fuel / itemCapacity) to scale based on fullness
-            Damage.damage(x, y, explosionRadius * tilesize, explosionDamage * 4);
+            Damage.damage(x, y, explosionRadius * tilesize, explosionDamage * 4, new Explosion(this));
 
             explodeEffect.at(x, y);
         }

--- a/core/src/mindustry/world/blocks/storage/CoreBlock.java
+++ b/core/src/mindustry/world/blocks/storage/CoreBlock.java
@@ -211,7 +211,7 @@ public class CoreBlock extends StorageBlock{
         }
 
         @Override
-        @Deprecated(forRemoval = true)
+        @Deprecated()
         public void damage(Team source, float damage){
             if(iframes > 0) return;
             if(source != null && source != team){

--- a/core/src/mindustry/world/blocks/storage/CoreBlock.java
+++ b/core/src/mindustry/world/blocks/storage/CoreBlock.java
@@ -211,13 +211,23 @@ public class CoreBlock extends StorageBlock{
         }
 
         @Override
-        public void damage(@Nullable Team source, float damage){
+        @Deprecated(forRemoval = true)
+        public void damage(Team source, float damage){
             if(iframes > 0) return;
-
             if(source != null && source != team){
                 lastDamage = source;
             }
-            super.damage(source, damage);
+            super.damage(damage, DamageSource.Unknown);
+        }
+
+        @Override
+        public void damage(float amount, DamageSource source){
+            if(iframes > 0) return;
+
+            if(source instanceof Teamc){
+                lastDamage = ((Teamc)source).team();
+            }
+            super.damage(amount, source);
         }
 
         @Override
@@ -283,7 +293,7 @@ public class CoreBlock extends StorageBlock{
         public void onDestroyed(){
             if(state.rules.coreCapture){
                 //just create an explosion, no fire. this prevents immediate recapture
-                Damage.dynamicExplosion(x, y, 0, 0, 0, tilesize * block.size / 2f, state.rules.damageExplosions);
+                Damage.dynamicExplosion(x, y, 0, 0, 0, tilesize * block.size / 2f, state.rules.damageExplosions, true, null, Fx.dynamicExplosion, this);
                 Fx.commandSend.at(x, y, 140f);
             }else{
                 super.onDestroyed();


### PR DESCRIPTION
Add new interface `DamageSource`, Building/Unit/Bullet/StatusEffect extends it. And some special type.
Make all damage function accept `DamageSource`.
No BREAKCHANGE, all old functions using DamageSource.Unknown, and set `deprecated`

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
