### PR TITLE
Fixed HeatCrafter consumes improper amount of liquid

### DIFF
--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -1678,6 +1678,11 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
 
     }
 
+    /** Calculate your own efficiency multiplier. */
+    public float efficiencyScale(){
+        return 1f;
+    }
+
     public void updateConsumption(){
         //everything is valid when cheating
         if(!block.hasConsumers || cheating()){

--- a/core/src/mindustry/world/blocks/production/HeatCrafter.java
+++ b/core/src/mindustry/world/blocks/production/HeatCrafter.java
@@ -72,6 +72,7 @@ public class HeatCrafter extends GenericCrafter{
             potentialEfficiency *= efficiencyScale();
         }
 
+        @Override
         public float efficiencyScale(){
             float over = Math.max(heat - heatRequirement, 0f);
             return Math.min(Mathf.clamp(heat / heatRequirement) + over / heatRequirement * overheatScale, maxEfficiency);

--- a/core/src/mindustry/world/consumers/ConsumeLiquid.java
+++ b/core/src/mindustry/world/consumers/ConsumeLiquid.java
@@ -40,7 +40,7 @@ public class ConsumeLiquid extends ConsumeLiquidBase{
 
     @Override
     public float efficiency(Building build){
-        float ed = build.edelta();
+        float ed = build.edelta() * build.efficiencyScale();
         if(ed <= 0.00000001f) return 0f;
         //there can be more liquid than necessary, so cap at 1
         return Math.min(build.liquids.get(liquid) / (amount * ed), 1f);


### PR DESCRIPTION
The problem currently appears on HeatCrafter.
**LiquidConsumer efficiency is not multiplied by heat efficiency, causing it works as usual at only 100% consumption of liquid if heat efficiency > 100%. Doesn't happen on < 100% heat.**

Before, right-side crucible works with 300% heat & 48/s slag, working as fast as the left one, which consumes 120/s slag. The slag input should be 120/s by calculating.
![bug](https://user-images.githubusercontent.com/65377021/182888972-24df790c-7ae3-40ef-9fbf-b87a17b32eb3.png)

After.
![fixed](https://user-images.githubusercontent.com/65377021/182888976-e37be814-5302-44d3-a8df-77ed2c954fcb.png)

This pr works properly but may not be a good implement I think.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:
- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
