### PR TITLE
Adding skip shortcut with f9.

### DIFF
--- a/core/src/mindustry/core/Logic.java
+++ b/core/src/mindustry/core/Logic.java
@@ -551,4 +551,9 @@ public class Logic implements ApplicationListener{
     public boolean isWaitingWave(){
         return (state.rules.waitEnemies || (state.wave >= state.rules.winWave && state.rules.winWave > 0)) && state.enemies > 0;
     }
+
+    /* @return if currently wave wait time can be skipped or not */
+    public boolean canSkipWave(){
+        return state.rules.waves && ((net.server() || player.admin) || !net.active()) && state.enemies == 0 && !spawner.isSpawning();
+    }
 }

--- a/core/src/mindustry/core/Logic.java
+++ b/core/src/mindustry/core/Logic.java
@@ -552,7 +552,7 @@ public class Logic implements ApplicationListener{
         return (state.rules.waitEnemies || (state.wave >= state.rules.winWave && state.rules.winWave > 0)) && state.enemies > 0;
     }
 
-    /* @return if currently wave wait time can be skipped or not */
+    /** @return if currently wave wait time can be skipped or not */
     public boolean canSkipWave(){
         return state.rules.waves && ((net.server() || player.admin) || !net.active()) && state.enemies == 0 && !spawner.isSpawning();
     }

--- a/core/src/mindustry/input/Binding.java
+++ b/core/src/mindustry/input/Binding.java
@@ -4,6 +4,7 @@ import arc.*;
 import arc.KeyBinds.*;
 import arc.input.InputDevice.*;
 import arc.input.*;
+import mindustry.net.Packets;
 
 public enum Binding implements KeyBind{
     move_x(new Axis(KeyCode.a, KeyCode.d), "general"),
@@ -71,6 +72,7 @@ public enum Binding implements KeyBind{
     chat_scroll(new Axis(KeyCode.scroll)),
     chat_mode(KeyCode.tab),
     console(KeyCode.f8),
+    skipWaveCall(KeyCode.f9),
     ;
 
     private final KeybindValue defaultValue;

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -18,6 +18,7 @@ import mindustry.game.EventType.*;
 import mindustry.game.*;
 import mindustry.gen.*;
 import mindustry.graphics.*;
+import mindustry.net.Packets;
 import mindustry.ui.*;
 import mindustry.world.*;
 
@@ -483,6 +484,14 @@ public class DesktopInput extends InputHandler{
             }
             schemX = -1;
             schemY = -1;
+        }
+
+        if(Core.input.keyTap(Binding.skipWaveCall)){
+            if(net.client() && player.admin && logic.canSkipWave()){
+                Call.adminRequest(player, Packets.AdminAction.wave);
+            }else if (logic.canSkipWave()){
+                logic.skipWave();
+            }
         }
 
         if(!selectPlans.isEmpty()){

--- a/core/src/mindustry/ui/fragments/HudFragment.java
+++ b/core/src/mindustry/ui/fragments/HudFragment.java
@@ -225,7 +225,7 @@ public class HudFragment{
                     }else{
                         logic.skipWave();
                     }
-                }).growY().fillX().right().width(40f).disabled(b -> !canSkipWave()).name("skip").get().toBack();
+                }).growY().fillX().right().width(40f).disabled(b -> !logic.canSkipWave()).name("skip").get().toBack();
             }).width(dsize * 5 + 4f).name("statustable");
 
             wavesMain.row();
@@ -760,9 +760,9 @@ public class HudFragment{
         lcell[0] = table.labelWrap(() -> {
 
             //update padding depend on whether the button to the right is there
-            boolean can = canSkipWave();
+            boolean can = logic.canSkipWave();
             if(can != couldSkip[0]){
-                if(canSkipWave()){
+                if(logic.canSkipWave()){
                     lcell[0].padRight(8f);
                 }else{
                     lcell[0].padRight(-42f);
@@ -884,10 +884,6 @@ public class HudFragment{
                 }
             }
         }).left();
-    }
-
-    private boolean canSkipWave(){
-        return state.rules.waves && ((net.server() || player.admin) || !net.active()) && state.enemies == 0 && !spawner.isSpawning();
     }
 
 }


### PR DESCRIPTION
This pull request adds a keybinding to skip the waiting time.

A check for "is waiting for next wave" and admin check and server/client check is in place.
If you feel a check is missing, feel free to contribute it.

```
if(Core.input.keyTap(Binding.skipWaveCall)){
            if(net.client() && player.admin && logic.canSkipWave()){
                Call.adminRequest(player, Packets.AdminAction.wave);
            }else if (logic.canSkipWave()){
                logic.skipWave();
            }
}
```

Also, I moved `canSkipWave` from private `HudSegment` as public boolean in `Logic`, so it is accessible from HudSegment and DesktopInput to reduce code duplicates.
The key to skip a wave is f9. Feel free to suggest another default key.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
