### PR TITLE
Stats for New Blocks

### DIFF
--- a/core/assets/contributors
+++ b/core/assets/contributors
@@ -138,3 +138,4 @@ Jerzy Paciorkiewicz
 YozoZChomutova
 Qendolin
 Goobrr
+[Error_27]

--- a/core/src/mindustry/world/blocks/payloads/PayloadMassDriver.java
+++ b/core/src/mindustry/world/blocks/payloads/PayloadMassDriver.java
@@ -80,6 +80,7 @@ public class PayloadMassDriver extends PayloadBlock{
 
         stats.add(Stat.payloadCapacity, StatValues.squared(maxPayloadSize, StatUnit.blocksSquared));
         stats.add(Stat.reload, 60f / (chargeTime + reload), StatUnit.seconds);
+        stats.add(Stat.shootRange, range / tilesize, StatUnit.blocks);
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/power/BeamNode.java
+++ b/core/src/mindustry/world/blocks/power/BeamNode.java
@@ -49,6 +49,13 @@ public class BeamNode extends PowerBlock{
     }
 
     @Override
+    public void setStats(){
+        super.setStats();
+
+        stats.add(Stat.powerRange, range, StatUnit.blocks);
+    }
+
+    @Override
     public void init(){
         super.init();
 

--- a/core/src/mindustry/world/blocks/production/BeamDrill.java
+++ b/core/src/mindustry/world/blocks/production/BeamDrill.java
@@ -106,7 +106,6 @@ public class BeamDrill extends Block{
         super.setStats();
 
         stats.add(Stat.drillTier, StatValues.blocks(b -> (b instanceof Floor f && f.wallOre && f.itemDrop != null && f.itemDrop.hardness <= tier) || (b instanceof StaticWall w && w.itemDrop != null && w.itemDrop.hardness <= tier)));
-//        stats.add(Stat.drillTier, StatValues.blocks(new Seq<Block>().add(Blocks.beryllicStoneWall)));
 
         stats.add(Stat.drillSpeed, 60f / drillTime * size, StatUnit.itemsSecond);
         if(optionalBoostIntensity != 1){

--- a/core/src/mindustry/world/blocks/production/BeamDrill.java
+++ b/core/src/mindustry/world/blocks/production/BeamDrill.java
@@ -5,9 +5,11 @@ import arc.graphics.*;
 import arc.graphics.g2d.*;
 import arc.math.*;
 import arc.math.geom.*;
+import arc.struct.*;
 import arc.util.*;
 import arc.util.io.*;
 import mindustry.annotations.Annotations.*;
+import mindustry.content.*;
 import mindustry.entities.units.*;
 import mindustry.game.*;
 import mindustry.gen.*;
@@ -15,6 +17,7 @@ import mindustry.graphics.*;
 import mindustry.type.*;
 import mindustry.ui.*;
 import mindustry.world.*;
+import mindustry.world.blocks.environment.*;
 import mindustry.world.meta.*;
 
 import static mindustry.Vars.*;
@@ -102,6 +105,10 @@ public class BeamDrill extends Block{
     public void setStats(){
         super.setStats();
 
+        stats.add(Stat.drillTier, StatValues.blocks(b -> (b instanceof Floor f && f.wallOre && f.itemDrop != null && f.itemDrop.hardness <= tier) || (b instanceof StaticWall w && w.itemDrop != null && w.itemDrop.hardness <= tier)));
+//        stats.add(Stat.drillTier, StatValues.blocks(new Seq<Block>().add(Blocks.beryllicStoneWall)));
+
+        stats.add(Stat.drillSpeed, 60f / drillTime * size, StatUnit.itemsSecond);
         if(optionalBoostIntensity != 1){
             stats.add(Stat.boostEffect, optionalBoostIntensity, StatUnit.timesSpeed);
         }

--- a/core/src/mindustry/world/blocks/production/WallCrafter.java
+++ b/core/src/mindustry/world/blocks/production/WallCrafter.java
@@ -64,6 +64,7 @@ public class WallCrafter extends Block{
 
         stats.add(Stat.output, output);
         stats.add(Stat.tiles, StatValues.blocks(attribute, floating, 1f, true, false));
+        stats.add(Stat.drillSpeed, 60f / drillTime * size);
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/units/RepairTower.java
+++ b/core/src/mindustry/world/blocks/units/RepairTower.java
@@ -11,6 +11,7 @@ import mindustry.gen.*;
 import mindustry.graphics.*;
 import mindustry.logic.*;
 import mindustry.world.*;
+import mindustry.world.meta.*;
 
 import static mindustry.Vars.*;
 
@@ -27,6 +28,14 @@ public class RepairTower extends Block{
         super(name);
         update = true;
         solid = true;
+    }
+
+    @Override
+    public void setStats(){
+        super.setStats();
+
+        stats.add(Stat.range, range, StatUnit.blocks);
+        stats.add(Stat.repairSpeed, healAmount * 60f, StatUnit.perSecond);
     }
 
     @Override

--- a/core/src/mindustry/world/meta/StatValues.java
+++ b/core/src/mindustry/world/meta/StatValues.java
@@ -204,7 +204,7 @@ public class StatValues{
             for(int i = 0; i < list.size; i++){
                 var item = list.get(i);
 
-                if(item instanceof Block block && block.itemDrop != null && !block.itemDrop.unlocked()) continue;
+                if(item instanceof Block block && block.itemDrop != null && !block.itemDrop.unlockedNow()) continue;
 
                 l.image(item.uiIcon).size(iconSmall).padRight(2).padLeft(2).padTop(3).padBottom(3);
                 l.add(item.localizedName).left().padLeft(1).padRight(4);


### PR DESCRIPTION
Adds: 
- Speed stat and drillables for `PlasmaDrill` 
- Speed stat for `WallCrafter`. 
- Range stat for `PayloadMassDriver`
- Range stat for `BeamNode`
- Range and repair speed for `RepairTower` (May gave gotten calculations wrong. Please review.)

Also fixes a bug where the `content()` method would not check if the game was a custom game or not.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
