### PR TITLE
Apply color stripping to player names in console wherever applicable.

### DIFF
--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -233,7 +233,7 @@ public class NetClient implements ApplicationListener{
         //log commands before they are handled
         if(message.startsWith(netServer.clientCommands.getPrefix())){
             //log with brackets
-            Log.info("<&fi@: @&fr>", "&lk" + player.name, "&lw" + message);
+            Log.info("<&fi@: @&fr>", "&lk" + player.plainName(), "&lw" + message);
         }
 
         //check if it's a command
@@ -251,7 +251,7 @@ public class NetClient implements ApplicationListener{
             }
 
             //server console logging
-            Log.info("&fi@: @", "&lc" + player.name, "&lw" + message);
+            Log.info("&fi@: @", "&lc" + player.plainName(), "&lw" + message);
 
             //invoke event for all clients but also locally
             //this is required so other clients get the correct name even if they don't know who's sending it yet

--- a/core/src/mindustry/core/NetServer.java
+++ b/core/src/mindustry/core/NetServer.java
@@ -481,7 +481,7 @@ public class NetServer implements ApplicationListener{
                 }
 
                 int sign = switch(arg[0].toLowerCase()){
-                    case "y", "yes" ->  1;
+                    case "y", "yes" -> 1;
                     case "n", "no" -> -1;
                     default -> 0;
                 };
@@ -895,7 +895,7 @@ public class NetServer implements ApplicationListener{
         short sent = 0;
         for(Building entity : Groups.build){
             if(!entity.block.sync) continue;
-            sent ++;
+            sent++;
 
             dataStream.writeInt(entity.pos());
             dataStream.writeShort(entity.block.id);
@@ -935,7 +935,7 @@ public class NetServer implements ApplicationListener{
 
         //write basic state data.
         Call.stateSnapshot(player.con, state.wavetime, state.wave, state.enemies, state.serverPaused, state.gameOver,
-            universe.seconds(), tps, GlobalConstants.rand.seed0, GlobalConstants.rand.seed1, syncStream.toByteArray());
+        universe.seconds(), tps, GlobalConstants.rand.seed0, GlobalConstants.rand.seed1, syncStream.toByteArray());
 
         syncStream.reset();
 
@@ -963,7 +963,7 @@ public class NetServer implements ApplicationListener{
             Call.entitySnapshot(player.con, (short)sent, syncStream.toByteArray());
         }
 
-        player.con.snapshotsSent ++;
+        player.con.snapshotsSent++;
     }
 
     String fixName(String name){

--- a/core/src/mindustry/core/NetServer.java
+++ b/core/src/mindustry/core/NetServer.java
@@ -560,7 +560,7 @@ public class NetServer implements ApplicationListener{
                 Call.playerDisconnect(player.id());
             }
 
-            String message = Strings.format("&lb@&fi&lk has disconnected. &fi&lk[&lb@&fi&lk] (@)", player.name, player.uuid(), reason);
+            String message = Strings.format("&lb@&fi&lk has disconnected. [&lb@&fi&lk] (@)", player.plainName(), player.uuid(), reason);
             if(Config.showConnectMessages.bool()) info(message);
         }
 
@@ -773,12 +773,12 @@ public class NetServer implements ApplicationListener{
     public static void adminRequest(Player player, Player other, AdminAction action){
         if(!player.admin && !player.isLocal()){
             warn("ACCESS DENIED: Player @ / @ attempted to perform admin action '@' on '@' without proper security access.",
-            player.name, player.con == null ? "null" : player.con.address, action.name(), other == null ? null : other.name);
+            player.plainName(), player.con == null ? "null" : player.con.address, action.name(), other == null ? null : other.plainName());
             return;
         }
 
         if(other == null || ((other.admin && !player.isLocal()) && other != player)){
-            warn("@ attempted to perform admin action on nonexistant or admin player.", player.name);
+            warn("@ &fi&lk[&lb@&fi&lk]&fb attempted to perform admin action on nonexistant or admin player.", player.plainName(), player.uuid());
             return;
         }
 
@@ -788,15 +788,15 @@ public class NetServer implements ApplicationListener{
             //no verification is done, so admins can hypothetically spam waves
             //not a real issue, because server owners may want to do just that
             logic.skipWave();
-            info("&lc@ has skipped the wave.", player.name);
+            info("&lc@ &fi&lk[&lb@&fi&lk]&fb has skipped the wave.", player.plainName(), player.uuid());
         }else if(action == AdminAction.ban){
             netServer.admins.banPlayerID(other.con.uuid);
             netServer.admins.banPlayerIP(other.con.address);
             other.kick(KickReason.banned);
-            info("&lc@ has banned @.", player.name, other.name);
+            info("&lc@ &fi&lk[&lb@&fi&lk]&fb has banned @ &fi&lk[&lb@&fi&lk]&fb.", player.plainName(), player.uuid(), other.plainName(), other.uuid());
         }else if(action == AdminAction.kick){
             other.kick(KickReason.kick);
-            info("&lc@ has kicked @.", player.name, other.name);
+            info("&lc@ &fi&lk[&lb@&fi&lk]&fb has kicked @ &fi&lk[&lb@&fi&lk]&fb.", player.plainName(), player.uuid(), other.plainName(), other.uuid());
         }else if(action == AdminAction.trace){
             PlayerInfo stats = netServer.admins.getInfo(other.uuid());
             TraceInfo info = new TraceInfo(other.con.address, other.uuid(), other.con.modclient, other.con.mobile, stats.timesJoined, stats.timesKicked);
@@ -805,7 +805,7 @@ public class NetServer implements ApplicationListener{
             }else{
                 NetClient.traceInfo(other, info);
             }
-            info("&lc@ has requested trace info of @.", player.name, other.name);
+            info("&lc@ &fi&lk[&lb@&fi&lk]&fb has requested trace info of @ &fi&lk[&lb@&fi&lk]&fb.", player.plainName(), player.uuid(), other.plainName(), other.uuid());
         }
     }
 
@@ -823,7 +823,7 @@ public class NetServer implements ApplicationListener{
 
         if(Config.showConnectMessages.bool()){
             Call.sendMessage("[accent]" + player.name + "[accent] has connected.");
-            String message = Strings.format("&lb@&fi&lk has connected. &fi&lk[&lb@&fi&lk]", player.name, player.uuid());
+            String message = Strings.format("&lb@&fi&lk has connected. &fi&lk[&lb@&fi&lk]", player.plainName(), player.uuid());
             info(message);
         }
 

--- a/core/src/mindustry/entities/comp/PlayerComp.java
+++ b/core/src/mindustry/entities/comp/PlayerComp.java
@@ -314,6 +314,10 @@ abstract class PlayerComp implements UnitController, Entityc, Syncc, Timerc, Dra
         return  "[#" + color.toString().toUpperCase() + "]" + name;
     }
 
+    String plainName(){
+        return Strings.stripColors(name);
+    }
+
     void sendMessage(String text){
         if(isLocal()){
             if(ui != null){

--- a/core/src/mindustry/net/Administration.java
+++ b/core/src/mindustry/net/Administration.java
@@ -568,6 +568,10 @@ public class Administration{
 
         public PlayerInfo(){
         }
+
+        public String plainLastName(){
+            return Strings.stripColors(lastName);
+        }
     }
 
     /** Handles chat messages from players and changes their contents. */

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -646,7 +646,7 @@ public class ServerControl implements ApplicationListener{
                     info("No whitelisted players found.");
                 }else{
                     info("Whitelist:");
-                    whitelist.each(p -> info("- Name: @ / UUID: @", p.lastName, p.id));
+                    whitelist.each(p -> info("- Name: @ / UUID: @", p.plainLastName(), p.id));
                 }
             }else{
                 if(arg.length == 2){
@@ -657,10 +657,10 @@ public class ServerControl implements ApplicationListener{
                     }else{
                         if(arg[0].equals("add")){
                             netServer.admins.whitelist(arg[1]);
-                            info("Player '@' has been whitelisted.", info.lastName);
+                            info("Player '@' has been whitelisted.", info.plainLastName());
                         }else if(arg[0].equals("remove")){
                             netServer.admins.unwhitelist(arg[1]);
-                            info("Player '@' has been un-whitelisted.", info.lastName);
+                            info("Player '@' has been un-whitelisted.", info.plainLastName());
                         }else{
                             err("Incorrect usage. Provide add/remove as the second argument.");
                         }
@@ -749,7 +749,7 @@ public class ServerControl implements ApplicationListener{
             }else{
                 info("Banned players [ID]:");
                 for(PlayerInfo info : bans){
-                    info(" @ / Last known name: '@'", info.id, info.lastName);
+                    info(" @ / Last known name: '@'", info.id, info.plainLastName());
                 }
             }
 
@@ -762,7 +762,7 @@ public class ServerControl implements ApplicationListener{
                 for(String string : ipbans){
                     PlayerInfo info = netServer.admins.findByIP(string);
                     if(info != null){
-                        info("  '@' / Last known name: '@' / ID: '@'", string, info.lastName, info.id);
+                        info("  '@' / Last known name: '@' / ID: '@'", string, info.plainLastName(), info.id);
                     }else{
                         info("  '@' (No known name or info)", string);
                     }
@@ -783,7 +783,7 @@ public class ServerControl implements ApplicationListener{
 
             if(info != null){
                 info.lastKicked = 0;
-                info("Pardoned player: @", info.lastName);
+                info("Pardoned player: @", info.plainLastName());
             }else{
                 err("That ID can't be found.");
             }
@@ -818,7 +818,7 @@ public class ServerControl implements ApplicationListener{
                     netServer.admins.unAdminPlayer(target.id);
                 }
                 if(playert != null) playert.admin = add;
-                info("Changed admin status of player: @", target.lastName);
+                info("Changed admin status of player: @", target.plainLastName());
             }else{
                 err("Nobody with that name or ID could be found. If adding an admin by name, make sure they're online; otherwise, use their UUID.");
             }
@@ -832,7 +832,7 @@ public class ServerControl implements ApplicationListener{
             }else{
                 info("Admins:");
                 for(PlayerInfo info : admins){
-                    info(" &lm @ /  ID: '@' / IP: '@'", info.lastName, info.id, info.lastIP);
+                    info(" &lm @ /  ID: '@' / IP: '@'", info.plainLastName(), info.id, info.lastIP);
                 }
             }
         });
@@ -844,7 +844,7 @@ public class ServerControl implements ApplicationListener{
                 info("Players: @", Groups.player.size());
                 for(Player user : Groups.player){
                     PlayerInfo userInfo = user.getInfo();
-                    info(" &lm @ /  ID: @ / IP: @ / Admin: @", userInfo.lastName, userInfo.id, userInfo.lastIP, userInfo.admin);
+                    info(" &lm @ /  ID: @ / IP: @ / Admin: @", userInfo.plainLastName(), userInfo.id, userInfo.lastIP, userInfo.admin);
                 }
             }
         });
@@ -946,7 +946,7 @@ public class ServerControl implements ApplicationListener{
 
                 int i = 0;
                 for(PlayerInfo info : infos){
-                    info("- [@] '@' / @", i++, info.lastName, info.id);
+                    info("- [@] '@' / @", i++, info.plainLastName(), info.id);
                 }
             }else{
                 info("Nobody with that name could be found.");

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -416,7 +416,7 @@ public class ServerControl implements ApplicationListener{
                 if(Groups.player.size() > 0){
                     info("  Players: @", Groups.player.size());
                     for(Player p : Groups.player){
-                        info("    @ / @", p.name, p.uuid());
+                        info("    @ / @", p.plainName(), p.uuid());
                     }
                 }else{
                     info("  No players connected.");
@@ -803,7 +803,7 @@ public class ServerControl implements ApplicationListener{
             boolean add = arg[0].equals("add");
 
             PlayerInfo target;
-            Player playert = Groups.player.find(p -> p.name.equalsIgnoreCase(arg[1]));
+            Player playert = Groups.player.find(p -> p.plainName().equalsIgnoreCase(Strings.stripColors(arg[1])));
             if(playert != null){
                 target = playert.getInfo();
             }else{

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -926,7 +926,7 @@ public class ServerControl implements ApplicationListener{
 
                 int i = 0;
                 for(PlayerInfo info : infos){
-                    info("[@] Trace info for player '@' / UUID @", i++, info.lastName, info.id);
+                    info("[@] Trace info for player '@' / UUID @ / RAW @", i++, info.plainLastName(), info.id, info.lastName);
                     info("  all names used: @", info.names);
                     info("  IP: @", info.lastIP);
                     info("  all IPs used: @", info.ips);

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -416,7 +416,7 @@ public class ServerControl implements ApplicationListener{
                 if(Groups.player.size() > 0){
                     info("  Players: @", Groups.player.size());
                     for(Player p : Groups.player){
-                        info("    @ / @", p.plainName(), p.uuid());
+                        info("    @ @ / @", p.admin() ? "&r[A]&c" : "&b[P]&c", p.plainName(), p.uuid());
                     }
                 }else{
                     info("  No players connected.");
@@ -584,7 +584,7 @@ public class ServerControl implements ApplicationListener{
                 if(arg.length == 1){
                     info("'@' is currently @.", c.name(), c.get());
                 }else{
-                    if (arg[1].equals("default")){
+                    if(arg[1].equals("default")){
                         c.set(c.defaultValue);
                     }else if(c.isBool()){
                         c.set(arg[1].equals("on") || arg[1].equals("true"));
@@ -844,7 +844,7 @@ public class ServerControl implements ApplicationListener{
                 info("Players: @", Groups.player.size());
                 for(Player user : Groups.player){
                     PlayerInfo userInfo = user.getInfo();
-                    info(" &lm @ /  ID: @ / IP: @ / Admin: @", userInfo.plainLastName(), userInfo.id, userInfo.lastIP, userInfo.admin);
+                    info(" @ &lm @ / ID: @ / IP: @", userInfo.admin ? "&r[A]&c" : "&b[P]&c", userInfo.plainLastName(), userInfo.id, userInfo.lastIP, userInfo.admin);
                 }
             }
         });

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -844,7 +844,7 @@ public class ServerControl implements ApplicationListener{
                 info("Players: @", Groups.player.size());
                 for(Player user : Groups.player){
                     PlayerInfo userInfo = user.getInfo();
-                    info(" @ &lm @ / ID: @ / IP: @", userInfo.admin ? "&r[A]&c" : "&b[P]&c", userInfo.plainLastName(), userInfo.id, userInfo.lastIP, userInfo.admin);
+                    info(" @&lm @ / ID: @ / IP: @", userInfo.admin ? "&r[A]&c" : "&b[P]&c", userInfo.plainLastName(), userInfo.id, userInfo.lastIP, userInfo.admin);
                 }
             }
         });


### PR DESCRIPTION
Have you ever looked at the console of a semi active server with players who know how to use color codes and a simple little formatted tag on their name? No? Here have a look:

![image](https://user-images.githubusercontent.com/62061444/160409189-2fdc173b-df06-49e6-aceb-08bb98691c13.png)

It is *painful* to read.

This PR:
 - Adds two utility methods, one to Player called `plainName()` that returns `Strings.stripColors(name)` and one to PlayerInfo called `plainLastName()` that does the same thing with `lastName`. 
 - Replaces all usage of the `Player.name` and `PlayerInfo.lastName` in console contexts (displaying and comparing in console commands) with the method variant for the stripped version.
 - Shows an `[A]` or `[P]` tag for the `players` and `status` command as an admin status indicator instead of a verbose boolean indicator. (image below)
 - Adds the uuid to the logs for admin actions so its easier to keep track. Player names are unreliable.
 - Displays both plain and raw names for trace info.
 - Various formatting fixes in the files changed because formatter did its thing.
 
![image](https://user-images.githubusercontent.com/62061444/160411351-472dadc3-c1fc-450b-81cb-f1a2f08295ec.png)

(ignore the underlining on IP, intellij console thinks its a URL for whatever reason)

---

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
