### PR TITLE
Add Casing Flipping to ParticleEffect

### DIFF
--- a/core/src/mindustry/entities/effect/ParticleEffect.java
+++ b/core/src/mindustry/entities/effect/ParticleEffect.java
@@ -17,6 +17,8 @@ public class ParticleEffect extends Effect{
     public Color colorFrom = Color.white.cpy(), colorTo = Color.white.cpy();
     public int particles = 6;
     public boolean randLength = true;
+    /** Gives the effect flipping compatability like casing effects. */
+    public boolean casingFlip;
     public float cone = 180f, length = 20f, baseLength = 0f;
     /** Particle size/length/radius interpolation. */
     public Interp interp = Interp.linear;
@@ -55,11 +57,12 @@ public class ParticleEffect extends Effect{
     public void render(EffectContainer e){
         if(tex == null) tex = Core.atlas.find(region);
 
-        float realRotation = (useRotation ? e.rotation : baseRotation);
+        float realRotation = (useRotation ? (casingFlip ? Math.abs(e.rotation) : e.rotation) : baseRotation);
+        int flip = casingFlip ? -Mathf.sign(e.rotation) : 1;
         float rawfin = e.fin();
         float fin = e.fin(interp);
         float rad = sizeInterp.apply(sizeFrom, sizeTo, rawfin) * 2;
-        float ox = e.x + Angles.trnsx(realRotation, offsetX, offsetY), oy = e.y + Angles.trnsy(realRotation, offsetX, offsetY);
+        float ox = e.x + Angles.trnsx(realRotation, offsetX * flip, offsetY), oy = e.y + Angles.trnsy(realRotation, offsetX * flip, offsetY);
 
         Draw.color(colorFrom, colorTo, fin);
         Color lightColor = this.lightColor == null ? Draw.getColor() : this.lightColor;


### PR DESCRIPTION
Adds `casingFlip`, which makes the effect flip sides with negative rotation, working similarly to turret casing effects.
json casing effects go brrrrrrr

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
