### PR TITLE
Unloader fix 4 - New Load Priority

### DIFF
--- a/core/src/mindustry/world/blocks/storage/Unloader.java
+++ b/core/src/mindustry/world/blocks/storage/Unloader.java
@@ -91,16 +91,8 @@ public class Unloader extends Block{
             Structs.comps(
                 Structs.comparingBool(e -> e.building.block.highUnloadPriority && !e.canLoad), //stackConveyors and Storage
                 Structs.comps(
-                    Structs.comparingBool(e -> {
-                        boolean i = e.canUnload && !e.canLoad;
-                        //if(i){ System.out.println(e);}
-                        return i;
-                    }), //priority to give
-                    Structs.comparingBool(e -> {
-                        boolean i = e.canUnload || !e.canLoad;
-                        //if(!i){ System.out.println(e);}
-                        return i;
-                    }) //priority to receive
+                    Structs.comparingBool(e -> e.canUnload && !e.canLoad), //priority to give
+                    Structs.comparingBool(e -> e.canUnload || !e.canLoad) //priority to receive
                 )
             ),
             Structs.comps(

--- a/core/src/mindustry/world/blocks/storage/Unloader.java
+++ b/core/src/mindustry/world/blocks/storage/Unloader.java
@@ -85,9 +85,23 @@ public class Unloader extends Block{
         public int[] lastUsed;
 
         protected final Comparator<ContainerStat> comparator = Structs.comps(
+            //sort so it gives priority for blocks that can only either recieve or give (not both), and then by load, and then by last use
+            //highest = unload from, lowest = unload to
+
             Structs.comps(
-                Structs.comparingBool(e -> e.building.block.highUnloadPriority && !e.canLoad),
-                Structs.comparingBool(e -> e.canUnload) // && !e.canLoad
+                Structs.comparingBool(e -> e.building.block.highUnloadPriority && !e.canLoad), //stackConveyors and Storage
+                Structs.comps(
+                    Structs.comparingBool(e -> {
+                        boolean i = e.canUnload && !e.canLoad;
+                        //if(i){ System.out.println(e);}
+                        return i;
+                    }), //priority to give
+                    Structs.comparingBool(e -> {
+                        boolean i = e.canUnload || !e.canLoad;
+                        //if(!i){ System.out.println(e);}
+                        return i;
+                    }) //priority to receive
+                )
             ),
             Structs.comps(
                 Structs.comparingFloat(e -> e.loadFactor),
@@ -168,7 +182,6 @@ public class Unloader extends Block{
                     pb.loadFactor = (other.getMaximumAccepted(item) == 0) || (other.items == null) ? 0 : other.items.get(item) / (float)other.getMaximumAccepted(item);
                 }
 
-                //sort so it gives full priority to blocks that can give but not receive (stackConveyors and Storage), and then by load, and then by last use
                 possibleBlocks.sort(comparator);
 
                 ContainerStat dumpingFrom = null;


### PR DESCRIPTION
should solve the MD bug and some others by giving load priority to blocks who can only receive

![image](https://user-images.githubusercontent.com/45213805/167976721-9bf04757-60f6-449e-a2c8-bc3e3c500289.png)


- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
