### PR TITLE
Refactor some power consumption

### DIFF
--- a/core/src/mindustry/mod/ClassMap.java
+++ b/core/src/mindustry/mod/ClassMap.java
@@ -249,7 +249,6 @@ public class ClassMap{
         classes.put("BatteryBuild", mindustry.world.blocks.power.Battery.BatteryBuild.class);
         classes.put("BurnerGenerator", mindustry.world.blocks.power.BurnerGenerator.class);
         classes.put("BurnerGeneratorBuild", mindustry.world.blocks.power.BurnerGenerator.BurnerGeneratorBuild.class);
-        classes.put("ConditionalConsumePower", mindustry.world.blocks.power.ConditionalConsumePower.class);
         classes.put("DecayGenerator", mindustry.world.blocks.power.DecayGenerator.class);
         classes.put("ImpactReactor", mindustry.world.blocks.power.ImpactReactor.class);
         classes.put("ImpactReactorBuild", mindustry.world.blocks.power.ImpactReactor.ImpactReactorBuild.class);

--- a/core/src/mindustry/mod/ClassMap.java
+++ b/core/src/mindustry/mod/ClassMap.java
@@ -1,6 +1,7 @@
 package mindustry.mod;
 
 import arc.struct.*;
+
 /** Generated class. Maps simple class names to concrete classes. For use in JSON mods. */
 @SuppressWarnings("deprecation")
 public class ClassMap{
@@ -250,7 +251,6 @@ public class ClassMap{
         classes.put("BurnerGeneratorBuild", mindustry.world.blocks.power.BurnerGenerator.BurnerGeneratorBuild.class);
         classes.put("ConditionalConsumePower", mindustry.world.blocks.power.ConditionalConsumePower.class);
         classes.put("DecayGenerator", mindustry.world.blocks.power.DecayGenerator.class);
-        classes.put("DynamicConsumePower", mindustry.world.blocks.power.DynamicConsumePower.class);
         classes.put("ImpactReactor", mindustry.world.blocks.power.ImpactReactor.class);
         classes.put("ImpactReactorBuild", mindustry.world.blocks.power.ImpactReactor.ImpactReactorBuild.class);
         classes.put("ItemLiquidGenerator", mindustry.world.blocks.power.ItemLiquidGenerator.class);

--- a/core/src/mindustry/world/consumers/ConsumePowerConditional.java
+++ b/core/src/mindustry/world/consumers/ConsumePowerConditional.java
@@ -1,14 +1,13 @@
-package mindustry.world.blocks.power;
+package mindustry.world.consumers;
 
 import arc.func.*;
 import mindustry.gen.*;
-import mindustry.world.consumers.*;
 
 /** A power consumer that only activates sometimes. */
-public class ConditionalConsumePower extends ConsumePower{
+public class ConsumePowerConditional extends ConsumePower{
     private final Boolf<Building> consume;
 
-    public ConditionalConsumePower(float usage, Boolf<Building> consume){
+    public ConsumePowerConditional(float usage, Boolf<Building> consume){
         super(usage, 0, false);
         this.consume = consume;
     }

--- a/core/src/mindustry/world/consumers/ConsumePowerDynamic.java
+++ b/core/src/mindustry/world/consumers/ConsumePowerDynamic.java
@@ -1,14 +1,14 @@
-package mindustry.world.blocks.power;
+package mindustry.world.consumers;
 
 import arc.func.*;
 import mindustry.gen.*;
-import mindustry.world.consumers.*;
+import mindustry.world.meta.*;
 
 /** A power consumer that uses a dynamic amount of power. */
-public class DynamicConsumePower extends ConsumePower{
+public class ConsumePowerDynamic extends ConsumePower{
     private final Floatf<Building> usage;
 
-    public DynamicConsumePower(Floatf<Building> usage){
+    public ConsumePowerDynamic(Floatf<Building> usage){
         super(0, 0, false);
         this.usage = usage;
     }
@@ -16,5 +16,10 @@ public class DynamicConsumePower extends ConsumePower{
     @Override
     public float requestedPower(Building entity){
         return usage.get(entity);
+    }
+
+    @Override
+    public void display(Stats stats){
+        //should be handled by the block
     }
 }

--- a/core/src/mindustry/world/consumers/Consumers.java
+++ b/core/src/mindustry/world/consumers/Consumers.java
@@ -78,7 +78,7 @@ public class Consumers{
 
     /** Creates a consumer that consumes a dynamic amount of power. */
     public <T extends Building> ConsumePower powerDynamic(Floatf<T> usage){
-        return add(new DynamicConsumePower((Floatf<Building>)usage));
+        return add(new ConsumePowerDynamic((Floatf<Building>)usage));
     }
 
     /**

--- a/core/src/mindustry/world/consumers/Consumers.java
+++ b/core/src/mindustry/world/consumers/Consumers.java
@@ -6,7 +6,6 @@ import arc.util.*;
 import mindustry.*;
 import mindustry.gen.*;
 import mindustry.type.*;
-import mindustry.world.blocks.power.*;
 import mindustry.world.meta.*;
 
 public class Consumers{
@@ -73,7 +72,7 @@ public class Consumers{
 
     /** Creates a consumer which only consumes power when the condition is met. */
     public <T extends Building> ConsumePower powerCond(float usage, Boolf<T> cons){
-        return add(new ConditionalConsumePower(usage, (Boolf<Building>)cons));
+        return add(new ConsumePowerConditional(usage, (Boolf<Building>)cons));
     }
 
     /** Creates a consumer that consumes a dynamic amount of power. */


### PR DESCRIPTION
- For some reason, `ConditionalConsumePower` and `DynamicConsumePower` were in `/blocks/power/` instead of `/consumers/`
- Renamed them to `ConsumePowerConditional` and `ConsumePowerDynamic` to be consistent with other consumes.
- Overrode `display()` in `ConsumePowerDynamic`, as it should be handled by the block, similarly to `ConsumeItemDynamic`

I know renaming stuff breaks things, but v7 private branch already breaks everything so this is nothing compared to that.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
