### PR TITLE
Fix mods on mac, other misc items

### DIFF
--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -787,7 +787,7 @@ public class Mods implements Loadable{
 
             try{
                 Fi zip = file.isDirectory() ? file : new ZipFi(file);
-
+                if(OS.isMac) zip.child(".DS_Store").delete(); //macOS loves adding garbage files that break everything
                 if(zip.list().length == 1 && zip.list()[0].isDirectory()){
                     zip = zip.list()[0];
                 }

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -46,6 +46,14 @@ public class Mods implements Loadable{
     Seq<LoadedMod> mods = new Seq<>();
     private ObjectMap<Class<?>, ModMeta> metas = new ObjectMap<>();
     private boolean requiresReload;
+    
+    private ObjectMap<Texture, PageType> pageTypes = ObjectMap.of(
+        Core.atlas.find("white").texture, PageType.main,
+        Core.atlas.find("stone1").texture, PageType.environment,
+        Core.atlas.find("clear-editor").texture, PageType.editor,
+        Core.atlas.find("whiteui").texture, PageType.ui,
+        Core.atlas.find("rubble-1-0").texture, PageType.rubble
+    );
 
     public Mods(){
         Events.on(ClientLoadEvent.class, e -> Core.app.post(this::checkWarnings));
@@ -192,7 +200,7 @@ public class Mods implements Loadable{
                     Log.warn("Sprite '@' in mod '@' attempts to override a non-existent sprite. Ignoring.", name, mod.name);
                     continue;
                 }
-                var existingPage = getPage(existing);
+                var existingPage = pageTypes.get(existing.texture, PageType.main);
                 if(page != existingPage){
                     Log.warn("Sprite '@' on page '@' in mod '@' attempts to override a sprite on page '@'. Ignoring.", name, page, mod.name, existingPage);
                     continue;
@@ -254,14 +262,6 @@ public class Mods implements Loadable{
             for(int i = 0; i < PageType.all.length; i++){
                 entries[i] = new Seq<>();
             }
-
-            ObjectMap<Texture, PageType> pageTypes = ObjectMap.of(
-            Core.atlas.find("white").texture, PageType.main,
-            Core.atlas.find("stone1").texture, PageType.environment,
-            Core.atlas.find("clear-editor").texture, PageType.editor,
-            Core.atlas.find("whiteui").texture, PageType.ui,
-            Core.atlas.find("rubble-1-0").texture, PageType.rubble
-            );
 
             for(AtlasRegion region : Core.atlas.getRegions()){
                 PageType type = pageTypes.get(region.texture, PageType.main);

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -413,7 +413,7 @@ public class Mods implements Loadable{
                 mods.add(mod);
             }catch(Throwable e){
                 if(e instanceof ClassNotFoundException && e.getMessage().contains("mindustry.plugin.Plugin")){
-                    Log.warn("Plugin '@' is outdated and needs to be ported to v7! Update its main class to inherit from 'mindustry.mod.Plugin'. See https://mindustrygame.github.io/wiki/modding/6-migrationv6/", file.name());
+                    Log.warn("Plugin '@' is outdated and needs to be ported to v7! Update its main class to inherit from 'mindustry.mod.Plugin'. See https://mindustrygame.github.io/wiki/modding/7-migrationv7/", file.name());
                 }else{
                     Log.err("Failed to load mod file @. Skipping.", file);
                     Log.err(e);

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -854,6 +854,7 @@ public class Mods implements Loadable{
 
         try{
             Fi zip = sourceFile.isDirectory() ? sourceFile : (rootZip = new ZipFi(sourceFile));
+            if(OS.isMac) zip.child(".DS_Store").delete(); //macOS loves adding garbage files that break everything
             if(zip.list().length == 1 && zip.list()[0].isDirectory()){
                 zip = zip.list()[0];
             }

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -184,16 +184,26 @@ public class Mods implements Loadable{
 
         for(Fi file : sprites){
             String name = file.nameWithoutExtension();
+            var page = getPage(file);
 
-            if(!prefix && !Core.atlas.has(name)){
-                Log.warn("Sprite '@' in mod '@' attempts to override a non-existent sprite. Ignoring.", name, mod.name);
+            if(!prefix){
+                var existing = Core.atlas.find(name);
+                if(existing == null){
+                    Log.warn("Sprite '@' in mod '@' attempts to override a non-existent sprite. Ignoring.", name, mod.name);
+                    continue;
+                }
+                var existingPage = getPage(existing);
+                if(page != existingPage){
+                    Log.warn("Sprite '@' on page '@' in mod '@' attempts to override a sprite on page '@'. Ignoring.", name, page, mod.name, existingPage);
+                    continue;
+                }
+            }else if(name.endsWith("-outline")){
+                //TODO !!! document this on the wiki !!!
+                //do not allow packing standard outline sprites for now, they are no longer necessary and waste space!
+                //TODO also full regions are bad:  || name.endsWith("-full")
+                Log.warn("Sprite '@' in mod '@' is redundant; outline sprites are no longer needed. Ignoring.", name, mod.name);
                 continue;
             }
-
-            //TODO !!! document this on the wiki !!!
-            //do not allow packing standard outline sprites for now, they are no longer necessary and waste space!
-            //TODO also full regions are bad:  || name.endsWith("-full")
-            if(prefix && (name.endsWith("-outline"))) continue;
 
             //read and bleed pixmaps in parallel
             tasks.add(mainExecutor.submit(() -> {

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -1167,7 +1167,7 @@ public class Mods implements Loadable{
             int dot = ver.indexOf(".");
             return dot != -1 ? Strings.parseInt(ver.substring(0, dot), 0) : Strings.parseInt(ver, 0);
         }
-        
+
         @Override
         public String toString(){
             return "ModMeta{" +

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -46,14 +46,7 @@ public class Mods implements Loadable{
     Seq<LoadedMod> mods = new Seq<>();
     private ObjectMap<Class<?>, ModMeta> metas = new ObjectMap<>();
     private boolean requiresReload;
-    
-    private ObjectMap<Texture, PageType> pageTypes = ObjectMap.of(
-        Core.atlas.find("white").texture, PageType.main,
-        Core.atlas.find("stone1").texture, PageType.environment,
-        Core.atlas.find("clear-editor").texture, PageType.editor,
-        Core.atlas.find("whiteui").texture, PageType.ui,
-        Core.atlas.find("rubble-1-0").texture, PageType.rubble
-    );
+    private ObjectMap<Texture, PageType> pageTypes;
 
     public Mods(){
         Events.on(ClientLoadEvent.class, e -> Core.app.post(this::checkWarnings));
@@ -131,6 +124,15 @@ public class Mods implements Loadable{
     @Override
     public void loadAsync(){
         if(!mods.contains(LoadedMod::enabled)) return;
+
+        pageTypes = ObjectMap.of(
+            Core.atlas.find("white").texture, PageType.main,
+            Core.atlas.find("stone1").texture, PageType.environment,
+            Core.atlas.find("clear-editor").texture, PageType.editor,
+            Core.atlas.find("whiteui").texture, PageType.ui,
+            Core.atlas.find("rubble-1-0").texture, PageType.rubble
+        );
+
         Time.mark();
 
         //TODO this should estimate sprite sizes per page

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -413,7 +413,7 @@ public class Mods implements Loadable{
                 mods.add(mod);
             }catch(Throwable e){
                 if(e instanceof ClassNotFoundException && e.getMessage().contains("mindustry.plugin.Plugin")){
-                    Log.info("Plugin '@' is outdated and needs to be ported to 6.0! Update its main class to inherit from 'mindustry.mod.Plugin'. See https://mindustrygame.github.io/wiki/modding/6-migrationv6/", file.name());
+                    Log.warn("Plugin '@' is outdated and needs to be ported to v7! Update its main class to inherit from 'mindustry.mod.Plugin'. See https://mindustrygame.github.io/wiki/modding/6-migrationv6/", file.name());
                 }else{
                     Log.err("Failed to load mod file @. Skipping.", file);
                     Log.err(e);

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -799,7 +799,7 @@ public class Mods implements Loadable{
 
             try{
                 Fi zip = file.isDirectory() ? file : new ZipFi(file);
-                if(OS.isMac) zip.child(".DS_Store").delete(); //macOS loves adding garbage files that break everything
+                if(zip.isDirectory() && OS.isMac) zip.child(".DS_Store").delete(); //macOS loves adding garbage files that break everything
                 if(zip.list().length == 1 && zip.list()[0].isDirectory()){
                     zip = zip.list()[0];
                 }
@@ -866,7 +866,7 @@ public class Mods implements Loadable{
 
         try{
             Fi zip = sourceFile.isDirectory() ? sourceFile : (rootZip = new ZipFi(sourceFile));
-            if(OS.isMac) zip.child(".DS_Store").delete(); //macOS loves adding garbage files that break everything
+            if(zip.isDirectory() && OS.isMac) zip.child(".DS_Store").delete(); //macOS loves adding garbage files that break everything
             if(zip.list().length == 1 && zip.list()[0].isDirectory()){
                 zip = zip.list()[0];
             }


### PR DESCRIPTION
Opening a folder such as `mods/someMod` which only has one item (such as `/someModContent` (this type of thing happens w/ the mod updater)) breaks the line just below what I changed. This fixes that.


Another issue that I've noticed previously is that this line checks for `mod.json` and `mod.hjson` but not for the plugin equivalents. Is this intended? https://github.com/Anuken/Mindustry/blob/124cf5fa4e370e38550bfb326898188a05ef9c37/core/src/mindustry/mod/Mods.java#L405


Also yes, this breaks the style guidelines.

**EDIT:** Maybe I shouldn't have changed the url in the warning considering that the issue mentioned is specific to v5 -> v6+

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
