### PR TITLE
Allow `printflush`ing to null

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -1020,8 +1020,6 @@ public class LExecutor{
 
         @Override
         public void run(LExecutor exec){
-
-            exec.textBuffer.setLength(0);
             
             if(exec.building(target) instanceof MessageBuild d && (d.team == exec.team || exec.privileged)){
 
@@ -1029,6 +1027,8 @@ public class LExecutor{
                 d.message.append(exec.textBuffer, 0, Math.min(exec.textBuffer.length(), maxTextBuffer));
 
             }
+            exec.textBuffer.setLength(0);
+
         }
     }
 

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -1021,12 +1021,13 @@ public class LExecutor{
         @Override
         public void run(LExecutor exec){
 
+            exec.textBuffer.setLength(0);
+            
             if(exec.building(target) instanceof MessageBuild d && (d.team == exec.team || exec.privileged)){
 
                 d.message.setLength(0);
                 d.message.append(exec.textBuffer, 0, Math.min(exec.textBuffer.length(), maxTextBuffer));
 
-                exec.textBuffer.setLength(0);
             }
         }
     }


### PR DESCRIPTION
There's currently no way to remove queued print instructions without pushing them to a valid message. This PR lets you just push to null.

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
