### PR TITLE
Fix desync when two players control the same unit at the same time

### DIFF
--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -406,7 +406,9 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
             if(net.client() && player.isLocal()){
                 player.justSwitchFrom = player.unit();
                 player.justSwitchTo = unit;
-            } else player.unit(unit);
+            }else{
+                player.unit(unit);
+            }
 
             player.unit(unit);
 

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -410,8 +410,6 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
                 player.unit(unit);
             }
 
-            player.unit(unit);
-
             Time.run(Fx.unitSpirit.lifetime, () -> Fx.unitControl.at(unit.x, unit.y, 0f, unit));
             if(!player.dead()){
                 Fx.unitSpirit.at(player.x, player.y, 0f, unit);

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -406,7 +406,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
             if(net.client() && player.isLocal()){
                 player.justSwitchFrom = player.unit();
                 player.justSwitchTo = unit;
-            }
+            } else player.unit(unit);
 
             player.unit(unit);
 


### PR DESCRIPTION
It seems to work fine though I havent extensively tested. Previously, one of the players would be banished to the shadow realm. The adminAction was seemingly ignored on the client before anyways so that probably desynced and this probably fixes that too..

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
