### PR TITLE
Allow ulocate to output enemy buildings

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -296,7 +296,7 @@ public class LExecutor{
                         cache.found = false;
                         exec.setnum(outFound, 0);
                     }
-                    exec.setobj(outBuild, res != null && res.build != null && res.build.team == exec.team ? cache.build = res.build : null);
+                    exec.setobj(outBuild, res != null && res.build != null ? cache.build = res.build : null);
                 }else{
                     exec.setobj(outBuild, cache.build);
                     exec.setbool(outFound, cache.found);

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -297,7 +297,8 @@ public class LExecutor{
                         exec.setnum(outFound, 0);
                     }
                     
-                    if(res != null && res.build != null && unit.within(res.build.x, res.build.y, Math.max(unit.range(), buildingRange))){
+                    if(res != null && res.build != null && 
+                        (unit.within(res.build.x, res.build.y, Math.max(unit.range(), buildingRange)) || res.build.team == exec.team)){
                         cache.build = res.build;
                         exec.setobj(outBuild, res.build);
                     }else{

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -296,7 +296,13 @@ public class LExecutor{
                         cache.found = false;
                         exec.setnum(outFound, 0);
                     }
-                    exec.setobj(outBuild, res != null && res.build != null ? cache.build = res.build : null);
+                    
+                    if(res != null && res.build != null && unit.within(res.build.x, res.build.y, Math.max(unit.range(), buildingRange))){
+                        cache.build = res.build;
+                        exec.setobj(outBuild, res.build);
+                    } else {
+                        exec.setobj(outBuild, null);
+                    }
                 }else{
                     exec.setobj(outBuild, cache.build);
                     exec.setbool(outFound, cache.found);

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -300,7 +300,7 @@ public class LExecutor{
                     if(res != null && res.build != null && unit.within(res.build.x, res.build.y, Math.max(unit.range(), buildingRange))){
                         cache.build = res.build;
                         exec.setobj(outBuild, res.build);
-                    } else {
+                    }else{
                         exec.setobj(outBuild, null);
                     }
                 }else{


### PR DESCRIPTION
Previously you would have to use ucontrol getblock to get the actual Building
that's weird and just confuses newbs
like me

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
- [x] I have made sure you can't control enemy buildings with this.
- [x] I have used [`mindustry --version src --compile`](https://github.com/BalaM314/MindustryLauncher) to test because it is fast, and epik.

Does not actually add any new features or capabilities and won't break scripts unless they depend on the building output being null which would be ridiculous.