### PR TITLE
`killShooter` + `shootOnDeath` Causes Double Firing

### DIFF
--- a/core/src/mindustry/entities/Damage.java
+++ b/core/src/mindustry/entities/Damage.java
@@ -545,7 +545,7 @@ public class Damage{
                         float mult = (1f-(Mathf.dst2(startX, startY, x, y) / rad2) + edgeScale) / (1f + edgeScale);
                         float next = damage * mult - dealt;
                         //register damage dealt
-                        int p = build.pos();
+                        int p = Point2.pack(startX, startY);
                         damages.put(p, Math.max(damages.get(p), next));
                         //register as hit
                         dealt += build.health;

--- a/core/src/mindustry/entities/Damage.java
+++ b/core/src/mindustry/entities/Damage.java
@@ -545,7 +545,7 @@ public class Damage{
                         float mult = (1f-(Mathf.dst2(startX, startY, x, y) / rad2) + edgeScale) / (1f + edgeScale);
                         float next = damage * mult - dealt;
                         //register damage dealt
-                        int p = Point2.pack(startX, startY);
+                        int p = build.pos();
                         damages.put(p, Math.max(damages.get(p), next));
                         //register as hit
                         dealt += build.health;

--- a/core/src/mindustry/type/Weapon.java
+++ b/core/src/mindustry/type/Weapon.java
@@ -408,12 +408,12 @@ public class Weapon implements Cloneable{
         }
 
         shoot.shoot(mount.totalShots, (xOffset, yOffset, angle, delay, mover) -> {
+            mount.totalShots++;
             if(delay > 0f){
                 Time.run(delay, () -> bullet(unit, mount, xOffset, yOffset, angle, mover));
             }else{
                 bullet(unit, mount, xOffset, yOffset, angle, mover);
             }
-            mount.totalShots++;
         });
     }
 


### PR DESCRIPTION
- `totalShots` increment in unit weapons moved to before bullet spawning
  - `shootOnDeath` + `killShooter` was able to shoot twice because by the time the code gets to the check, `totalShots` has not been incremented yet.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.