### PR TITLE
Erekir core units make flak bullets explode

### DIFF
--- a/core/src/mindustry/entities/bullet/FlakBulletType.java
+++ b/core/src/mindustry/entities/bullet/FlakBulletType.java
@@ -30,7 +30,7 @@ public class FlakBulletType extends BasicBulletType{
         if(b.time >= flakDelay && b.fdata >= 0 && b.timer(2, flakInterval)){
             Units.nearbyEnemies(b.team, Tmp.r1.setSize(explodeRange * 2f).setCenter(b.x, b.y), unit -> {
                 //fdata < 0 means it's primed to explode
-                if(b.fdata < 0f || !unit.checkTarget(collidesAir, collidesGround)) return;
+                if(b.fdata < 0f || !unit.checkTarget(collidesAir, collidesGround) || !unit.type.targetable) return;
 
                 if(unit.within(b, explodeRange + unit.hitSize/2f)){
                     //mark as primed


### PR DESCRIPTION
Erekir core unit can make flak bullets explode, even if they can't actually be hurt.
![6IAA3}ZW2T$JT(` (~Y)15C](https://user-images.githubusercontent.com/57857764/183239468-834eb4fe-6b80-4b2b-808b-1ed0a458f5e5.png)
![{}R_2GB~T$82~ C@%F4 {}0](https://user-images.githubusercontent.com/57857764/183239519-3dd3c17d-0d11-4ffa-bdbb-2010f4a145b4.png)

The way to fix it is to add another statement so that the bullets don't target them.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
