### PR TITLE
Make closestEnemyCore find the actual closest core

### DIFF
--- a/core/src/mindustry/game/Teams.java
+++ b/core/src/mindustry/game/Teams.java
@@ -36,11 +36,19 @@ public class Teams{
 
     @Nullable
     public CoreBuild closestEnemyCore(float x, float y, Team team){
-        Seq<CoreBuild> enemyCores = new Seq<>();
+        CoreBuild closest = null;
+        float closestDst = Float.MAX_VALUE;
+        
         for(Team enemy : team.data().coreEnemies){
-            enemyCores.addAll(enemy.cores());
+            for(CoreBuild core : enemy.cores()){
+                float dst = Mathf.dst2(x, y, core.getX(), core.getY());
+                if(closestDst > dst){
+                    closest = core;
+                    closestDst = dst;
+                }
+            }
         }
-        return Geometry.findClosest(x, y, enemyCores);
+        return closest;
     }
 
     @Nullable

--- a/core/src/mindustry/game/Teams.java
+++ b/core/src/mindustry/game/Teams.java
@@ -36,11 +36,11 @@ public class Teams{
 
     @Nullable
     public CoreBuild closestEnemyCore(float x, float y, Team team){
+        Seq<CoreBuild> enemyCores = new Seq<>();
         for(Team enemy : team.data().coreEnemies){
-            CoreBuild tile = Geometry.findClosest(x, y, enemy.cores());
-            if(tile != null) return tile;
+            enemyCores.addAll(enemy.cores());
         }
-        return null;
+        return Geometry.findClosest(x, y, enemyCores);
     }
 
     @Nullable


### PR DESCRIPTION
This method should return the closest core of all of `team`’s enemies, but it instead returns the closest core of the first enemy team that has a core

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
