### PR TITLE
Fix units that can't be hit being hit by some things.

### DIFF
--- a/core/src/mindustry/ai/types/DefenderAI.java
+++ b/core/src/mindustry/ai/types/DefenderAI.java
@@ -28,7 +28,7 @@ public class DefenderAI extends AIController{
     public Teamc findTarget(float x, float y, float range, boolean air, boolean ground){
 
         //Sort by max health and closer target.
-        var result = Units.closest(unit.team, x, y, Math.max(range, 400f), u -> !u.dead() && u.type != unit.type, (u, tx, ty) -> -u.maxHealth + Mathf.dst2(u.x, u.y, tx, ty) / 6400f);
+        var result = Units.closest(unit.team, x, y, Math.max(range, 400f), u -> !u.dead() && u.type != unit.type && u.targetable(unit.team), (u, tx, ty) -> -u.maxHealth + Mathf.dst2(u.x, u.y, tx, ty) / 6400f);
         if(result != null) return result;
 
         //return core if found

--- a/core/src/mindustry/entities/Damage.java
+++ b/core/src/mindustry/entities/Damage.java
@@ -171,7 +171,7 @@ public class Damage{
         Units.nearbyEnemies(b.team, rect, u -> {
             u.hitbox(hitrect);
 
-            if(u.checkTarget(b.type.collidesAir, b.type.collidesGround) && Intersector.intersectSegmentRectangle(b.x, b.y, b.x + vec.x, b.y + vec.y, hitrect)){
+            if(u.checkTarget(b.type.collidesAir, b.type.collidesGround) && u.hittable() && Intersector.intersectSegmentRectangle(b.x, b.y, b.x + vec.x, b.y + vec.y, hitrect)){
                 distances.add(u.dst(b));
             }
         });
@@ -468,7 +468,7 @@ public class Damage{
     /** Damages all entities and blocks in a radius that are enemies of the team. */
     public static void damage(Team team, float x, float y, float radius, float damage, boolean complete, boolean air, boolean ground, boolean scaled, Bullet source){
         Cons<Unit> cons = entity -> {
-            if(entity.team == team  || !entity.checkTarget(air, ground) || !entity.within(x, y, radius + (scaled ? entity.hitSize / 2f : 0f))){
+            if(entity.team == team  || !entity.checkTarget(air, ground) || !entity.hittable() || !entity.within(x, y, radius + (scaled ? entity.hitSize / 2f : 0f))){
                 return;
             }
 

--- a/core/src/mindustry/entities/Damage.java
+++ b/core/src/mindustry/entities/Damage.java
@@ -374,7 +374,7 @@ public class Damage{
         tmpUnit = null;
 
         Units.nearbyEnemies(hitter.team, rect, e -> {
-            if((tmpUnit != null && e.dst2(x, y) > tmpUnit.dst2(x, y)) || !e.checkTarget(hitter.type.collidesAir, hitter.type.collidesGround)) return;
+            if((tmpUnit != null && e.dst2(x, y) > tmpUnit.dst2(x, y)) || !e.checkTarget(hitter.type.collidesAir, hitter.type.collidesGround) || !e.targetable(hitter.team)) return;
 
             e.hitbox(hitrect);
             Rect other = hitrect;

--- a/core/src/mindustry/entities/Damage.java
+++ b/core/src/mindustry/entities/Damage.java
@@ -171,7 +171,7 @@ public class Damage{
         Units.nearbyEnemies(b.team, rect, u -> {
             u.hitbox(hitrect);
 
-            if(u.checkTarget(b.type.collidesAir, b.type.collidesGround) && u.hittable() && Intersector.intersectSegmentRectangle(b.x, b.y, b.x + vec.x, b.y + vec.y, hitrect)){
+            if(u.checkTarget(b.type.collidesAir, b.type.collidesGround) && Intersector.intersectSegmentRectangle(b.x, b.y, b.x + vec.x, b.y + vec.y, hitrect)){
                 distances.add(u.dst(b));
             }
         });
@@ -468,7 +468,7 @@ public class Damage{
     /** Damages all entities and blocks in a radius that are enemies of the team. */
     public static void damage(Team team, float x, float y, float radius, float damage, boolean complete, boolean air, boolean ground, boolean scaled, Bullet source){
         Cons<Unit> cons = entity -> {
-            if(entity.team == team  || !entity.hittable() || !entity.within(x, y, radius + (scaled ? entity.hitSize / 2f : 0f)) || (entity.isFlying() && !air) || (entity.isGrounded() && !ground)){
+            if(entity.team == team  || !entity.checkTarget(air, ground) || !entity.within(x, y, radius + (scaled ? entity.hitSize / 2f : 0f))){
                 return;
             }
 

--- a/core/src/mindustry/entities/abilities/EnergyFieldAbility.java
+++ b/core/src/mindustry/entities/abilities/EnergyFieldAbility.java
@@ -101,7 +101,7 @@ public class EnergyFieldAbility extends Ability{
 
             if(hitUnits){
                 Units.nearby(null, rx, ry, range, other -> {
-                    if(other != unit && (other.isFlying() ? targetAir : targetGround)){
+                    if(other != unit && other.checkTarget(targetAir, targetGround)){
                         all.add(other);
                     }
                 });

--- a/core/src/mindustry/entities/abilities/EnergyFieldAbility.java
+++ b/core/src/mindustry/entities/abilities/EnergyFieldAbility.java
@@ -101,7 +101,7 @@ public class EnergyFieldAbility extends Ability{
 
             if(hitUnits){
                 Units.nearby(null, rx, ry, range, other -> {
-                    if(other != unit && other.checkTarget(targetAir, targetGround)){
+                    if(other != unit && other.checkTarget(targetAir, targetGround) && other.targetable(unit.team)){
                         all.add(other);
                     }
                 });

--- a/core/src/mindustry/entities/bullet/FlakBulletType.java
+++ b/core/src/mindustry/entities/bullet/FlakBulletType.java
@@ -30,7 +30,7 @@ public class FlakBulletType extends BasicBulletType{
         if(b.time >= flakDelay && b.fdata >= 0 && b.timer(2, flakInterval)){
             Units.nearbyEnemies(b.team, Tmp.r1.setSize(explodeRange * 2f).setCenter(b.x, b.y), unit -> {
                 //fdata < 0 means it's primed to explode
-                if(b.fdata < 0f || !unit.checkTarget(collidesAir, collidesGround) || !unit.type.targetable) return;
+                if(b.fdata < 0f || !unit.checkTarget(collidesAir, collidesGround) || !unit.targetable(b.team)) return;
 
                 if(unit.within(b, explodeRange + unit.hitSize/2f)){
                     //mark as primed

--- a/core/src/mindustry/entities/bullet/PointBulletType.java
+++ b/core/src/mindustry/entities/bullet/PointBulletType.java
@@ -16,6 +16,7 @@ public class PointBulletType extends BulletType{
          scaleLife = true;
          lifetime = 100f;
          collides = false;
+         reflectable = false;
          keepVelocity = false;
          backMove = false;
      }

--- a/core/src/mindustry/entities/bullet/PointBulletType.java
+++ b/core/src/mindustry/entities/bullet/PointBulletType.java
@@ -43,7 +43,7 @@ public class PointBulletType extends BulletType{
         float range = 1f;
 
         Units.nearbyEnemies(b.team, px - range, py - range, range*2f, range*2f, e -> {
-            if(e.dead() && !e.checkTarget(collidesAir, collidesGround)) return;
+            if(e.dead() || !e.checkTarget(collidesAir, collidesGround)) return;
 
             e.hitbox(Tmp.r1);
             if(!Tmp.r1.contains(px, py)) return;

--- a/core/src/mindustry/entities/bullet/PointBulletType.java
+++ b/core/src/mindustry/entities/bullet/PointBulletType.java
@@ -43,7 +43,7 @@ public class PointBulletType extends BulletType{
         float range = 1f;
 
         Units.nearbyEnemies(b.team, px - range, py - range, range*2f, range*2f, e -> {
-            if(e.dead() || !e.checkTarget(collidesAir, collidesGround)) return;
+            if(e.dead() || !e.checkTarget(collidesAir, collidesGround) || !e.targetable(b.team)) return;
 
             e.hitbox(Tmp.r1);
             if(!Tmp.r1.contains(px, py)) return;

--- a/core/src/mindustry/entities/bullet/PointBulletType.java
+++ b/core/src/mindustry/entities/bullet/PointBulletType.java
@@ -43,7 +43,7 @@ public class PointBulletType extends BulletType{
         float range = 1f;
 
         Units.nearbyEnemies(b.team, px - range, py - range, range*2f, range*2f, e -> {
-            if(e.dead() || !e.checkTarget(collidesAir, collidesGround) || !e.targetable(b.team)) return;
+            if(e.dead() || !e.checkTarget(collidesAir, collidesGround) || !e.hittable()) return;
 
             e.hitbox(Tmp.r1);
             if(!Tmp.r1.contains(px, py)) return;

--- a/core/src/mindustry/entities/bullet/PointBulletType.java
+++ b/core/src/mindustry/entities/bullet/PointBulletType.java
@@ -42,7 +42,7 @@ public class PointBulletType extends BulletType{
         float range = 1f;
 
         Units.nearbyEnemies(b.team, px - range, py - range, range*2f, range*2f, e -> {
-            if(e.dead()) return;
+            if(e.dead() && !e.checkTarget(collidesAir, collidesGround)) return;
 
             e.hitbox(Tmp.r1);
             if(!Tmp.r1.contains(px, py)) return;
@@ -56,7 +56,7 @@ public class PointBulletType extends BulletType{
 
         if(result != null){
             b.collision(result, px, py);
-        }else{
+        }else if(collidesTiles){
             Building build = Vars.world.buildWorld(px, py);
             if(build != null && build.team != b.team){
                 build.collision(b);

--- a/core/src/mindustry/entities/comp/FlyingComp.java
+++ b/core/src/mindustry/entities/comp/FlyingComp.java
@@ -29,7 +29,7 @@ abstract class FlyingComp implements Posc, Velc, Healthc, Hitboxc{
     transient @Nullable Floor lastDrownFloor;
 
     boolean checkTarget(boolean targetAir, boolean targetGround){
-        return (isGrounded() && targetGround) || (isFlying() && targetAir);
+        return (isGrounded() && targetGround) || (isFlying() && targetAir) && type.hittable(self());
     }
 
     boolean isGrounded(){

--- a/core/src/mindustry/entities/comp/FlyingComp.java
+++ b/core/src/mindustry/entities/comp/FlyingComp.java
@@ -29,7 +29,7 @@ abstract class FlyingComp implements Posc, Velc, Healthc, Hitboxc{
     transient @Nullable Floor lastDrownFloor;
 
     boolean checkTarget(boolean targetAir, boolean targetGround){
-        return (isGrounded() && targetGround) || (isFlying() && targetAir) && type.hittable(self());
+        return (isGrounded() && targetGround) || (isFlying() && targetAir);
     }
 
     boolean isGrounded(){


### PR DESCRIPTION
Fixes units that can't be hit still being detected, such as with:
- EnergyFieldAbility shocks
- SapBulletType linecasting
- FlakBulletType auto-bursting
- Probably other things

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
