### PR TITLE
LiquidRouters - Loosen Throughput Reduction

### DIFF
--- a/core/src/mindustry/world/blocks/liquid/LiquidRouter.java
+++ b/core/src/mindustry/world/blocks/liquid/LiquidRouter.java
@@ -16,7 +16,7 @@ public class LiquidRouter extends LiquidBlock{
         @Override
         public void updateTile(){
             if(liquids.total() > 0.01f){
-                dumpLiquid(liquids.current());
+                dumpLiquid(liquids.current(), 1.1f);
             }
         }
 


### PR DESCRIPTION
temporary fix at best, but can improve the throughput by ~30% up to 4-5 routers in a row, and then go a tiny bit lower than with default scaling, but youre not supposed to have that many in a row anyways. 1.4-1.5 were good all rounders if you prefer. Didnt introduce bugs on my end, but i saw bugs when going lower like 1.01.

I mostly wanted to initiate the conversation about liquid routers. I want to fix them, and for real.
With no reduction (`scaling=1f`), its perfect, but backflow can make them hoard liquid that goes back and forth between two routers forever, and thats why you added that reduction by half, right?

I believe i can fix that if i modify `dumpLiquid()` to behave differently when outputting in the block it recieved liquid from the last. A solution i tried in here (using last block outputted into, so it keeps alternating and blinking cause its very bad), but the  speed is quite nice despite not being perfect (430-450/s compared to the full 500/s) (yes i dont play at 60fps) (and yes, it works less well at 60fps).
![image](https://user-images.githubusercontent.com/45213805/159137487-55c83c66-fb8b-42e1-bf77-796a2696c53e.png)

I am also proposing another solution: separate tanks/containers from routers, and remove all inventory from routers. And make them act like item gates or liquid junctions, just be a direct transfer. Which would have the side effect of trivializing cryo schematics for beginners, and reduce lag from anti-jam logic.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
