### PR TITLE
Fix BeamDrill mining ore covered by buildings.

### DIFF
--- a/core/src/mindustry/world/blocks/production/BeamDrill.java
+++ b/core/src/mindustry/world/blocks/production/BeamDrill.java
@@ -15,7 +15,6 @@ import mindustry.graphics.*;
 import mindustry.type.*;
 import mindustry.ui.*;
 import mindustry.world.*;
-import mindustry.world.blocks.environment.Prop;
 import mindustry.world.meta.*;
 
 import static mindustry.Vars.*;

--- a/core/src/mindustry/world/blocks/production/BeamDrill.java
+++ b/core/src/mindustry/world/blocks/production/BeamDrill.java
@@ -292,7 +292,7 @@ public class BeamDrill extends Block{
 
             for(int i = 0; i < size; i++){
                 Tile face = facing[i];
-                if(face != null){
+                if(face != null && face.wallDrop() != null){
                     Point2 p = lasers[i];
                     float lx = face.worldx() - (dir.x/2f)*tilesize, ly = face.worldy() - (dir.y/2f)*tilesize;
 

--- a/core/src/mindustry/world/blocks/production/BeamDrill.java
+++ b/core/src/mindustry/world/blocks/production/BeamDrill.java
@@ -15,6 +15,7 @@ import mindustry.graphics.*;
 import mindustry.type.*;
 import mindustry.ui.*;
 import mindustry.world.*;
+import mindustry.world.blocks.environment.Prop;
 import mindustry.world.meta.*;
 
 import static mindustry.Vars.*;
@@ -123,7 +124,7 @@ public class BeamDrill extends Block{
                 Tile other = world.tile(rx, ry);
                 if(other != null && other.solid()){
                     Item drop = other.wallDrop();
-                    if(drop != null){
+                    if(drop != null && !other.breakable()){
                         if(drop.hardness <= tier){
                             found = drop;
                             count++;
@@ -175,7 +176,7 @@ public class BeamDrill extends Block{
                 Tile other = world.tile(Tmp.p1.x + Geometry.d4x(rotation)*j, Tmp.p1.y + Geometry.d4y(rotation)*j);
                 if(other != null && other.solid()){
                     Item drop = other.wallDrop();
-                    if(drop != null && drop.hardness <= tier){
+                    if(drop != null && !other.breakable() && drop.hardness <= tier){
                         return true;
                     }
                     break;
@@ -228,7 +229,7 @@ public class BeamDrill extends Block{
                     if(other != null){
                         if(other.solid()){
                             Item drop = other.wallDrop();
-                            if(drop != null && drop.hardness <= tier){
+                            if(drop != null && !other.breakable() && drop.hardness <= tier){
                                 facingAmount ++;
                                 if(lastItem != drop && lastItem != null){
                                     multiple = true;

--- a/core/src/mindustry/world/blocks/production/BeamDrill.java
+++ b/core/src/mindustry/world/blocks/production/BeamDrill.java
@@ -123,7 +123,7 @@ public class BeamDrill extends Block{
                 Tile other = world.tile(rx, ry);
                 if(other != null && other.solid()){
                     Item drop = other.wallDrop();
-                    if(drop != null && !other.breakable()){
+                    if(drop != null && validOre(other)){
                         if(drop.hardness <= tier){
                             found = drop;
                             count++;
@@ -175,7 +175,7 @@ public class BeamDrill extends Block{
                 Tile other = world.tile(Tmp.p1.x + Geometry.d4x(rotation)*j, Tmp.p1.y + Geometry.d4y(rotation)*j);
                 if(other != null && other.solid()){
                     Item drop = other.wallDrop();
-                    if(drop != null && !other.breakable() && drop.hardness <= tier){
+                    if(drop != null && validOre(other) && drop.hardness <= tier){
                         return true;
                     }
                     break;
@@ -184,6 +184,10 @@ public class BeamDrill extends Block{
         }
 
         return false;
+    }
+
+    public boolean validOre(Tile tile){
+        return !tile.breakable();
     }
 
     public class BeamDrillBuild extends Building{
@@ -228,7 +232,7 @@ public class BeamDrill extends Block{
                     if(other != null){
                         if(other.solid()){
                             Item drop = other.wallDrop();
-                            if(drop != null && !other.breakable() && drop.hardness <= tier){
+                            if(drop != null && validOre(other) && drop.hardness <= tier){
                                 facingAmount ++;
                                 if(lastItem != drop && lastItem != null){
                                     multiple = true;


### PR DESCRIPTION
![136p1](https://user-images.githubusercontent.com/65377021/171567885-b91a374e-5a09-4ec4-b645-53c1ca0fcfa8.gif)
Beam drills can mine wall ores covered by any solid blocks, **including player buildings**. This looks funny but it is unreasonable. 


After fix:
![fix1](https://user-images.githubusercontent.com/65377021/171571156-8f0f31c8-51f0-4081-bf5c-3a8c170e768a.png)
Also fix crash by drawing null wall drop. It occurs if you break a building covering a wall ore while beam drill is mining it.


If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
