### PR TITLE
Deleted SubZero

### DIFF
--- a/servers_v7.json
+++ b/servers_v7.json
@@ -48,10 +48,6 @@
     "address": ["mindustry.kr"]
   },
   {
-    "name": "SubZero",
-    "address": ["minty-server.ddns.net"]
-  },
-  {
     "name": "Phoenix Network",
     "address": ["172.104.253.198", "172.104.253.198:6464"]
   },


### PR DESCRIPTION
The owners of SubZero focus more on the Minecraft server and the mindustry server will stay offline indefinitely so why not delete it

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [ ] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
