### PR TITLE
Less ResetEvent

### DIFF
--- a/core/src/mindustry/core/Control.java
+++ b/core/src/mindustry/core/Control.java
@@ -347,6 +347,7 @@ public class Control implements ApplicationListener, Loadable{
     public void playMap(Map map, Rules rules, boolean playtest){
         ui.loadAnd(() -> {
             logic.reset();
+            SaveIO.justReset = true;
             world.loadMap(map, rules);
             state.rules = rules;
             if(playtest) state.playtestingMap = map;

--- a/core/src/mindustry/io/SaveIO.java
+++ b/core/src/mindustry/io/SaveIO.java
@@ -21,6 +21,7 @@ public class SaveIO{
     public static final byte[] header = {'M', 'S', 'A', 'V'};
     public static final IntMap<SaveVersion> versions = new IntMap<>();
     public static final Seq<SaveVersion> versionArray = Seq.with(new Save1(), new Save2(), new Save3(), new Save4(), new Save5(), new Save6(), new Save7());
+    public static boolean justReset = false;
 
     static{
         for(SaveVersion version : versionArray){
@@ -157,7 +158,8 @@ public class SaveIO{
     /** Loads from a deflated (!) input stream. */
     public static void load(InputStream is, WorldContext context) throws SaveException{
         try(CounterInputStream counter = new CounterInputStream(is); DataInputStream stream = new DataInputStream(counter)){
-            logic.reset();
+            if(!justReset) logic.reset();
+            justReset = false;
             readHeader(stream);
             int version = stream.readInt();
             SaveVersion ver = versions.get(version);

--- a/core/src/mindustry/net/WorldReloader.java
+++ b/core/src/mindustry/net/WorldReloader.java
@@ -3,6 +3,7 @@ package mindustry.net;
 import arc.struct.*;
 import arc.struct.Seq.*;
 import mindustry.gen.*;
+import mindustry.io.*;
 
 import static mindustry.Vars.*;
 
@@ -29,6 +30,7 @@ public class WorldReloader{
             }
 
             logic.reset();
+            SaveIO.justReset = true;
 
             Call.worldDataBegin();
         }else{

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -345,6 +345,7 @@ public class ServerControl implements ApplicationListener{
             lastMode = preset;
             Core.settings.put("lastServerMode", lastMode.name());
             try{
+                SaveIO.justReset = true;
                 world.loadMap(result, result.applyRules(lastMode));
                 state.rules = result.applyRules(preset);
                 logic.play();


### PR DESCRIPTION
Less ResetEvent emit twice.
In many case, Call `SaveIO.load` will emit `ResetEvent` twice.

Another reason:
I want to do something between `ResetEvent` and `WorldLoad`, but it seems very hard as all `SaveIO.load` begin with a `logic.reset`

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
