### PR TITLE
Move `damageMultiplier` to `BulletType`

### DIFF
--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -417,7 +417,7 @@ public class BulletType extends Content implements Cloneable{
 
     public void createSplashDamage(Bullet b, float x, float y){
         if(splashDamageRadius > 0 && !b.absorbed){
-            Damage.damage(b.team, x, y, splashDamageRadius, splashDamage * damageMultiplier(b), false, collidesAir, collidesGround, scaledSplashDamage, b);
+            Damage.damage(b.team, x, y, splashDamageRadius, splashDamage * b.damageMultiplier(), false, collidesAir, collidesGround, scaledSplashDamage, b);
 
             if(status != StatusEffects.none){
                 Damage.status(b.team, x, y, splashDamageRadius, status, statusDuration, collidesAir, collidesGround);
@@ -719,7 +719,7 @@ public class BulletType extends Content implements Cloneable{
         bullet.drag = drag;
         bullet.hitSize = hitSize;
         bullet.mover = mover;
-        bullet.damage = (damage < 0 ? this.damage : damage) * damageMultiplier(bullet);
+        bullet.damage = (damage < 0 ? this.damage : damage) * bullet.damageMultiplier();
         //reset trail
         if(bullet.trail != null){
             bullet.trail.clear();

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -364,6 +364,13 @@ public class BulletType extends Content implements Cloneable{
         }
     }
 
+    public float damageMultiplier(Bullet b){
+        if(b.owner instanceof Unit u) return u.damageMultiplier() * state.rules.unitDamage(b.team);
+        if(b.owner instanceof Building) return state.rules.blockDamage(b.team);
+
+        return 1f;
+    }
+
     public void hit(Bullet b){
         hit(b, b.x, b.y);
     }

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -417,7 +417,7 @@ public class BulletType extends Content implements Cloneable{
 
     public void createSplashDamage(Bullet b, float x, float y){
         if(splashDamageRadius > 0 && !b.absorbed){
-            Damage.damage(b.team, x, y, splashDamageRadius, splashDamage * b.damageMultiplier(), false, collidesAir, collidesGround, scaledSplashDamage, b);
+            Damage.damage(b.team, x, y, splashDamageRadius, splashDamage * damageMultiplier(b), false, collidesAir, collidesGround, scaledSplashDamage, b);
 
             if(status != StatusEffects.none){
                 Damage.status(b.team, x, y, splashDamageRadius, status, statusDuration, collidesAir, collidesGround);
@@ -719,7 +719,7 @@ public class BulletType extends Content implements Cloneable{
         bullet.drag = drag;
         bullet.hitSize = hitSize;
         bullet.mover = mover;
-        bullet.damage = (damage < 0 ? this.damage : damage) * bullet.damageMultiplier();
+        bullet.damage = (damage < 0 ? this.damage : damage) * damageMultiplier(bullet);
         //reset trail
         if(bullet.trail != null){
             bullet.trail.clear();

--- a/core/src/mindustry/entities/comp/BulletComp.java
+++ b/core/src/mindustry/entities/comp/BulletComp.java
@@ -82,10 +82,7 @@ abstract class BulletComp implements Timedc, Damagec, Hitboxc, Teamc, Posc, Draw
 
     @Override
     public float damageMultiplier(){
-        if(owner instanceof Unit u) return u.damageMultiplier() * state.rules.unitDamage(team);
-        if(owner instanceof Building) return state.rules.blockDamage(team);
-
-        return 1f;
+        return type.damageMultiplier(self());
     }
 
     @Override


### PR DESCRIPTION
Allows different bullet types to override the damage multiplier. Also opens up the possibility of bullets who's damage scales over time, should the fields be added.

Should it be removed from BulletComp? Unnecessary overlap.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
