### PR TITLE
Allow force projectors to not have item consumption

### DIFF
--- a/core/src/mindustry/world/blocks/defense/ForceProjector.java
+++ b/core/src/mindustry/world/blocks/defense/ForceProjector.java
@@ -130,7 +130,7 @@ public class ForceProjector extends Block{
 
         @Override
         public void updateTile(){
-            boolean phaseValid = consumes.get(ConsumeType.item).valid(this);
+            boolean phaseValid = consumes.has(ConsumeType.item) && consumes.getItem().valid(this);
 
             phaseHeat = Mathf.lerpDelta(phaseHeat, Mathf.num(phaseValid), 0.1f);
 


### PR DESCRIPTION
Adds a `consumes.has(ConsumeType.item)` so that the game doesn't crash of a force projector does not have item consumption.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
