### PR TITLE
Merge functionality of getBlockI into unit getBlock

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -121,7 +121,7 @@ committingchanges = Committing Changes
 done = Done
 feature.unsupported = Your device does not support this feature.
 
-mods.initfailed = [red]⚠[] The previous Mindustry instance failed to initialize. This was likely caused by misbehaving mods.\n\nTo prevent a crash loop, [red]all mods have been disabled.[]
+mods.initfailed = [red]âš [] The previous Mindustry instance failed to initialize. This was likely caused by misbehaving mods.\n\nTo prevent a crash loop, [red]all mods have been disabled.[]
 mods = Mods
 mods.none = [lightgray]No mods found!
 mods.guide = Modding Guide
@@ -894,7 +894,7 @@ bullet.reload = [stat]{0}[lightgray]x fire rate
 bullet.range = [stat]{0}[lightgray] tiles range
 
 unit.blocks = blocks
-unit.blockssquared = blocks�
+unit.blockssquared = blocks²
 unit.powersecond = power units/second
 unit.tilessecond = tiles/second
 unit.liquidsecond = liquid units/second
@@ -1496,7 +1496,7 @@ hint.payloadDrop.mobile = [accent]Tap and hold[] an empty location to drop a pay
 hint.waveFire = [accent]Wave[] turrets with water as ammunition will automatically put out nearby fires.
 hint.generator = \uf879 [accent]Combustion Generators[] burn coal and transmit power to adjacent blocks.\n\nPower transmission range can be extended with \uf87f [accent]Power Nodes[].
 hint.guardian = [accent]Guardian[] units are armored. Weak ammo such as [accent]Copper[] and [accent]Lead[] is [scarlet]not effective[].\n\nUse higher tier turrets or \uf835 [accent]Graphite[] \uf861Duo/\uf859Salvo ammunition to take Guardians down.
-hint.coreUpgrade = Cores can be upgraded by [accent]placing higher-tier cores over them[].\n\nPlace a  [accent]Foundation[] core over the  [accent]Shard[] core. Make sure it is free from nearby obstructions.
+hint.coreUpgrade = Cores can be upgraded by [accent]placing higher-tier cores over them[].\n\nPlace a ï¡¨ [accent]Foundation[] core over the ï¡© [accent]Shard[] core. Make sure it is free from nearby obstructions.
 hint.presetLaunch = Gray [accent]landing zone sectors[], such as [accent]Frozen Forest[], can be launched to from anywhere. They do not require capture of nearby territory.\n\n[accent]Numbered sectors[], such as this one, are [accent]optional[].
 hint.presetDifficulty = This sector has a [scarlet]high enemy threat level[].\nLaunching to such sectors is [accent]not recommended[] without proper technology and preparation.
 hint.coreIncinerate = After the core is filled to capacity with an item, any extra items of that type it receives will be [accent]incinerated[].
@@ -1529,7 +1529,7 @@ liquid.slag.description = Refined in separators into constituent metals. Consume
 liquid.oil.description = Used in advanced material production and as incendiary ammunition.
 liquid.cryofluid.description = Used as coolant in reactors, turrets and factories.
 
-block.derelict =  [lightgray]Derelict
+block.derelict = ï¾ [lightgray]Derelict
 block.armored-conveyor.description = Moves items forward. Does not accept non-conveyor inputs from the sides.
 block.illuminator.description = Emits light.
 block.message.description = Stores a message for communication between allies.
@@ -1882,7 +1882,7 @@ lenum.payenter = Enter/land on the payload block the unit is on.
 lenum.flag = Numeric unit flag.
 lenum.mine = Mine at a position.
 lenum.build = Build a structure.
