### PR TITLE
Make PayloadAmmoTurret accept units

### DIFF
--- a/core/src/mindustry/world/blocks/defense/turrets/PayloadAmmoTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/PayloadAmmoTurret.java
@@ -51,7 +51,7 @@ public class PayloadAmmoTurret extends Turret{
         super.setStats();
 
         stats.remove(Stat.itemCapacity);
-        stats.add(Stat.ammo, StatValues.ammo(ammoTypes));
+        stats.add(Stat.ammo, StatValues.ammo(ammoTypes, true));
     }
 
     @Override
@@ -60,8 +60,8 @@ public class PayloadAmmoTurret extends Turret{
             @Override
             public void build(Building build, Table table){
                 MultiReqImage image = new MultiReqImage();
-                content.blocks().each(i -> filter.get(i) && i.unlockedNow(), block -> image.add(new ReqImage(new Image(block.uiIcon),
-                () -> build instanceof PayloadTurretBuild it && !it.payloads.isEmpty() && it.currentBlock() == block)));
+                content.blocks().each(i -> filter.get(i) && i.unlockedNow(), content -> image.add(new ReqImage(new Image(content.uiIcon),
+                () -> build instanceof PayloadTurretBuild it && !it.payloads.isEmpty() && it.currentBlock() == content)));
 
                 table.add(image).size(8 * 4);
             }
@@ -78,7 +78,7 @@ public class PayloadAmmoTurret extends Turret{
             }
         });
 
-        ammoKeys = ammoTypes.keys().toSeq().toArray(Block.class);
+        ammoKeys = ammoTypes.keys().toSeq().toArray(UnlockableContent.class);
 
         super.init();
     }
@@ -87,9 +87,9 @@ public class PayloadAmmoTurret extends Turret{
         public PayloadSeq payloads = new PayloadSeq();
 
         public UnlockableContent currentBlock(){
-            for(var block : ammoKeys){
-                if(payloads.contains(block)){
-                    return block;
+            for(var content : ammoKeys){
+                if(payloads.contains(content)){
+                    return content;
                 }
             }
             return null;
@@ -97,12 +97,12 @@ public class PayloadAmmoTurret extends Turret{
 
         @Override
         public boolean acceptPayload(Building source, Payload payload){
-            return payload instanceof BuildPayload build && payloads.total() < maxAmmo && ammoTypes.containsKey(build.block());
+            return payloads.total() < maxAmmo && ammoTypes.containsKey(payload.content());
         }
 
         @Override
         public void handlePayload(Building source, Payload payload){
-            payloads.add(((BuildPayload)payload).block());
+            payloads.add(payload.content());
         }
 
         @Override
@@ -112,10 +112,10 @@ public class PayloadAmmoTurret extends Turret{
 
         @Override
         public BulletType useAmmo(){
-            for(var block : ammoKeys){
-                if(payloads.contains(block)){
-                    payloads.remove(block);
-                    return ammoTypes.get(block);
+            for(var content : ammoKeys){
+                if(payloads.contains(content)){
+                    payloads.remove(content);
+                    return ammoTypes.get(content);
                 }
             }
             return null;
@@ -123,9 +123,9 @@ public class PayloadAmmoTurret extends Turret{
 
         @Override
         public BulletType peekAmmo(){
-            for(var block : ammoKeys){
-                if(payloads.contains(block)){
-                    return ammoTypes.get(block);
+            for(var content : ammoKeys){
+                if(payloads.contains(content)){
+                    return ammoTypes.get(content);
                 }
             }
             return null;

--- a/core/src/mindustry/world/meta/StatValues.java
+++ b/core/src/mindustry/world/meta/StatValues.java
@@ -308,10 +308,14 @@ public class StatValues{
     }
 
     public static <T extends UnlockableContent> StatValue ammo(ObjectMap<T, BulletType> map){
-        return ammo(map, 0);
+        return ammo(map, 0, false);
     }
 
-    public static <T extends UnlockableContent> StatValue ammo(ObjectMap<T, BulletType> map, int indent){
+    public static <T extends UnlockableContent> StatValue ammo(ObjectMap<T, BulletType> map, boolean showUnit){
+        return ammo(map, 0, showUnit);
+    }
+
+    public static <T extends UnlockableContent> StatValue ammo(ObjectMap<T, BulletType> map, int indent, boolean showUnit){
         return table -> {
 
             table.row();
@@ -320,12 +324,12 @@ public class StatValues{
             orderedKeys.sort();
 
             for(T t : orderedKeys){
-                boolean compact = t instanceof UnitType || indent > 0;
+                boolean compact = t instanceof UnitType && !showUnit || indent > 0;
 
                 BulletType type = map.get(t);
 
                 if(type.spawnUnit != null && type.spawnUnit.weapons.size > 0){
-                    ammo(ObjectMap.of(t, type.spawnUnit.weapons.first().bullet), indent).display(table);
+                    ammo(ObjectMap.of(t, type.spawnUnit.weapons.first().bullet), indent, false).display(table);
                     return;
                 }
 
@@ -406,7 +410,7 @@ public class StatValues{
                         sep(bt, Core.bundle.format("bullet.frags", type.fragBullets));
                         bt.row();
 
-                        ammo(ObjectMap.of(t, type.fragBullet), indent + 1).display(bt);
+                        ammo(ObjectMap.of(t, type.fragBullet), indent + 1, false).display(bt);
                     }
                 }).padTop(compact ? 0 : -9).padLeft(indent * 8).left().get().background(compact ? null : Tex.underline);
 


### PR DESCRIPTION
The `ammoTypes` object map allows `UnlockableContent`s to be the keys, and thus I'm gonna let people have that full functionality.

https://user-images.githubusercontent.com/54301439/183311634-76691e71-dca2-4a34-9b52-8f7b248355eb.mp4

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.