### PR TITLE
fix added assembler module doesnt reset progress

### DIFF
--- a/core/src/mindustry/world/blocks/units/UnitAssembler.java
+++ b/core/src/mindustry/world/blocks/units/UnitAssembler.java
@@ -275,7 +275,10 @@ public class UnitAssembler extends PayloadBlock{
                     break;
                 }
             }
-            currentTier = max;
+            if(currentTier != max){
+                progress=0;
+                currentTier = max;
+            }
         }
 
         public UnitType unit(){


### PR DESCRIPTION
This bug is severe in pvp game(especially in rules.cheat = true), as you can build a assembler, and a assembler module adjacency but unlink, wait the T4 progress to 99% and link the module. Thus you can build a T5 with a T4 build time.


If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
