### PR TITLE
Dynamic atlas page size

### DIFF
--- a/core/src/mindustry/graphics/MultiPacker.java
+++ b/core/src/mindustry/graphics/MultiPacker.java
@@ -9,7 +9,7 @@ import arc.util.*;
 import arc.util.Log.*;
 import mindustry.*;
 
-public class MultiPacker implements Disposable {
+public class MultiPacker implements Disposable{
     private PixmapPacker[] packers = new PixmapPacker[PageType.all.length];
     private ObjectSet<String> outlined = new ObjectSet<>();
 
@@ -75,9 +75,6 @@ public class MultiPacker implements Disposable {
                     sizeY *= 2;
                 }
             }
-
-            Log.info(type.name() + " " + sizeX + "x" + sizeY);
-
             Core.settings.put("pagetype"+type.ordinal()+"x", sizeX);
             Core.settings.put("pagetype"+type.ordinal()+"y", sizeY);
         }

--- a/core/src/mindustry/graphics/MultiPacker.java
+++ b/core/src/mindustry/graphics/MultiPacker.java
@@ -4,13 +4,10 @@ import arc.Core;
 import arc.graphics.*;
 import arc.graphics.Texture.*;
 import arc.graphics.g2d.*;
-import arc.math.geom.Vec2;
 import arc.struct.*;
 import arc.util.*;
 import arc.util.Log.*;
 import mindustry.*;
-
-import static mindustry.Vars.ui;
 
 public class MultiPacker implements Disposable {
     private PixmapPacker[] packers = new PixmapPacker[PageType.all.length];

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -38,6 +38,7 @@ public class Mods implements Loadable{
     private ContentParser parser = new ContentParser();
     private ObjectMap<String, Seq<Fi>> bundles = new ObjectMap<>();
     private ObjectSet<String> specialFolders = ObjectSet.with("bundles", "sprites", "sprites-override");
+    ObjectIntMap<String> totalAreas = new ObjectIntMap<>(PageType.all.length);
 
     private int totalSprites;
     private MultiPacker packer;
@@ -344,6 +345,7 @@ public class Mods implements Loadable{
             }
             Log.debug("Time to generate icons: @", Time.elapsed());
 
+            packer.updatePageSize();
             packer.printStats();
 
             //dispose old atlas data

--- a/core/src/mindustry/ui/dialogs/ModsDialog.java
+++ b/core/src/mindustry/ui/dialogs/ModsDialog.java
@@ -95,6 +95,12 @@ public class ModsDialog extends BaseDialog{
         hidden(() -> {
             if(mods.requiresReload()){
                 reload();
+
+                //reset everything to default after mod reload
+                for(var type : MultiPacker.PageType.all){
+                    Core.settings.put("pagetype"+type.ordinal()+"x", type.width);
+                    Core.settings.put("pagetype"+type.ordinal()+"y", type.width);
+                }
             }
         });
 


### PR DESCRIPTION
Estimates the size needed for all types of atlas pages, and applies the changes on the next game reload.
Resets to default after you update the mod list.

Its just a bit cursed but i mean, it works

It still doesnt check for black atlas if out of memory though

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
