### PR TITLE
Update circleAttack condition to fix a crush

### DIFF
--- a/core/src/mindustry/ai/types/CommandAI.java
+++ b/core/src/mindustry/ai/types/CommandAI.java
@@ -78,7 +78,7 @@ public class CommandAI extends AIController{
             float engageRange = unit.type.range - 10f;
 
             if(move){
-                if(unit.type.circleTarget && attackTarget != null){
+                if(unit.type.circleTarget && target != null){
                     circleAttack(80f);
                 }else{
                     moveTo(vecOut,


### PR DESCRIPTION

Bug reproduce:
Use horizon or quad to attack a wall or something, may trigger this bug.

Crush Log:
`[E] java.lang.NullPointerException: Cannot invoke "arc.math.geom.Position.getX()" because "v" is null
        at arc.math.geom.Vec2.set(Vec2.java:87)
        at mindustry.entities.units.AIController.circleAttack(AIController.java:238)
        at mindustry.ai.types.CommandAI.updateUnit(CommandAI.java:82)
        at mindustry.gen.UnitEntity.update(UnitEntity.java:2101)
        at mindustry.entities.EntityGroup.update(EntityGroup.java:76)
        at mindustry.gen.Groups.update(Groups.java:79)
        at mindustry.core.Logic.update(Logic.java:541)
        at arc.ApplicationCore.update(ApplicationCore.java:37)
        at mindustry.ClientLauncher.update(ClientLauncher.java:168)
        at arc.backend.sdl.SdlApplication.listen(SdlApplication.java:201)
        at arc.backend.sdl.SdlApplication.loop(SdlApplication.java:189)
        at arc.backend.sdl.SdlApplication.<init>(SdlApplication.java:54)
        at mindustry.desktop.DesktopLauncher.main(DesktopLauncher.java:39)`

After change from 'attackTarget' to 'target', this cursh disappear, and AI seems to be normal 'circleAttack' 




If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- 

- [x] [ ] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).

- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
