### PR TITLE
Better Duplicate Op Support (json/hjson) + 1 more op

### DIFF
--- a/core/src/mindustry/entities/part/DrawPart.java
+++ b/core/src/mindustry/entities/part/DrawPart.java
@@ -124,6 +124,10 @@ public abstract class DrawPart{
             return p -> get(p) / (1f - amount);
         }
 
+        default PartProgress compress(float start, float end){
+            return p -> Mathf.curve(get(p), start, end);
+        }
+
         default PartProgress blend(PartProgress other, float amount){
             return p -> Mathf.lerp(get(p), other.get(p), amount);
         }

--- a/core/src/mindustry/mod/ContentParser.java
+++ b/core/src/mindustry/mod/ContentParser.java
@@ -201,6 +201,7 @@ public class ContentParser{
                 case "delay" -> base.delay(data.getFloat("amount"));
                 case "sustain" -> base.sustain(data.getFloat("offset", 0f), data.getFloat("grow", 0f), data.getFloat("sustain"));
                 case "shorten" -> base.shorten(data.getFloat("amount"));
+                case "compress" -> base.compress(data.getFloat("start"), data.getFloat("end"));
                 case "add" -> data.has("amount") ? base.add(data.getFloat("amount")) : base.add(parser.readValue(PartProgress.class, data.get("other")));
                 case "blend" -> base.blend(parser.readValue(PartProgress.class, data.get("other")), data.getFloat("amount"));
                 case "mul" -> data.has("amount") ? base.mul(data.getFloat("amount")) : base.mul(parser.readValue(PartProgress.class, data.get("other")));

--- a/core/src/mindustry/mod/ContentParser.java
+++ b/core/src/mindustry/mod/ContentParser.java
@@ -203,11 +203,11 @@ public class ContentParser{
                 case "shorten" -> base.shorten(data.getFloat("amount"));
                 case "add" -> data.has("amount") ? base.add(data.getFloat("amount")) : base.add(parser.readValue(PartProgress.class, data.get("other")));
                 case "blend" -> base.blend(parser.readValue(PartProgress.class, data.get("other")), data.getFloat("amount"));
-                case "mul" -> base.mul(parser.readValue(PartProgress.class, data.get("other")));
+                case "mul" -> data.has("amount") ? base.mul(data.getFloat("amount")) : base.mul(parser.readValue(PartProgress.class, data.get("other")));
                 case "min" -> base.min(parser.readValue(PartProgress.class, data.get("other")));
-                case "sin" -> base.sin(data.getFloat("scl"), data.getFloat("mag"));
+                case "sin" -> base.sin(data.has("offset") ? data.getFloat("offset") : 0f, data.getFloat("scl"), data.getFloat("mag"));
                 case "absin" -> base.absin(data.getFloat("scl"), data.getFloat("mag"));
-                case "curve" -> base.curve(parser.readValue(Interp.class, data.get("interp")));
+                case "curve" -> data.has("interp") ? base.curve(parser.readValue(Interp.class, data.get("interp"))) : base.curve(data.getFloat("offset"), data.getFloat("duration"));
                 default -> throw new RuntimeException("Unknown operation '" + op + "', check PartProgress class for a list of methods.");
             };
         });


### PR DESCRIPTION
- Better support for using `mul`, `sin`, and `curve` (json/hjson)
  - `mul` now checks for "amount" similarly to `add`
  - `sin` checks for "offset", and inputs it if it exists. Otherwise 0 is input for the offset
  - `curve` now checks for "interp" similarly to `add`
- Added `compress`
  - Uses `Mathf.curve`, so you could make something that starts with a delay and ends early without having to use `delay` and `shorten` together and calculate what the amount put into `shorten` should be because `delay` already is shortening the time span blah blah
  - I don't know if "compress" is the best name for the op but it's what I came up with.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
