### PR TITLE
More info on unit control responsibility

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -755,6 +755,7 @@ error.title = [scarlet]An error has occured
 error.crashtitle = An error has occured
 unit.nobuild = [scarlet]Unit can't build
 lastaccessed = [lightgray]Last Accessed: {0}
+lastcommanded = [lightgray]Last Commanded: {0}
 block.unknown = [lightgray]???
 
 stat.showinmap = <load map to show>

--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -1250,7 +1250,7 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
         if(value instanceof UnitType) type = UnitType.class;
         
         if(builder != null && builder.isPlayer()){
-            lastAccessed = builder.getPlayer().name;
+            lastAccessed = builder.getPlayer().coloredName();
         }
 
         if(block.configurations.containsKey(type)){

--- a/core/src/mindustry/entities/comp/UnitComp.java
+++ b/core/src/mindustry/entities/comp/UnitComp.java
@@ -51,6 +51,7 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
     //TODO could be better represented as a unit
     transient @Nullable UnitType dockedType;
 
+    transient String lastCommanded;
     transient float shadowAlpha = -1f, healTime;
     transient int lastFogPos;
     private transient float resupplyTime = Mathf.random(10f);

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -234,6 +234,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
                     ai.commandPosition(posTarget);
                 }
             }
+            unit.lastCommanded = player.coloredName();
         }
 
         if(unitIds.length > 0 && player == Vars.player){

--- a/core/src/mindustry/type/UnitType.java
+++ b/core/src/mindustry/type/UnitType.java
@@ -510,11 +510,22 @@ public class UnitType extends UnlockableContent{
             }
         }).growX();
 
-        if(unit.controller() instanceof LogicAI){
+        if(unit.controller() instanceof LogicAI ai){
             table.row();
             table.add(Blocks.microProcessor.emoji() + " " + Core.bundle.get("units.processorcontrol")).growX().wrap().left();
+            if(ai.controller != null && (Core.settings.getBool("mouseposition") || Core.settings.getBool("position"))){
+                table.row();
+                table.add("[lightgray](" + ai.controller.tileX() + ", " + ai.controller.tileY() + ")").growX().wrap().left();
+            }
             table.row();
             table.label(() -> Iconc.settings + " " + (long)unit.flag + "").color(Color.lightGray).growX().wrap().left();
+            if(ai.controller != null && ai.controller.lastAccessed != null){
+                table.row();
+                table.add(Core.bundle.format("lastaccessed", ai.controller.lastAccessed)).growX().wrap().left();
+            }
+        }else if(net.active() && unit.lastCommanded != null){
+            table.row();
+            table.add(Core.bundle.format("lastcommanded", unit.lastCommanded)).growX().wrap().left();
         }
         
         table.row();

--- a/core/src/mindustry/type/UnitType.java
+++ b/core/src/mindustry/type/UnitType.java
@@ -519,7 +519,7 @@ public class UnitType extends UnlockableContent{
             }
             table.row();
             table.label(() -> Iconc.settings + " " + (long)unit.flag + "").color(Color.lightGray).growX().wrap().left();
-            if(ai.controller != null && ai.controller.lastAccessed != null){
+            if(net.active() && ai.controller != null && ai.controller.lastAccessed != null){
                 table.row();
                 table.add(Core.bundle.format("lastaccessed", ai.controller.lastAccessed)).growX().wrap().left();
             }
@@ -527,7 +527,7 @@ public class UnitType extends UnlockableContent{
             table.row();
             table.add(Core.bundle.format("lastcommanded", unit.lastCommanded)).growX().wrap().left();
         }
-        
+
         table.row();
     }
 


### PR DESCRIPTION
Features:
- Displays who last commanded a unit
- For logic-controlled units, displays processor coordinates and last accessed
![изображение](https://user-images.githubusercontent.com/57039557/173557648-a855dbd8-8bc7-4a07-ab9f-8d4bcaccb4cb.png)
![изображение](https://user-images.githubusercontent.com/57039557/173557721-c1058796-e405-4d5b-8744-feae92268ec3.png)
This has the **clientside-only** "issue" of failing to update the lastCommanded of a unit when *you* command a unit, but i decided that it's not a bug, it's a feature, and intentionally did not fix it, since this ends up being more useful than it just telling you that you last commanded a unit

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
