### PR TITLE
format infinities

### DIFF
--- a/core/src/mindustry/core/UI.java
+++ b/core/src/mindustry/core/UI.java
@@ -595,8 +595,9 @@ public class UI implements ApplicationListener, Loadable{
     }
 
     public static String formatAmount(long number){
-        //prevent overflow
-        if(number == Long.MIN_VALUE) number ++;
+        //prevent things like bars displaying erroneous representations of casted infinities
+        if(number == Long.MAX_VALUE) return "+∞";
+        if(number == Long.MIN_VALUE) return "-∞";
 
         long mag = Math.abs(number);
         String sign = number < 0 ? "-" : "";

--- a/core/src/mindustry/core/UI.java
+++ b/core/src/mindustry/core/UI.java
@@ -596,7 +596,7 @@ public class UI implements ApplicationListener, Loadable{
 
     public static String formatAmount(long number){
         //prevent things like bars displaying erroneous representations of casted infinities
-        if(number == Long.MAX_VALUE) return "+∞";
+        if(number == Long.MAX_VALUE) return "∞";
         if(number == Long.MIN_VALUE) return "-∞";
 
         long mag = Math.abs(number);


### PR DESCRIPTION
# Why?

Power voids currently report -214748364.7b/s as a combined result of `Strings.fixed` being broken with large enough floats and `UI.formatAmount` using longs internally. Instead of fixing the issue at the root, I recognized that `(long)(Double.NEGATIVE_INFINITY)` and the positive countepart only have one cast. I just want `Bar` hell to be gone.

## Screenshots

before
![Screenshot_20220613_040624](https://user-images.githubusercontent.com/21104932/173263244-676c1165-440a-46dc-b5d6-f95387289a26.png)

after
![Screenshot_20220613_041008](https://user-images.githubusercontent.com/21104932/173263298-d8efd82a-24e3-4209-9b6b-2a08c23b222b.png)
![Screenshot_20220613_041027](https://user-images.githubusercontent.com/21104932/173263305-f4170c4f-70b3-4f17-bc58-73a7eaaeea62.png)

(plus sign not included)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