-lenum.getblock = Fetch a building and type at coordinates.\nUnit must be in range of position.\nSolid non-buildings will have the type [accent]@solid[].
+lenum.getblock = Fetch a tile at coordinates.\nUnit must be in range of position.\nLayer dictates the tile layer, 0 = Floor, 1 = Ore, 2 = Block, 3 = Building.
 lenum.within = Check if unit is near a position.
 lenum.boost = Start/stop boosting.
 

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -497,13 +497,13 @@ public class LExecutor{
                     case getBlock -> {
                         float range = Math.max(unit.range(), unit.type.buildRange);
                         if(!unit.within(x1, y1, range)){
-                            exec.setobj(p4, null);
+                            exec.setobj(p3, null);
                         }else{
                             Tile tile = world.tile(exec.numi(p1), exec.numi(p2));
                             if(tile == null){
-                                exec.setobj(p4, null);
+                                exec.setobj(p3, null);
                             }else{
-                            exec.setobj(p4, switch(exec.numi(p3)){
+                            exec.setobj(p3, switch(exec.numi(p4)){
                                 case 0 -> tile.floor();
                                 case 1 -> tile.overlay();
                                 case 2 -> tile.block();

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -499,6 +499,10 @@ public class LExecutor{
                         if(!unit.within(x1, y1, range)){
                             exec.setobj(p4, null);
                         }else{
+                            Tile tile = world.tile(exec.numi(p1), exec.numi(p2));
+                            if(tile == null){
+                                exec.setobj(dest, null);
+                            }else{
                             exec.setobj(p4, switch(p3){
                                 case 0 -> tile.floor();
                                 case 1 -> tile.overlay();

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -501,7 +501,7 @@ public class LExecutor{
                         }else{
                             Tile tile = world.tile(exec.numi(p1), exec.numi(p2));
                             if(tile == null){
-                                exec.setobj(dest, null);
+                                exec.setobj(p4, null);
                             }else{
                             exec.setobj(p4, switch(p3){
                                 case 0 -> tile.floor();
@@ -509,12 +509,13 @@ public class LExecutor{
                                 case 2 -> tile.block();
                                 case 3 -> tile.build;
                              });
-                           
+                            
                             //Tile tile = world.tileWorld(x1, y1);
                             //any environmental solid block is returned as StoneWall, aka "@solid"
                             //Block block = tile == null ? null : !tile.synthetic() ? (tile.solid() ? Blocks.stoneWall : Blocks.air) : tile.block();
                             //exec.setobj(p3, block);
                             //exec.setobj(p4, tile != null && tile.build != null ? tile.build : null);
+                            }
                         }
                     }
                     case itemDrop -> {

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -503,11 +503,12 @@ public class LExecutor{
                             if(tile == null){
                                 exec.setobj(p4, null);
                             }else{
-                            exec.setobj(p4, switch(p3){
+                            exec.setobj(p4, switch(exec.numi(p3)){
                                 case 0 -> tile.floor();
                                 case 1 -> tile.overlay();
                                 case 2 -> tile.block();
                                 case 3 -> tile.build;
+                                default -> null;
                              });
                             
                             //Tile tile = world.tileWorld(x1, y1);

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -497,14 +497,20 @@ public class LExecutor{
                     case getBlock -> {
                         float range = Math.max(unit.range(), unit.type.buildRange);
                         if(!unit.within(x1, y1, range)){
-                            exec.setobj(p3, null);
                             exec.setobj(p4, null);
                         }else{
-                            Tile tile = world.tileWorld(x1, y1);
+                            exec.setobj(p4, switch(p3){
+                                case 0 -> tile.floor();
+                                case 1 -> tile.overlay();
+                                case 2 -> tile.block();
+                                case 3 -> tile.build;
+                             });
+                           
+                            //Tile tile = world.tileWorld(x1, y1);
                             //any environmental solid block is returned as StoneWall, aka "@solid"
-                            Block block = tile == null ? null : !tile.synthetic() ? (tile.solid() ? Blocks.stoneWall : Blocks.air) : tile.block();
-                            exec.setobj(p3, block);
-                            exec.setobj(p4, tile != null && tile.build != null ? tile.build : null);
+                            //Block block = tile == null ? null : !tile.synthetic() ? (tile.solid() ? Blocks.stoneWall : Blocks.air) : tile.block();
+                            //exec.setobj(p3, block);
+                            //exec.setobj(p4, tile != null && tile.build != null ? tile.build : null);
                         }
                     }
                     case itemDrop -> {

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -503,19 +503,13 @@ public class LExecutor{
                             if(tile == null){
                                 exec.setobj(p3, null);
                             }else{
-                            exec.setobj(p3, switch(exec.numi(p4)){
-                                case 0 -> tile.floor();
-                                case 1 -> tile.overlay();
-                                case 2 -> tile.block();
-                                case 3 -> tile.build;
-                                default -> null;
-                             });
-                            
-                            //Tile tile = world.tileWorld(x1, y1);
-                            //any environmental solid block is returned as StoneWall, aka "@solid"
-                            //Block block = tile == null ? null : !tile.synthetic() ? (tile.solid() ? Blocks.stoneWall : Blocks.air) : tile.block();
-                            //exec.setobj(p3, block);
-                            //exec.setobj(p4, tile != null && tile.build != null ? tile.build : null);
+                                exec.setobj(p3, switch(exec.numi(p4)){
+                                    case 0 -> tile.floor();
+                                    case 1 -> tile.overlay();
+                                    case 2 -> tile.block();
+                                    case 3 -> tile.build;
+                                    default -> null;
+                                });
                             }
                         }
                     }

--- a/core/src/mindustry/logic/LUnitControl.java
+++ b/core/src/mindustry/logic/LUnitControl.java
@@ -16,7 +16,7 @@ public enum LUnitControl{
     mine("x", "y"),
     flag("value"),
     build("x", "y", "block", "rotation", "config"),
-    getBlock("x", "y", "type", "building"),
+    getBlock("x", "y", "layer", "tile"),
     within("x", "y", "radius", "result"),
     unbind;
 

--- a/core/src/mindustry/logic/LUnitControl.java
+++ b/core/src/mindustry/logic/LUnitControl.java
@@ -16,7 +16,7 @@ public enum LUnitControl{
     mine("x", "y"),
     flag("value"),
     build("x", "y", "block", "rotation", "config"),
-    getBlock("x", "y", "layer", "tile"),
+    getBlock("x", "y", "tile", "layer"),
     within("x", "y", "radius", "result"),
     unbind;
 


### PR DESCRIPTION
Makes the old unit control getBlock have the same output options as the new getBlock for world logic (though of course with the same range restrictions as before) caveat being it outputs to one variable instead of two and uses an input of 0-3 to change its modes similarly to radar changing its order.

This lets players access floor and ore tile types and lets them read all wall tile types. It also makes "@ solid" redundant (you can still reach the same functionality of detecting "@ solid" by determining if it's a block without any related building, ie. all walls and cliffs will have a block type but no building)

Unlike in #5811, a similar pr, floor tiles and such have already been made into variables (for the new world processors) so we can actually compare things and make simple example pieces of logic like this:

![getBlock Demo](https://user-images.githubusercontent.com/75582921/171495354-83d67969-31f5-472f-800a-41e31856bf0b.png)

(the logic basically just grabs the tiles in the copper square and draws them)

~~I basically just reused the cat's code so don't look at me if it's odd~~

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
