### PR TITLE
Made BeamDrill show ores it can mine

### DIFF
--- a/core/src/mindustry/world/blocks/production/BeamDrill.java
+++ b/core/src/mindustry/world/blocks/production/BeamDrill.java
@@ -102,6 +102,8 @@ public class BeamDrill extends Block{
     public void setStats(){
         super.setStats();
 
+        stats.add(Stat.drillTier, StatValues.blocks(b -> ((b instanceof Floor f && f.wallOre)|| b instanceof StaticWall) && b.itemDrop != null && b.itemDrop.hardness <= tier));
+        
         if(optionalBoostIntensity != 1){
             stats.add(Stat.boostEffect, optionalBoostIntensity, StatUnit.timesSpeed);
         }


### PR DESCRIPTION
Currently beamdrill shows nothing, this would made it show the wallore it can mine

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [ ] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
