### PR TITLE
Add rule to control whether units can automatically rebuild destroyed blocks

### DIFF
--- a/core/src/mindustry/core/Logic.java
+++ b/core/src/mindustry/core/Logic.java
@@ -34,12 +34,14 @@ public class Logic implements ApplicationListener{
     public Logic(){
 
         Events.on(BlockDestroyEvent.class, event -> {
-            //blocks that get broken are appended to the team's broken block queue
-            Tile tile = event.tile;
-            //skip null entities or un-rebuildables, for obvious reasons
-            if(tile.build == null || !tile.block().rebuildable) return;
+            if(state.rules.unitAutoRebuild){
+                //blocks that get broken are appended to the team's broken block queue
+                Tile tile = event.tile;
+                //skip null entities or un-rebuildables, for obvious reasons
+                if(tile.build == null || !tile.block().rebuildable) return;
 
-            tile.build.addPlan(true);
+                tile.build.addPlan(true);
+            }
         });
 
         Events.on(BlockBuildEndEvent.class, event -> {

--- a/core/src/mindustry/game/Rules.java
+++ b/core/src/mindustry/game/Rules.java
@@ -63,6 +63,8 @@ public class Rules{
     public float unitBuildSpeedMultiplier = 1f;
     /** How much damage any other units deal. */
     public float unitDamageMultiplier = 1f;
+    /** If true, builder units will automatically rebuild destroyed blocks. */
+    public boolean unitAutoRebuild = true;
     /** Whether to allow units to build with logic. */
     public boolean logicUnitBuild = true;
     /** If true, world processors no longer update. Used for testing. */


### PR DESCRIPTION
This rule is quite useful. For players that want extra difficulty or specific Mindustry servers like lobbies or in my case a schematic showcase server (Clearing build areas without units rebuilding it).

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
