### PR TITLE
Community server search

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -168,6 +168,7 @@ mod.scripts.disable = Your device does not support mods with scripts. You must d
 about.button = About
 name = Name:
 noname = Pick a[accent] player name[] first.
+search = Search:
 planetmap = Planet Map
 launchcore = Launch Core
 filename = File Name:

--- a/core/src/mindustry/ui/dialogs/JoinDialog.java
+++ b/core/src/mindustry/ui/dialogs/JoinDialog.java
@@ -401,7 +401,7 @@ public class JoinDialog extends BaseDialog{
         global.table(t -> {
             t.add("Search:").padRight(10);
             t.field(serverSearch, text ->
-                serverSearch = text.trim().replaceAll(" +", " ")
+                serverSearch = text.trim().replaceAll(" +", " ").toLowerCase()
             ).grow().pad(8);
             t.button(Icon.zoom, Styles.emptyi, this::refreshCommunity).size(54f);
         }).width(targetWidth()).height(70f).pad(4).row();
@@ -423,11 +423,11 @@ public class JoinDialog extends BaseDialog{
                     if(refreshes != cur) return;
 
                     if(!serverSearch.isEmpty()){
-                        if(!(group.name.contains(serverSearch)
-                            || res.name.contains(serverSearch)
-                            || res.description.contains(serverSearch)
-                            || res.mapname.contains(serverSearch)
-                            || (res.modeName != null && res.modeName.contains(serverSearch))))
+                        if(!(group.name.toLowerCase().contains(serverSearch)
+                            || res.name.toLowerCase().contains(serverSearch)
+                            || res.description.toLowerCase().contains(serverSearch)
+                            || res.mapname.toLowerCase().contains(serverSearch)
+                            || (res.modeName != null && res.modeName.toLowerCase().contains(serverSearch))))
                             return;
                     }
 

--- a/core/src/mindustry/ui/dialogs/JoinDialog.java
+++ b/core/src/mindustry/ui/dialogs/JoinDialog.java
@@ -40,6 +40,8 @@ public class JoinDialog extends BaseDialog{
     int lastPort;
     Task ping;
 
+    String serverSearch = "";
+
     public JoinDialog(){
         super("@joingame");
 
@@ -395,6 +397,15 @@ public class JoinDialog extends BaseDialog{
 
         global.clear();
         global.background(null);
+
+        global.table(t -> {
+            t.add("Search:").padRight(10);
+            t.field(serverSearch, text ->
+                serverSearch = text.trim().replaceAll(" +", " ")
+            ).grow().pad(8);
+            t.button(Icon.zoom, Styles.emptyi, this::refreshCommunity).size(54f);
+        }).width(targetWidth()).height(70f).pad(4).row();
+
         for(int i = 0; i < defaultServers.size; i ++){
             ServerGroup group = defaultServers.get((i + defaultServers.size/2) % defaultServers.size);
             boolean hidden = group.hidden();
@@ -410,6 +421,15 @@ public class JoinDialog extends BaseDialog{
                 int resport = address.contains(":") ? Strings.parseInt(address.split(":")[1]) : port;
                 net.pingHost(resaddress, resport, res -> {
                     if(refreshes != cur) return;
+
+                    if(!serverSearch.isEmpty()){
+                        if(!(group.name.contains(serverSearch)
+                            || res.name.contains(serverSearch)
+                            || res.description.contains(serverSearch)
+                            || res.mapname.contains(serverSearch)
+                            || (res.modeName != null && res.modeName.contains(serverSearch))))
+                            return;
+                    }
 
                     //add header
                     if(groupTable[0] == null){

--- a/core/src/mindustry/ui/dialogs/JoinDialog.java
+++ b/core/src/mindustry/ui/dialogs/JoinDialog.java
@@ -399,7 +399,7 @@ public class JoinDialog extends BaseDialog{
         global.background(null);
 
         global.table(t -> {
-            t.add("Search:").padRight(10);
+            t.add("@search").padRight(10);
             t.field(serverSearch, text ->
                 serverSearch = text.trim().replaceAll(" +", " ").toLowerCase()
             ).grow().pad(8);


### PR DESCRIPTION
Adds a searchbar to the community servers menu. If there is a search query, a server is only displayed if its displayed text contains the query on refresh (e.g. with the search button).

While there's a lot of small improvements that could be made on top (e.g. allowing searching with regex, excluding group/map/server names, highlighting matches...), I felt this is good enough for things like "all attack maps" or "just this server group" without requiring a lot of changes.

![image](https://user-images.githubusercontent.com/16821808/183218322-5e344faf-257d-4a7d-b8f0-7cbeddcd276b.png)

----

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
