### PR TITLE
fix: IconConverter using deprecated inkscape --verb option

### DIFF
--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -20,7 +20,6 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 def genFolder = "../core/assets-raw/sprites_out/generated/"
-def doAntialias = !project.hasProperty("disableAntialias")
 def enableAA = true
 
 @groovy.transform.CompileStatic

--- a/tools/src/mindustry/tools/IconConverter.java
+++ b/tools/src/mindustry/tools/IconConverter.java
@@ -28,7 +28,7 @@ public class IconConverter{
             }
         }
 
-        Seq<String> args = Seq.with("inkscape", "--batch-process", "--verb", "EditSelectAll;SelectionUnion;FitCanvasToSelectionOrDrawing;FileSave");
+        Seq<String> args = Seq.with("inkscape", "--batch-process", "--actions", "select-all; path-union; fit-canvas-to-selection; export-overwrite; export-do");
         args.addAll(files.map(Fi::absolutePath));
 
         Fi.get("fontgen/extra").findAll().each(f -> f.copyTo(Fi.get("fontgen/icons").child(f.name())));


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

---
https://wiki.inkscape.org/wiki/Release_notes/1.2#Command_line

<details><summary>diff comparing output of v1.1 and v2.1 of about.svg</summary>

```diff
6c6
<    id="svg10536"
---
>    id="svg8106"
8d7
<    inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
14c13
<      id="defs10540" />
---
>      id="defs8110" />
16c15
<      id="namedview10538"
---
>      id="namedview8108"
20c19
<      inkscape:pageshadow="2"
---
>      inkscape:showpageshadow="2"
23,32c22,23
<      showgrid="false"
<      inkscape:zoom="62"
<      inkscape:cx="0.99193548"
<      inkscape:cy="5"
<      inkscape:window-width="1704"
<      inkscape:window-height="1080"
<      inkscape:window-x="2886"
<      inkscape:window-y="12"
<      inkscape:window-maximized="0"
<      inkscape:current-layer="svg10536" />
---
>      inkscape:deskcolor="#d1d1d1"
>      showgrid="false" />
34c25
<      id="polygon10470"
---
>      id="polygon8040"
```</details>