### PR TITLE
FlakDelay

### DIFF
--- a/core/src/mindustry/entities/bullet/FlakBulletType.java
+++ b/core/src/mindustry/entities/bullet/FlakBulletType.java
@@ -6,7 +6,7 @@ import mindustry.entities.*;
 import mindustry.gen.*;
 
 public class FlakBulletType extends BasicBulletType{
-    public float explodeRange = 30f, explodeDelay = 5f, flakInterval = 6f;
+    public float explodeRange = 30f, explodeDelay = 5f, flakDelay = 0f, flakInterval = 6f;
 
     public FlakBulletType(float speed, float damage){
         super(speed, damage, "shell");
@@ -27,9 +27,9 @@ public class FlakBulletType extends BasicBulletType{
         super.update(b);
 
         //don't check for targets if primed to explode
-        if(b.fdata >= 0 && b.timer(2, flakInterval)){
+        if(b.time >= flakDelay && b.fdata >= 0 && b.timer(2, flakInterval)){
             Units.nearbyEnemies(b.team, Tmp.r1.setSize(explodeRange * 2f).setCenter(b.x, b.y), unit -> {
-                //fadata < 0 means it's primed to explode
+                //fdata < 0 means it's primed to explode
                 if(b.fdata < 0f || !unit.checkTarget(collidesAir, collidesGround)) return;
 
                 if(unit.within(b, explodeRange + unit.hitSize/2f)){


### PR DESCRIPTION
Similar to `homingDelay`, adds a delay before a `FlakBulletType` starts checking for enemies.
Idk may be useful for someone?

https://user-images.githubusercontent.com/54301439/182704196-4223caaf-5f09-4409-bb95-30a888ab4913.mp4

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
