### PR TITLE
Add Javadoc UTF-8 Encoding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -231,6 +231,7 @@ configure(subprojects - project(":annotations")){
         options{
             addStringOption('Xdoclint:none', '-quiet')
             addStringOption('-release', '16')
+            encoding('UTF-8')
         }
     }
 }


### PR DESCRIPTION
```
> Task :core:javadoc FAILED
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ai\types\CommandAI.java:219: error: unmappable character (0xE3) for encoding x-windows-949
    //TODO ?��?��?��
           ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ai\types\CommandAI.java:219: error: unmappable character (0xE3) for encoding x-windows-949
    //TODO ?��?��?��
             ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ai\types\CommandAI.java:219: error: unmappable character (0xE3) for encoding x-windows-949
    //TODO ?��?��?��
               ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\core\UI.java:603: error: unmappable character (0xE2) for encoding x-windows-949
        if(number == Long.MAX_VALUE) return "?��";
                                             ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\core\UI.java:604: error: unmappable character (0xE2) for encoding x-windows-949
        if(number == Long.MIN_VALUE) return "-?��";
                                              ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\editor\WaveInfoDialog.java:261: error: unmappable character (0xE2) for encoding x-windows-949
                            }).width(100f).get().setMessageText("?��");
                                                                 ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\entities\comp\BuildingComp.java:851: error: unmappable character (0xE2) for encoding x-windows-949
                //handle reactions between different liquid types ?��
                                                                  ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\entities\Units.java:110: error: unmappable character (0xE2) for encoding x-windows-949
        return cap >= Integer.MAX_VALUE - 1 ? "?��" : cap + "";
                                               ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:41: error: unmappable character (0xD0) for encoding x-windows-949
    "be", "?�ела�??�ска�?",
           ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:41: error: unmappable character (0x80) for encoding x-windows-949
    "be", "?�ела�??�ска�?",
                ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:41: error: unmappable character (0xD1) for encoding x-windows-949
    "be", "?�ела�??�ска�?",
                 ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:41: error: unmappable character (0x8F) for encoding x-windows-949
    "be", "?�ела�??�ска�?",
                      ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:42: error: unmappable character (0xD0) for encoding x-windows-949
    "bg", "?�ълга�??�к�?",
           ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:42: error: unmappable character (0x80) for encoding x-windows-949
    "bg", "?�ълга�??�к�?",
                 ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:42: error: unmappable character (0xD1) for encoding x-windows-949
    "bg", "?�ълга�??�к�?",
                  ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:42: error: unmappable character (0xB8) for encoding x-windows-949
    "bg", "?�ълга�??�к�?",
                     ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:43: error: unmappable character (0xD0) for encoding x-windows-949
    "ru", "?�усски�?",
           ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:43: error: unmappable character (0xB9) for encoding x-windows-949
    "ru", "?�усски�?",
                  ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:44: error: unmappable character (0xD180) for encoding x-windows-949
    "sr", "С?п?�к�?",
            ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:44: error: unmappable character (0xD1) for encoding x-windows-949
    "sr", "С?п?�к�?",
              ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:44: error: unmappable character (0xB8) for encoding x-windows-949
    "sr", "С?п?�к�?",
                 ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:45: error: unmappable character (0xD180) for encoding x-windows-949
    "uk_UA", "Ук?а?�нськ�?",
                ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:45: error: unmappable character (0xD1) for encoding x-windows-949
    "uk_UA", "Ук?а?�нськ�?",
                  ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:45: error: unmappable character (0xB0) for encoding x-windows-949
    "uk_UA", "Ук?а?�нськ�?",
                        ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:46: error: unmappable character (0xA2) for encoding x-windows-949
    "th", "ไท�?",
               ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:47: error: unmappable character (0x80) for encoding x-windows-949
    "zh_CN", "�?体中?��",
               ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:47: error: unmappable character (0xE6) for encoding x-windows-949
    "zh_CN", "�?体中?��",
                   ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:48: error: unmappable character (0xAD) for encoding x-windows-949
    "zh_TW", "正體�??��",
                  ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:48: error: unmappable character (0xE6) for encoding x-windows-949
    "zh_TW", "正體�??��",
                   ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:49: error: unmappable character (0xE6) for encoding x-windows-949
    "ja", "?��?���?",
           ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:49: error: unmappable character (0xE6) for encoding x-windows-949
    "ja", "?��?���?",
             ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:49: error: unmappable character (0x9E) for encoding x-windows-949
    "ja", "?��?���?",
                ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:50: error: unmappable character (0xED) for encoding x-windows-949
    "ko", "?���??��",
           ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:50: error: unmappable character (0xAD) for encoding x-windows-949
    "ko", "?���??��",
              ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\LanguageDialog.java:50: error: unmappable character (0xEC) for encoding x-windows-949
    "ko", "?���??��",
               ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\ui\dialogs\PlanetDialog.java:600: error: unmappable character (0xE2) for encoding x-windows-949
            (attacked == 0 ? "" : "\n[red]?��[lightgray] " + bundle.format("sectorlist.attacked", "[red]" + attacked + "[]")),
                                          ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\world\blocks\distribution\StackConveyor.java:292: error: unmappable character (0xE2) for encoding x-windows-949
                            //?�� to | from ?��
                              ^
D:\jenkins\.jenkins\workspace\Mindustry\core\src\mindustry\world\blocks\distribution\StackConveyor.java:292: error: unmappable character (0xE2) for encoding x-windows-949
                            //?�� to | from ?��
                                           ^
38 errors
```
jitpack is really stupid and slow so I am getting an error while building a jenkins server
**TESTED**

I'll build immediately after PR accepted