### PR TITLE
Make missile units not be affected by map border.

### DIFF
--- a/core/src/mindustry/entities/comp/BoundedComp.java
+++ b/core/src/mindustry/entities/comp/BoundedComp.java
@@ -5,6 +5,7 @@ import arc.util.*;
 import mindustry.annotations.Annotations.*;
 import mindustry.game.*;
 import mindustry.gen.*;
+import mindustry.type.*;
 
 import static mindustry.Vars.*;
 
@@ -12,11 +13,14 @@ import static mindustry.Vars.*;
 abstract class BoundedComp implements Velc, Posc, Healthc, Flyingc{
     static final float warpDst = 30f;
 
+    @Import UnitType type;
     @Import float x, y;
     @Import Team team;
 
     @Override
     public void update(){
+        if(!type.bounded) return;
+        
         float bot = 0f, left = 0f, top = world.unitHeight(), right = world.unitWidth();
 
         //TODO hidden map rules only apply to player teams? should they?

--- a/core/src/mindustry/type/UnitType.java
+++ b/core/src/mindustry/type/UnitType.java
@@ -208,6 +208,8 @@ public class UnitType extends UnlockableContent{
     hidden = false,
     /** if true, this unit is for internal use only and does not have a sprite generated. */
     internal = false,
+    /** If false, this unit is not pushed away from map edges. */
+    bounded = true,
     /** if true, this unit is detected as naval - do NOT assign this manually! Initialized in init() */
     naval = false,
 

--- a/core/src/mindustry/type/unit/MissileUnitType.java
+++ b/core/src/mindustry/type/unit/MissileUnitType.java
@@ -25,6 +25,7 @@ public class MissileUnitType extends UnitType{
         envEnabled = Env.any;
         envDisabled = Env.none;
         physics = false;
+        bounded = false;
         trailLength = 7;
         hidden = true;
         speed = 4f;


### PR DESCRIPTION
Because normal bullets aren't affected either.

https://user-images.githubusercontent.com/54301439/189166440-30fe2660-8503-41be-a21a-a5dbb6307740.mp4

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
