### PR TITLE
Add a solar panel output multiplier

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -1104,6 +1104,7 @@ rules.blockdamagemultiplier = Block Damage Multiplier
 rules.unitbuildspeedmultiplier = Unit Production Speed Multiplier
 rules.unithealthmultiplier = Unit Health Multiplier
 rules.unitdamagemultiplier = Unit Damage Multiplier
+rules.solarmultiplier = Solar Power Multiplier
 rules.unitcapvariable = Cores Contribute To Unit Cap
 rules.unitcap = Base Unit Cap
 rules.limitarea = Limit Map Area

--- a/core/src/mindustry/game/Rules.java
+++ b/core/src/mindustry/game/Rules.java
@@ -56,6 +56,8 @@ public class Rules{
     public boolean unitCapVariable = true;
     /** If true, unit spawn points are shown. */
     public boolean showSpawns = false;
+    /** Multiplies power output of solar panels. */
+    public float solarMultiplier = 1f;
     /** How fast unit factories build units. */
     public float unitBuildSpeedMultiplier = 1f;
     /** How much damage any other units deal. */

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -1401,6 +1401,7 @@ public class LExecutor{
                     }
                 }
                 case ambientLight -> state.rules.ambientLight.fromDouble(exec.num(value));
+                case solarMultiplier -> state.rules.solarMultiplier = exec.numf(value);
                 case unitBuildSpeed, unitDamage, blockHealth, blockDamage, buildSpeed, rtsMinSquad, rtsMinWeight -> {
                     Team team = exec.team(p1);
                     if(team != null){

--- a/core/src/mindustry/logic/LogicRule.java
+++ b/core/src/mindustry/logic/LogicRule.java
@@ -13,6 +13,7 @@ public enum LogicRule{
     mapArea,
     lighting,
     ambientLight,
+    solarMultiplier,
 
     //team specific
     buildSpeed,

--- a/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
+++ b/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
@@ -208,7 +208,7 @@ public class CustomRulesDialog extends BaseDialog{
             numberi("h", h -> state.rules.limitHeight = h, () -> state.rules.limitHeight, () -> state.rules.limitMapArea, 0, 10000);
         }
 
-        number("@rules.solarmultiplier", f -> rules.solarMultiplier = f, () -> rules.solarMultiplier, 0f, Float.MAX_VALUE);
+        number("@rules.solarmultiplier", f -> rules.solarMultiplier = f, () -> rules.solarMultiplier);
 
         main.button(b -> {
             b.left();

--- a/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
+++ b/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
@@ -208,6 +208,8 @@ public class CustomRulesDialog extends BaseDialog{
             numberi("h", h -> state.rules.limitHeight = h, () -> state.rules.limitHeight, () -> state.rules.limitMapArea, 0, 10000);
         }
 
+        number("@rules.solarmultiplier", f -> rules.solarMultiplier = f, () -> rules.solarMultiplier, 0f, Float.MAX_VALUE);
+
         main.button(b -> {
             b.left();
             b.table(Tex.pane, in -> {

--- a/core/src/mindustry/world/blocks/power/SolarGenerator.java
+++ b/core/src/mindustry/world/blocks/power/SolarGenerator.java
@@ -26,7 +26,7 @@ public class SolarGenerator extends PowerGenerator{
         @Override
         public void updateTile(){
             productionEfficiency = enabled ?
-                Mathf.maxZero(Attribute.light.env() +
+                state.rules.solarMultiplier * Mathf.maxZero(Attribute.light.env() +
                     (state.rules.lighting ?
                         1f - state.rules.ambientLight.a :
                         1f


### PR DESCRIPTION
I believe this gamerule is a good addition since this allows for flexible adjustment of solar panel output which, as compared to an alternative rule which would just make solar panels ignore lighting, would let world processor-driven maps still have variable solar panel output

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
