### PR TITLE
`shouldDiplay()` + `canWithdraw()`

### DIFF
--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -613,6 +613,10 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
         Fx.unitDrop.at(unit);
     }
 
+    public boolean canWithdraw(){
+        return true;
+    }
+
     public boolean canUnload(){
         return block.unloadable;
     }

--- a/core/src/mindustry/ui/Displayable.java
+++ b/core/src/mindustry/ui/Displayable.java
@@ -4,5 +4,9 @@ import arc.scene.ui.layout.*;
 
 /** An interface for things that can be displayed when hovered over. */
 public interface Displayable{
+    default boolean shouldDisplay(){
+        return true;
+    }
+
     void display(Table table);
 }

--- a/core/src/mindustry/ui/fragments/BlockInventoryFragment.java
+++ b/core/src/mindustry/ui/fragments/BlockInventoryFragment.java
@@ -70,6 +70,8 @@ public class BlockInventoryFragment{
     }
 
     private void takeItem(int requested){
+        if(!build.canWithdraw()) return;
+
         //take everything
         int amount = Math.min(requested, player.unit().maxAccepted(lastItem));
 

--- a/core/src/mindustry/ui/fragments/PlacementFragment.java
+++ b/core/src/mindustry/ui/fragments/PlacementFragment.java
@@ -383,7 +383,7 @@ public class PlacementFragment{
                                 }).padTop(2).left();
                             }
 
-                        }else if(hovered != null){
+                        }else if(hovered != null && hovered.shouldDisplay()){
                             //show hovered item, whatever that may be
                             hovered.display(topTable);
                         }


### PR DESCRIPTION
`shouldDisplay()`: returns true by default, if it returns false hovering over does not display info.
`canWidthdraw()`: returns true by default, if it returns false you can't manually withdraw items from that block.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
