### PR TITLE
Name Saves on Custom Game Screen

### DIFF
--- a/core/assets/contributors
+++ b/core/assets/contributors
@@ -135,3 +135,4 @@ Evolveye
 Jerzy Paciorkiewicz
 YozoZChomutova
 Qendolin
+[Error_27]

--- a/core/src/mindustry/core/Control.java
+++ b/core/src/mindustry/core/Control.java
@@ -294,7 +294,7 @@ public class Control implements ApplicationListener, Loadable{
         }
     }
 
-    public void playMap(Map map, Rules rules){
+    public void playMap(Map map, Rules rules, String name){
         ui.loadAnd(() -> {
             logic.reset();
             world.loadMap(map, rules);
@@ -303,7 +303,7 @@ public class Control implements ApplicationListener, Loadable{
             state.rules.editor = false;
             logic.play();
             if(settings.getBool("savecreate") && !world.isInvalidMap()){
-                control.saves.addSave(map.name() + " " + new SimpleDateFormat("MMM dd h:mm", Locale.getDefault()).format(new Date()));
+                control.saves.addSave(name);
             }
             Events.fire(Trigger.newGame);
         });

--- a/core/src/mindustry/ui/dialogs/MapPlayDialog.java
+++ b/core/src/mindustry/ui/dialogs/MapPlayDialog.java
@@ -71,13 +71,16 @@ public class MapPlayDialog extends BaseDialog{
         selmode.add(modes);
         selmode.button("?", this::displayGameModeHelp).width(50f).fillY().padLeft(18f);
 
+        Table customize = new Table();
+
+        customize.button("@customize", Icon.settings, () -> dialog.show(rules, () -> rules = map.applyRules(selectedGamemode))).height(50f).width(230);
+        customize.button("@save.rename", Icon.pencil, () -> {
+            ui.showTextInput("@save.rename", "@save.rename.text", name, text -> name = text);
+        }).height(50f).width(150f).padLeft(5f);
+
         cont.add(selmode);
         cont.row();
-        cont.button("@customize", Icon.settings, () -> dialog.show(rules, () -> rules = map.applyRules(selectedGamemode))).height(50f).width(230);
-        cont.row();
-        cont.button("@save.rename", Icon.pencil, () -> {
-            ui.showTextInput("@save.rename", "@save.rename.text", name, text -> name = text);
-        }).height(50f).width(150f);
+        cont.add(customize);
         cont.row();
         cont.add(new BorderImage(map.safeTexture(), 3f)).size(mobile && !Core.graphics.isPortrait() ? 150f : 250f).get().setScaling(Scaling.fit);
         //only maps with survival are valid for high scores

--- a/core/src/mindustry/ui/dialogs/MapPlayDialog.java
+++ b/core/src/mindustry/ui/dialogs/MapPlayDialog.java
@@ -7,7 +7,11 @@ import arc.util.*;
 import mindustry.game.*;
 import mindustry.gen.*;
 import mindustry.maps.*;
+import mindustry.maps.Map;
 import mindustry.ui.*;
+
+import java.text.*;
+import java.util.*;
 
 import static mindustry.Vars.*;
 
@@ -16,6 +20,7 @@ public class MapPlayDialog extends BaseDialog{
     Rules rules;
     Gamemode selectedGamemode = Gamemode.survival;
     Map lastMap;
+    String name;
 
     public MapPlayDialog(){
         super("");
@@ -34,6 +39,8 @@ public class MapPlayDialog extends BaseDialog{
         this.lastMap = map;
         title.setText(map.name());
         cont.clearChildren();
+
+        name = map.name() + " " + new SimpleDateFormat("MMM dd h:mm", Locale.getDefault()).format(new Date());
 
         //reset to any valid mode after switching to attack (one must exist)
         if(!selectedGamemode.valid(map)){
@@ -68,6 +75,10 @@ public class MapPlayDialog extends BaseDialog{
         cont.row();
         cont.button("@customize", Icon.settings, () -> dialog.show(rules, () -> rules = map.applyRules(selectedGamemode))).height(50f).width(230);
         cont.row();
+        cont.button("@save.rename", Icon.pencil, () -> {
+            ui.showTextInput("@save.rename", "@save.rename.text", name, text -> name = text);
+        }).height(50f).width(150f);
+        cont.row();
         cont.add(new BorderImage(map.safeTexture(), 3f)).size(mobile && !Core.graphics.isPortrait() ? 150f : 250f).get().setScaling(Scaling.fit);
         //only maps with survival are valid for high scores
         if(Gamemode.survival.valid(map)){
@@ -79,7 +90,7 @@ public class MapPlayDialog extends BaseDialog{
         addCloseButton();
 
         buttons.button("@play", Icon.play, () -> {
-            control.playMap(map, rules);
+            control.playMap(map, rules, name);
             hide();
             ui.custom.hide();
         }).size(210f, 64f);


### PR DESCRIPTION
This thing has been bothering me for a while so I finally fixed it.
![image](https://user-images.githubusercontent.com/43973418/164321685-35778633-c6ea-4d0f-999e-fe8e1ef19738.png)
![image](https://user-images.githubusercontent.com/43973418/164321717-7dd1e366-c99f-4515-a2f0-42f5759163cf.png)

It currently uses the same strings as the save renaming screen but I can change that if needed.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
