### PR TITLE
Reenable jitpack desktop and tools building

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -431,7 +431,7 @@ project(":annotations"){
     }
 }
 
-configure([":core", ":server"].collect{project(it)}){
+configure([":core", ":desktop", ":server", ":tools"].collect{project(it)}){
     java{
         withJavadocJar()
         withSourcesJar()


### PR DESCRIPTION
It seems that desktop and tools publishing was disabled in [this commit](https://github.com/Anuken/Mindustry/commit/0169a925efc11158b0c44de7a1888fbbf68bc4d9) due to testing, but you [forgot (?) to revert it back](https://github.com/Anuken/Mindustry/commit/60d3a51ebca0ce2c1f0fb900df64fbb510a5303e).
~~I don't know much about gradle configuration, I could be entirely wrong tho~~

---

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
