### PR TITLE
Generates building keybindings per planet

### DIFF
--- a/core/src/mindustry/ui/fragments/PlacementFragment.java
+++ b/core/src/mindustry/ui/fragments/PlacementFragment.java
@@ -547,7 +547,7 @@ public class PlacementFragment{
     }
 
     Seq<Block> getByCategory(Category cat){
-        return returnArray.selectFrom(content.blocks(), block -> block.category == cat && block.isVisible());
+        return returnArray.selectFrom(content.blocks(), block -> block.category == cat && block.isVisible() && block.environmentBuildable());
     }
 
     Seq<Block> getUnlockedByCategory(Category cat){


### PR DESCRIPTION
- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

This PR makes it so that the keybindings for selecting buildings generated per planet, so for example a beam node would be [5, 1] instead of [5, 1, 6]. I opened this PR since I don't think anyone will go through the effort to memorize a 3 button input

For the code I see 13 lines below it says "TODO this hides env unsupported blocks, not always a good thing" so I'm not sure what the stance on this is