### PR TITLE
For some reason the load world doesn't fire a WLE

### DIFF
--- a/core/src/mindustry/ui/dialogs/LoadDialog.java
+++ b/core/src/mindustry/ui/dialogs/LoadDialog.java
@@ -214,6 +214,7 @@ public class LoadDialog extends BaseDialog{
                     state.rules.editor = false;
                     state.rules.sector = null;
                     state.set(State.playing);
+                    Events.fire(new WorldLoadEvent());
                 }catch(SaveException e){
                     Log.err(e);
                     logic.reset();


### PR DESCRIPTION
This probably doesn't work, but I don't know how loading games work and I'm not qualified to make a PR for this.
https://github.com/AvantTeam/ProjectUnityPublic/issues/27#issuecomment-1060657206

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
