### PR TITLE
Fancy custom map play dialog

### DIFF
--- a/core/src/mindustry/ui/dialogs/MapPlayDialog.java
+++ b/core/src/mindustry/ui/dialogs/MapPlayDialog.java
@@ -25,7 +25,6 @@ public class MapPlayDialog extends BaseDialog{
     Gamemode selectedGamemode = Gamemode.survival;
     Seq<Gamemode> validModes = new Seq<>();
     Map lastMap;
-
     int modeIndex = 0;
 
     public MapPlayDialog(){
@@ -193,7 +192,6 @@ public class MapPlayDialog extends BaseDialog{
                 t.table(Styles.grayPanel, desc -> {
                     desc.margin(15f);
                     desc.pane(descPane -> {
-                        Log.info("described");
                         descPane.labelWrap(map.description()).grow().top().left().get().setAlignment(Align.topLeft);
                     }).grow().padBottom(15f);
                     desc.row();

--- a/core/src/mindustry/ui/dialogs/MapPlayDialog.java
+++ b/core/src/mindustry/ui/dialogs/MapPlayDialog.java
@@ -78,7 +78,7 @@ public class MapPlayDialog extends BaseDialog{
         show();
     }
 
-    public void buildMobile(Map map, boolean playtesting){
+    private void buildMobile(Map map, boolean playtesting){
         float width = Core.graphics.getWidth() * 0.8f;
 
         cont.table(Styles.grayPanel, t -> {
@@ -131,7 +131,7 @@ public class MapPlayDialog extends BaseDialog{
         }).fillX().padTop(15f);
     }
 
-    public void buildDesktop(Map map, boolean playtesting){
+    private void buildDesktop(Map map, boolean playtesting){
         boolean hasDesc = map.tags.containsKey("description") && !map.tags.get("description").trim().isEmpty();
 
         Table buttonsTable = new Table();

--- a/core/src/mindustry/ui/dialogs/MapPlayDialog.java
+++ b/core/src/mindustry/ui/dialogs/MapPlayDialog.java
@@ -1,11 +1,17 @@
 package mindustry.ui.dialogs;
 
 import arc.*;
+import arc.graphics.*;
+import arc.math.*;
+import arc.scene.actions.*;
+import arc.scene.style.*;
 import arc.scene.ui.*;
 import arc.scene.ui.layout.*;
+import arc.struct.*;
 import arc.util.*;
 import mindustry.game.*;
 import mindustry.gen.*;
+import mindustry.graphics.*;
 import mindustry.maps.*;
 import mindustry.ui.*;
 
@@ -17,11 +23,16 @@ public class MapPlayDialog extends BaseDialog{
     CustomRulesDialog dialog = new CustomRulesDialog();
     Rules rules;
     Gamemode selectedGamemode = Gamemode.survival;
+    Seq<Gamemode> validModes = new Seq<>();
     Map lastMap;
+
+    int modeIndex = 0;
 
     public MapPlayDialog(){
         super("");
-        setFillParent(false);
+        titleTable.clear();
+
+        cont.setTransform(true);
 
         onResize(() -> {
             if(lastMap != null){
@@ -38,12 +49,19 @@ public class MapPlayDialog extends BaseDialog{
 
     public void show(Map map, boolean playtesting){
         this.lastMap = map;
-        title.setText(map.name());
         cont.clearChildren();
+
+        validModes.clear();
+        modeIndex = 0;
+        for(Gamemode mode : Gamemode.all){
+            if(!mode.hidden && mode.valid(map)){
+                validModes.add(mode);
+            }
+        }
 
         //reset to any valid mode after switching to attack (one must exist)
         if(!selectedGamemode.valid(map)){
-            selectedGamemode = Structs.find(Gamemode.all, m -> m.valid(map));
+            selectedGamemode = validModes.first();
             if(selectedGamemode == null){
                 selectedGamemode = Gamemode.survival;
             }
@@ -51,47 +69,144 @@ public class MapPlayDialog extends BaseDialog{
 
         rules = map.applyRules(selectedGamemode);
 
-        Table selmode = new Table();
-        selmode.add("@level.mode").colspan(2);
-        selmode.row();
+        if(mobile){
+            buildMobile(map, playtesting);
+        }else{
+            buildDesktop(map, playtesting);
+        }
 
-        selmode.table(Tex.button, modes -> {
-            int i = 0;
-            for(Gamemode mode : Gamemode.all){
-                if(mode.hidden) continue;
+        show();
+    }
 
-                modes.button(mode.toString(), Styles.flatToggleMenut, () -> {
-                    selectedGamemode = mode;
-                    rules = map.applyRules(mode);
-                }).update(b -> b.setChecked(selectedGamemode == mode)).size(140f, 54f).disabled(!mode.valid(map));
-                if(i++ % 2 == 1) modes.row();
+    public void buildMobile(Map map, boolean playtesting){
+        float width = Core.graphics.getWidth() * 0.8f;
+
+        cont.table(Styles.grayPanel, t -> {
+            t.margin(15f);
+            t.table(header -> {
+                header.image(Icon.map).size(30);
+                header.label(() -> map.name() + (Core.settings.getBool("console") ? "\n[gray]" + map.file.nameWithoutExtension() : "")).growX().left().padLeft(10f).get().setAlignment(Align.left);
+            }).growX().padBottom(15f);
+            t.row();
+            t.add(new BorderImage(map.safeTexture(), 3f)).size(width).get().setScaling(Scaling.fit);
+
+            t.row();
+            t.label(() -> Core.bundle.get("editor.author") + " " + map.author()).padTop(8f).left().get().setAlignment(Align.left);
+
+            if(Gamemode.survival.valid(map)){
+                t.row();
+                t.label((() -> Core.bundle.format("level.highscore", map.getHightScore()))).pad(3f).left().get().setAlignment(Align.left);;
+            }
+        });
+        cont.row();
+        cont.table(selmode -> {
+            selmode.table(Styles.grayPanel, modes -> {
+                modes.margin(15f);
+                modes.button(Icon.left, Styles.grayi, () -> {
+                    modeIndex = (modeIndex - 1) % validModes.size;
+                    if(modeIndex < 0) modeIndex = validModes.size - 1;
+                    selectedGamemode = validModes.get(modeIndex);
+                }).size(30f);
+                modes.label(() -> selectedGamemode.toString()).growX().get().setAlignment(Align.center);
+                modes.button(Icon.right, Styles.grayi, () -> {
+                    modeIndex = (modeIndex + 1) % validModes.size;
+                    selectedGamemode = validModes.get(modeIndex);
+                }).size(30f);
+            }).growX().height(50f);
+
+            selmode.button("?", Styles.grayt, this::displayGameModeHelp).size(50f).padLeft(15f);
+        }).fillX().padTop(15f);
+        cont.row();
+        cont.table(buttons -> {
+            buttons.defaults().height(50f);
+            buttons.button("@customize", Icon.settings, Styles.grayt, () -> dialog.show(rules, () -> rules = map.applyRules(selectedGamemode))).growX().padBottom(15f).margin(10f).colspan(2);
+            buttons.row();
+            buttons.button("@back", Icon.left, Styles.grayt, this::hide).growX().padRight(15f).margin(10f);
+            buttons.button("@play", Icon.play, Styles.grayt, () -> {
+                if(playListener != null) playListener.run();
+                control.playMap(map, rules, playtesting);
+                hide();
+                ui.custom.hide();
+            }).growX().margin(10f);;
+        }).fillX().padTop(15f);
+    }
+
+    public void buildDesktop(Map map, boolean playtesting){
+        boolean hasDesc = map.tags.containsKey("description") && !map.tags.get("description").trim().isEmpty();
+
+        Table buttonsTable = new Table();
+        buttonsTable.table(selmode -> {
+            selmode.table(Styles.grayPanel, modes -> {
+                for(Gamemode mode : validModes){
+                    TextureRegionDrawable icon = ui.getIcon("mode" + Strings.capitalize(mode.name()));
+                    if(!Core.atlas.isFound(icon.getRegion())) icon = Icon.none;
+
+                    modes.button(icon, Styles.emptyTogglei, 30f, () -> {
+                        selectedGamemode = mode;
+                        rules = map.applyRules(mode);
+                    }).height(30f).growX()
+                    .update(b -> b.setChecked(selectedGamemode == mode))
+                    .size(140f, 54f)
+                    .tooltip(mode.toString());
+                }
+            }).growX();
+
+            selmode.button("?", Styles.grayt, this::displayGameModeHelp).size(50f).padLeft(15f);
+        }).top().left().growX().padBottom(15f);
+
+        buttonsTable.row();
+        buttonsTable.table(buttons -> {
+            buttons.defaults().height(50f);
+            buttons.button("@back", Icon.left, Styles.grayt, this::hide).growX().padRight(15f).margin(10f);
+            buttons.button("@play", Icon.play, Styles.grayt, () -> {
+                if(playListener != null) playListener.run();
+                control.playMap(map, rules, playtesting);
+                hide();
+                ui.custom.hide();
+            }).growX().margin(10f);;
+            buttons.button("@customize", Icon.settings, Styles.grayt, () -> dialog.show(rules, () -> rules = map.applyRules(selectedGamemode))).growX().padLeft(15f).margin(10f);;
+        }).growX();
+
+
+        cont.table(Styles.grayPanel, t -> {
+            t.margin(15f);
+            t.table(header -> {
+                header.image(Icon.map).size(30);
+                header.label(() -> map.name() + (Core.settings.getBool("console") ? "\n[gray]" + map.file.nameWithoutExtension() : "")).growX().left().padLeft(10f).get().setAlignment(Align.left);
+            }).growX().padBottom(15f);
+            t.row();
+            t.add(new BorderImage(map.safeTexture(), 3f)).size(Core.graphics.getWidth() / 4f).get().setScaling(Scaling.fit);
+
+            if(!hasDesc){
+                t.row();
+                t.label(() -> Core.bundle.get("editor.author") + " " + map.author()).padTop(8f).left().get().setAlignment(Align.left);
+            }
+
+            if(Gamemode.survival.valid(map)){
+                t.row();
+                t.label((() -> Core.bundle.format("level.highscore", map.getHightScore()))).pad(3f).left().get().setAlignment(Align.left);;
             }
         });
 
-        selmode.button("?", this::displayGameModeHelp).width(50f).fillY().padLeft(18f);
+        if(hasDesc){
+            cont.table(t -> {
+                t.table(Styles.grayPanel, desc -> {
+                    desc.margin(15f);
+                    desc.pane(descPane -> {
+                        Log.info("described");
+                        descPane.labelWrap(map.description()).grow().top().left().get().setAlignment(Align.topLeft);
+                    }).grow().padBottom(15f);
+                    desc.row();
+                    desc.label(() -> Core.bundle.get("editor.author") + " " + map.author()).left().growX();
+                }).top().left().grow().padBottom(15f);
+                t.row();
 
-        cont.add(selmode);
-        cont.row();
-        cont.button("@customize", Icon.settings, () -> dialog.show(rules, () -> rules = map.applyRules(selectedGamemode))).height(50f).width(230);
-        cont.row();
-        cont.add(new BorderImage(map.safeTexture(), 3f)).size(mobile && !Core.graphics.isPortrait() ? 150f : 250f).get().setScaling(Scaling.fit);
-        //only maps with survival are valid for high scores
-        if(Gamemode.survival.valid(map)){
+                t.add(buttonsTable).growX();
+            }).fillY().width(Core.graphics.getWidth() / 4f * 1.5f).padLeft(10f);
+        }else{
             cont.row();
-            cont.label((() -> Core.bundle.format("level.highscore", map.getHightScore()))).pad(3f);
+            cont.add(buttonsTable).fillX().padTop(10f);
         }
-
-        buttons.clearChildren();
-        addCloseButton();
-
-        buttons.button("@play", Icon.play, () -> {
-            if(playListener != null) playListener.run();
-            control.playMap(map, rules, playtesting);
-            hide();
-            ui.custom.hide();
-        }).size(210f, 64f);
-
-        show();
     }
 
     private void displayGameModeHelp(){


### PR DESCRIPTION
Layout for maps without description
![image](https://user-images.githubusercontent.com/73060700/190895125-be0f73d8-2808-465d-b9c9-cb4147046fd7.png)

Layout for maps with description
![image](https://user-images.githubusercontent.com/73060700/190895111-7f713b0b-e6a6-4255-b901-cce8b9c14532.png)

Mobile layout, description is always hidden.
![image](https://user-images.githubusercontent.com/73060700/190895201-154e683a-8720-4255-ac20-f9b4660b4e3c.png)

I know the contribution guidelines advises against making single-use methods, but inlining the build methods just makes the already messy code look messier.

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
