### PR TITLE
Fixed loading mods with non-existent or disabled dependencies

### DIFF
--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -448,9 +448,8 @@ public class Mods implements Loadable{
     }
 
     private void resolveModState(){
-        mods.each(this::updateDependencies);
-
         for(LoadedMod mod : mods){
+            updateDependencies(mod);
             mod.state =
                 !mod.isSupported() ? ModState.unsupported :
                 mod.hasUnmetDependencies() ? ModState.missingDependencies :
@@ -908,15 +907,23 @@ public class Mods implements Loadable{
                     }
                 }
             }
-
+            //checking for dependencies.
+            //they must be loaded because in resolveDependencies mods sort
+            boolean validDependencies = !meta.dependencies.map(it -> {
+                LoadedMod mod = getMod(it);
+                return mod.shouldBeEnabled() ? mod : null;
+            }).contains((LoadedMod)null);
+            //debug logging
+            Log.info("@.validDependencies: @",sourceFile.name(),validDependencies);
             //make sure the main class exists before loading it; if it doesn't just don't put it there
             //if the mod is explicitly marked as java, try loading it anyway
             if(
-                (mainFile.exists() || meta.java) &&
-                !skipModLoading() &&
-                Core.settings.getBool("mod-" + baseName + "-enabled", true) &&
-                Version.isAtLeast(meta.minGameVersion) &&
-                (meta.getMinMajor() >= 136 || headless)
+            (mainFile.exists() || meta.java) &&
+            !skipModLoading() &&
+            Core.settings.getBool("mod-" + baseName + "-enabled", true) &&
+            Version.isAtLeast(meta.minGameVersion) &&
+            (meta.getMinMajor() >= 136 || headless) &&
+            validDependencies
             ){
                 if(ios){
                     throw new ModLoadException("Java class mods are not supported on iOS.");
@@ -1159,7 +1166,7 @@ public class Mods implements Loadable{
             int dot = ver.indexOf(".");
             return dot != -1 ? Strings.parseInt(ver.substring(0, dot), 0) : Strings.parseInt(ver, 0);
         }
-        
+
         @Override
         public String toString(){
             return "ModMeta{" +

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -913,17 +913,15 @@ public class Mods implements Loadable{
                 LoadedMod mod = getMod(it);
                 return mod.shouldBeEnabled() ? mod : null;
             }).contains((LoadedMod)null);
-            //debug logging
-            Log.info("@.validDependencies: @",sourceFile.name(),validDependencies);
             //make sure the main class exists before loading it; if it doesn't just don't put it there
             //if the mod is explicitly marked as java, try loading it anyway
             if(
-            (mainFile.exists() || meta.java) &&
-            !skipModLoading() &&
-            Core.settings.getBool("mod-" + baseName + "-enabled", true) &&
-            Version.isAtLeast(meta.minGameVersion) &&
-            (meta.getMinMajor() >= 136 || headless) &&
-            validDependencies
+                (mainFile.exists() || meta.java) &&
+                !skipModLoading() &&
+                Core.settings.getBool("mod-" + baseName + "-enabled", true) &&
+                Version.isAtLeast(meta.minGameVersion) &&
+                (meta.getMinMajor() >= 136 || headless) &&
+                validDependencies
             ){
                 if(ios){
                     throw new ModLoadException("Java class mods are not supported on iOS.");


### PR DESCRIPTION
This error has existed since v6. But the first time I came across this, I prefer to make AnnotationProcessor for generate special class for cheching existing of dependencies.

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
[mods to check(version for v7)](https://github.com/Anuken/Mindustry/files/8792240/modsForCheching.zip)

