### PR TITLE
fix weird corners in shield shader

### DIFF
--- a/core/assets/contributors
+++ b/core/assets/contributors
@@ -141,3 +141,4 @@ Goobrr
 xem8k5小恶魔
 BlueWolf
 [Error_27]
+code-explorer786

--- a/core/assets/shaders/shield.frag
+++ b/core/assets/shaders/shield.frag
@@ -21,7 +21,7 @@ void main(){
     vec4 color = texture2D(u_texture, T);
     vec2 v = u_invsize;
 
-    vec4 maxed = max(max(max(texture2D(u_texture, T + vec2(0, step) * v), texture2D(u_texture, T + vec2(0, -step) * v)), texture2D(u_texture, T + vec2(step, 0) * v)), texture2D(u_texture, T + vec2(-step, 0) * v));
+    vec4 maxed = max(max(max(max(max(max(max(texture2D(u_texture, T + vec2(0, step) * v), texture2D(u_texture, T + vec2(0, -step) * v)), texture2D(u_texture, T + vec2(step, 0) * v)), texture2D(u_texture, T + vec2(-step, 0) * v)), texture2D(u_texture, T + vec2(step, step) * v)), texture2D(u_texture, T + vec2(step, -step) * v)), texture2D(u_texture, T + vec2(-step, step) * v)), texture2D(u_texture, T + vec2(-step, -step) * v));
 
     if(texture2D(u_texture, T).a < 0.9 && maxed.a > 0.9){
 


### PR DESCRIPTION
BUG: cursed left and right corners in shield projectors
but you can use matrixes to do stuff

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
