### PR TITLE
`alwaysShooting` field for weapons

### DIFF
--- a/core/src/mindustry/type/Weapon.java
+++ b/core/src/mindustry/type/Weapon.java
@@ -51,6 +51,8 @@ public class Weapon implements Cloneable{
     public boolean alwaysContinuous;
     /** whether this weapon can be aimed manually by players */
     public boolean controllable = true;
+    /** whether this weapon is always shooting, regardless of targets ore cone */
+    public boolean alwaysShooting = false;
     /** whether to automatically target relevant units in update(); only works when controllable = false. */
     public boolean autoTarget = false;
     /** whether to perform target trajectory prediction */
@@ -322,6 +324,8 @@ public class Weapon implements Cloneable{
             //note that shooting state is not affected, as these cannot be controlled
             //logic will return shooting as false even if these return true, which is fine
         }
+
+        if(alwaysShooting) mount.shoot = true;
 
         //update continuous state
         if(continuous && mount.bullet != null){


### PR DESCRIPTION
`alwaysShooting = true` makes the weapon always shoot, regardless of anything in range or shoot cone.

https://user-images.githubusercontent.com/54301439/187288888-5d264c5d-ae1f-49ab-80ba-c60ceaee6c9d.mp4

![image](https://user-images.githubusercontent.com/54301439/187288847-4c2a50f5-38d1-4ff2-b29e-539d0e0861bd.png)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
