### PR TITLE
Rearrange Unit factory

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -4247,6 +4247,22 @@ public class Blocks{
             );
         }};
 
+        shipRefabricator = new Reconstructor("ship-refabricator"){{
+            requirements(Category.units, with(Items.beryllium, 200, Items.tungsten, 100, Items.silicon, 150, Items.oxide, 40));
+            regionSuffix = "-dark";
+
+            size = 3;
+            consumePower(2.5f);
+            consumeLiquid(Liquids.hydrogen, 3f / 60f);
+            consumeItems(with(Items.silicon, 60, Items.tungsten, 40));
+
+            constructTime = 60f * 50f;
+
+            upgrades.addAll(
+            new UnitType[]{UnitTypes.elude, UnitTypes.avert}
+            );
+        }};
+        
         mechRefabricator = new Reconstructor("mech-refabricator"){{
             requirements(Category.units, with(Items.beryllium, 250, Items.tungsten, 120, Items.silicon, 150));
             regionSuffix = "-dark";
@@ -4261,22 +4277,6 @@ public class Blocks{
 
             upgrades.addAll(
             new UnitType[]{UnitTypes.merui, UnitTypes.cleroi}
-            );
-        }};
-
-        shipRefabricator = new Reconstructor("ship-refabricator"){{
-            requirements(Category.units, with(Items.beryllium, 200, Items.tungsten, 100, Items.silicon, 150, Items.oxide, 40));
-            regionSuffix = "-dark";
-
-            size = 3;
-            consumePower(2.5f);
-            consumeLiquid(Liquids.hydrogen, 3f / 60f);
-            consumeItems(with(Items.silicon, 60, Items.tungsten, 40));
-
-            constructTime = 60f * 50f;
-
-            upgrades.addAll(
-            new UnitType[]{UnitTypes.elude, UnitTypes.avert}
             );
         }};
 


### PR DESCRIPTION
To make all tier unit factory correspond (tank->ship->mech), with just rearrange the order of T2 factories.
It looks quite strange now.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
