### PR TITLE
Payload source inputting into PayloadAmmoTurret fix

### DIFF
--- a/core/src/mindustry/world/blocks/defense/turrets/PayloadAmmoTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/PayloadAmmoTurret.java
@@ -26,6 +26,7 @@ public class PayloadAmmoTurret extends Turret{
         super(name);
 
         maxAmmo = 3;
+        acceptsPayload = true;
     }
 
     /** Initializes accepted ammo map. Format: [block1, bullet1, block2, bullet2...] */


### PR DESCRIPTION
I find it interesting how payload conveyors are capable of putting payloads into something that had neither `acceptsPayload = true` or `outputsPayload = true`.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
