### PR TITLE
Fix show wrong output liquid icon

### DIFF
--- a/core/src/mindustry/world/blocks/production/GenericCrafter.java
+++ b/core/src/mindustry/world/blocks/production/GenericCrafter.java
@@ -145,7 +145,7 @@ public class GenericCrafter extends Block{
     public void drawOverlay(float x, float y, int rotation){
         if(outputLiquids != null){
             for(int i = 0; i < outputLiquids.length; i++){
-                int dir = liquidOutputDirections.length > i ? liquidOutputDirections[i] + rotation : -1;
+                int dir = liquidOutputDirections.length > i && liquidOutputDirections[i]!=-1 ? liquidOutputDirections[i] + rotation : -1;
 
                 if(dir != -1){
                     Draw.rect(


### PR DESCRIPTION
Fix show output liquid icon if rotate non-specified output liquids factory like melter.
![a](https://user-images.githubusercontent.com/55009845/167819082-14a8fe34-4ce5-4400-8a4b-7aac8e0bb8b5.png)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
