### PR TITLE
Support for custom menu buttons

### DIFF
--- a/core/src/mindustry/ui/fragments/MenuFragment.java
+++ b/core/src/mindustry/ui/fragments/MenuFragment.java
@@ -122,7 +122,7 @@ public class MenuFragment{
         Seq<MobileButton> customs = customButtons.map(b -> new MobileButton(b.icon, b.text, b.runnable == null ? () -> {} : b.runnable));
 
         if(!Core.graphics.isPortrait()){
-            container.marginTop(60f);
+            container.marginTop(60f).left();
             container.add(play);
             container.add(join);
             container.add(custom);
@@ -196,7 +196,7 @@ public class MenuFragment{
                 new Buttoni("@mods", Icon.book, ui.mods::show),
                 new Buttoni("@settings", Icon.settings, ui.settings::show)
             );
-            buttons(t, customButtons.toArray());
+            buttons(t, customButtons.toArray(Buttoni.class));
             buttons(t, new Buttoni("@quit", Icon.exit, Core.app::exit));
         }).width(width).growY();
 

--- a/core/src/mindustry/ui/fragments/MenuFragment.java
+++ b/core/src/mindustry/ui/fragments/MenuFragment.java
@@ -42,53 +42,6 @@ public class MenuFragment{
 
         parent.fill((x, y, w, h) -> renderer.render());
 
-        parent.fill(c -> {
-            c.pane(cont -> {
-                container = cont;
-                cont.name = "menu container";
-
-                if(!mobile){
-                    c.left();
-                    buildDesktop();
-                    Events.on(ResizeEvent.class, event -> buildDesktop());
-                }else{
-                    buildMobile();
-                    Events.on(ResizeEvent.class, event -> buildMobile());
-                }
-            }).with(pane -> {
-                pane.setOverscroll(false, false);
-                pane.setFadeScrollBars(true);
-                pane.setupFadeScrollBars(0.2f, 1f);
-            }).grow();
-        });
-
-        parent.fill(c -> c.bottom().right().button(Icon.discord, new ImageButtonStyle(){{
-            up = discordBanner;
-        }}, ui.discord::show).marginTop(9f).marginLeft(10f).tooltip("@discord").size(84, 45).name("discord"));
-
-        //info icon
-        if(mobile){
-            parent.fill(c -> c.bottom().left().button("", new TextButtonStyle(){{
-                font = Fonts.def;
-                fontColor = Color.white;
-                up = infoBanner;
-            }}, ui.about::show).size(84, 45).name("info"));
-
-
-        }else if(becontrol.active()){
-            parent.fill(c -> c.bottom().right().button("@be.check", Icon.refresh, () -> {
-                ui.loadfrag.show();
-                becontrol.checkUpdate(result -> {
-                    ui.loadfrag.hide();
-                    if(!result){
-                        ui.showInfo("@be.noupdates");
-                    }
-                });
-            }).size(200, 60).name("becheck").update(t -> {
-                t.getLabel().setColor(becontrol.isUpdateAvailable() ? Tmp.c1.set(Color.white).lerp(Pal.accent, Mathf.absin(5f, 1f)) : Color.white);
-            }));
-        }
-
         String versionText = ((Version.build == -1) ? "[#fc8140aa]" : "[#ffffffba]") + Version.combined();
         parent.fill((x, y, w, h) -> {
             TextureRegion logo = Core.atlas.find("logo");
@@ -106,6 +59,49 @@ public class MenuFragment{
             Fonts.outline.setColor(Color.white);
             Fonts.outline.draw(versionText, fx, fy - logoh/2f - Scl.scl(2f), Align.center);
         }).touchable = Touchable.disabled;
+
+        parent.fill(c -> {
+            c.pane(Styles.noBarPane, cont -> {
+                container = cont;
+                cont.name = "menu container";
+
+                if(!mobile){
+                    c.left();
+                    buildDesktop();
+                    Events.on(ResizeEvent.class, event -> buildDesktop());
+                }else{
+                    buildMobile();
+                    Events.on(ResizeEvent.class, event -> buildMobile());
+                }
+            }).with(pane -> {
+                pane.setOverscroll(false, false);
+            }).grow();
+        });
+
+        parent.fill(c -> c.bottom().right().button(Icon.discord, new ImageButtonStyle(){{
+            up = discordBanner;
+        }}, ui.discord::show).marginTop(9f).marginLeft(10f).tooltip("@discord").size(84, 45).name("discord"));
+
+        //info icon
+        if(mobile){
+            parent.fill(c -> c.bottom().left().button("", new TextButtonStyle(){{
+                font = Fonts.def;
+                fontColor = Color.white;
+                up = infoBanner;
+            }}, ui.about::show).size(84, 45).name("info"));
+        }else if(becontrol.active()){
+            parent.fill(c -> c.bottom().right().button("@be.check", Icon.refresh, () -> {
+                ui.loadfrag.show();
+                becontrol.checkUpdate(result -> {
+                    ui.loadfrag.hide();
+                    if(!result){
+                        ui.showInfo("@be.noupdates");
+                    }
+                });
+            }).size(200, 60).name("becheck").update(t -> {
+                t.getLabel().setColor(becontrol.isUpdateAvailable() ? Tmp.c1.set(Color.white).lerp(Pal.accent, Mathf.absin(5f, 1f)) : Color.white);
+            }));
+        }
     }
 
     private void buildMobile(){

--- a/core/src/mindustry/ui/fragments/MenuFragment.java
+++ b/core/src/mindustry/ui/fragments/MenuFragment.java
@@ -122,7 +122,7 @@ public class MenuFragment{
         Seq<MobileButton> customs = customButtons.map(b -> new MobileButton(b.icon, b.text, b.runnable == null ? () -> {} : b.runnable));
 
         if(!Core.graphics.isPortrait()){
-            container.marginTop(60f).left();
+            container.marginTop(60f);
             container.add(play);
             container.add(join);
             container.add(custom);
@@ -133,19 +133,14 @@ public class MenuFragment{
             }
             container.row();
 
-            container.table(table -> {
-                table.defaults().set(container.defaults());
-
-                table.add(editor);
-                table.add(tools);
-
-                table.add(mods);
-                // add odd custom buttons (before the exit button)
-                for(int i = 1; i < customs.size; i += 2){
-                    table.add(customs.get(i));
-                }
-                if(!ios) table.add(exit);
-            }).colspan(container.getChildren().size - 1);
+            container.add(editor);
+            container.add(tools);
+            container.add(mods);
+            // add custom buttons (before the exit button)
+            for(int i = 1; i < customs.size; i += 2){
+                container.add(customs.get(i));
+            }
+            if(!ios) container.add(exit);
         }else{
             container.marginTop(0f);
             container.add(play);

--- a/core/src/mindustry/ui/fragments/MenuFragment.java
+++ b/core/src/mindustry/ui/fragments/MenuFragment.java
@@ -28,7 +28,7 @@ public class MenuFragment{
     private Table container, submenu;
     private Button currentMenu;
     private MenuRenderer renderer;
-    private Seq<Buttoni> customButtons = new Seq<>();
+    private Seq<MenuButton> customButtons = new Seq<>();
 
     public void build(Group parent){
         renderer = new MenuRenderer();
@@ -179,23 +179,23 @@ public class MenuFragment{
             t.name = "buttons";
 
             buttons(t,
-                new Buttoni("@play", Icon.play,
-                    new Buttoni("@campaign", Icon.play, () -> checkPlay(ui.planet::show)),
-                    new Buttoni("@joingame", Icon.add, () -> checkPlay(ui.join::show)),
-                    new Buttoni("@customgame", Icon.terrain, () -> checkPlay(ui.custom::show)),
-                    new Buttoni("@loadgame", Icon.download, () -> checkPlay(ui.load::show))
+                new MenuButton("@play", Icon.play,
+                    new MenuButton("@campaign", Icon.play, () -> checkPlay(ui.planet::show)),
+                    new MenuButton("@joingame", Icon.add, () -> checkPlay(ui.join::show)),
+                    new MenuButton("@customgame", Icon.terrain, () -> checkPlay(ui.custom::show)),
+                    new MenuButton("@loadgame", Icon.download, () -> checkPlay(ui.load::show))
                 ),
-                new Buttoni("@database.button", Icon.menu,
-                    new Buttoni("@schematics", Icon.paste, ui.schematics::show),
-                    new Buttoni("@database", Icon.book, ui.database::show),
-                    new Buttoni("@about.button", Icon.info, ui.about::show)
+                new MenuButton("@database.button", Icon.menu,
+                    new MenuButton("@schematics", Icon.paste, ui.schematics::show),
+                    new MenuButton("@database", Icon.book, ui.database::show),
+                    new MenuButton("@about.button", Icon.info, ui.about::show)
                 ),
-                new Buttoni("@editor", Icon.terrain, () -> checkPlay(ui.maps::show)), steam ? new Buttoni("@workshop", Icon.steam, platform::openWorkshop) : null,
-                new Buttoni("@mods", Icon.book, ui.mods::show),
-                new Buttoni("@settings", Icon.settings, ui.settings::show)
+                new MenuButton("@editor", Icon.terrain, () -> checkPlay(ui.maps::show)), steam ? new MenuButton("@workshop", Icon.steam, platform::openWorkshop) : null,
+                new MenuButton("@mods", Icon.book, ui.mods::show),
+                new MenuButton("@settings", Icon.settings, ui.settings::show)
             );
-            buttons(t, customButtons.toArray(Buttoni.class));
-            buttons(t, new Buttoni("@quit", Icon.exit, Core.app::exit));
+            buttons(t, customButtons.toArray(MenuButton.class));
+            buttons(t, new MenuButton("@quit", Icon.exit, Core.app::exit));
         }).width(width).growY();
 
         container.table(background, t -> {
@@ -232,8 +232,8 @@ public class MenuFragment{
         submenu.actions(Actions.alpha(1f), Actions.alpha(0f, 0.2f, Interp.fade), Actions.run(() -> submenu.clearChildren()));
     }
 
-    private void buttons(Table t, Buttoni... buttons){
-        for(Buttoni b : buttons){
+    private void buttons(Table t, MenuButton... buttons){
+        for(MenuButton b : buttons){
             if(b == null) continue;
             Button[] out = {null};
             out[0] = t.button(b.text, b.icon, Styles.flatToggleMenut, () -> {
@@ -263,7 +263,7 @@ public class MenuFragment{
 
     /** Adds a custom button to the menu. */
     public void addButton(String text, Drawable icon, Runnable callback){
-        addButton(new Buttoni(text, icon, callback));
+        addButton(new MenuButton(text, icon, callback));
     }
 
     /** Adds a custom button to the menu. */
@@ -273,24 +273,24 @@ public class MenuFragment{
 
     /** 
      * Adds a custom button to the menu.
-     * If {@link Buttoni#submenu} is null or the player is on mobile, {@link Buttoni#runnable} is invoked on click.
-     * Otherwise, {@link Buttoni#submenu} is shown.
+     * If {@link MenuButton#submenu} is null or the player is on mobile, {@link MenuButton#runnable} is invoked on click.
+     * Otherwise, {@link MenuButton#submenu} is shown.
      */
-    public void addButton(Buttoni button){
+    public void addButton(MenuButton button){
         customButtons.add(button);
     }
 
     /** Represents a menu button definition. */
-    public static class Buttoni{
+    public static class MenuButton{
         public final Drawable icon;
         public final String text;
         /** Runnable ran when the button is clicked. Ignored on desktop if {@link #submenu} is not null. */
         public final Runnable runnable;
         /** Submenu shown when this button is clicked. Used instead of {@link #runnable} on desktop. */
-        public final @Nullable Buttoni[] submenu;
+        public final @Nullable MenuButton[] submenu;
 
         /** Constructs a simple menu button, which behaves the same way on desktop and mobile. */
-        public Buttoni(String text, Drawable icon, Runnable runnable){
+        public MenuButton(String text, Drawable icon, Runnable runnable){
             this.icon = icon;
             this.text = text;
             this.runnable = runnable;
@@ -298,7 +298,7 @@ public class MenuFragment{
         }
 
         /** Constructs a button that runs the runnable when clicked on mobile or shows the submenu on desktop. */
-        public Buttoni(String text, Drawable icon, Runnable runnable, Buttoni... submenu){
+        public MenuButton(String text, Drawable icon, Runnable runnable, MenuButton... submenu){
             this.icon = icon;
             this.text = text;
             this.runnable = runnable;
@@ -306,7 +306,7 @@ public class MenuFragment{
         }
 
         /** Comstructs a desktop-only button; used internally. */
-        Buttoni(String text, Drawable icon, Buttoni... submenu){
+        MenuButton(String text, Drawable icon, MenuButton... submenu){
             this.icon = icon;
             this.text = text;
             this.runnable = () -> {};

--- a/core/src/mindustry/ui/fragments/MenuFragment.java
+++ b/core/src/mindustry/ui/fragments/MenuFragment.java
@@ -43,16 +43,23 @@ public class MenuFragment{
         parent.fill((x, y, w, h) -> renderer.render());
 
         parent.fill(c -> {
-            container = c;
-            c.name = "menu container";
+            c.pane(cont -> {
+                container = cont;
+                cont.name = "menu container";
 
-            if(!mobile){
-                buildDesktop();
-                Events.on(ResizeEvent.class, event -> buildDesktop());
-            }else{
-                buildMobile();
-                Events.on(ResizeEvent.class, event -> buildMobile());
-            }
+                if(!mobile){
+                    buildDesktop();
+                    Events.on(ResizeEvent.class, event -> buildDesktop());
+                }else{
+                    buildMobile();
+                    Events.on(ResizeEvent.class, event -> buildMobile());
+                }
+            }).with(pane -> {
+                pane.setOverscroll(false, false);
+                pane.setFadeScrollBars(true);
+                pane.setupFadeScrollBars(0.2f, 1f);
+                pane.setScrollBarPositions(true, false);
+            });
         });
 
         parent.fill(c -> c.bottom().right().button(Icon.discord, new ImageButtonStyle(){{

--- a/core/src/mindustry/ui/fragments/MenuFragment.java
+++ b/core/src/mindustry/ui/fragments/MenuFragment.java
@@ -127,8 +127,8 @@ public class MenuFragment{
             container.add(join);
             container.add(custom);
             container.add(maps);
-            // add even custom buttons
-            for(int i = 0; i < customs.size; i += 2){
+            // add odd custom buttons
+            for(int i = 1; i < customs.size; i += 2){
                 container.add(customs.get(i));
             }
             container.row();
@@ -136,8 +136,8 @@ public class MenuFragment{
             container.add(editor);
             container.add(tools);
             container.add(mods);
-            // add custom buttons (before the exit button)
-            for(int i = 1; i < customs.size; i += 2){
+            // add even custom buttons (before the exit button)
+            for(int i = 0; i < customs.size; i += 2){
                 container.add(customs.get(i));
             }
             if(!ios) container.add(exit);

--- a/core/src/mindustry/ui/fragments/MenuFragment.java
+++ b/core/src/mindustry/ui/fragments/MenuFragment.java
@@ -128,7 +128,7 @@ public class MenuFragment{
             container.add(custom);
             container.add(maps);
             // add even custom buttons
-            for (int i = 0; i < customs.size; i += 2) {
+            for(int i = 0; i < customs.size; i += 2){
                 container.add(customs.get(i));
             }
             container.row();
@@ -141,11 +141,11 @@ public class MenuFragment{
 
                 table.add(mods);
                 // add odd custom buttons (before the exit button)
-                for (int i = 1; i < customs.size; i += 2) {
+                for(int i = 1; i < customs.size; i += 2){
                     table.add(customs.get(i));
                 }
                 if(!ios) table.add(exit);
-            }).colspan(4);
+            }).colspan(container.getChildren().size - 1);
         }else{
             container.marginTop(0f);
             container.add(play);
@@ -157,18 +157,13 @@ public class MenuFragment{
             container.add(editor);
             container.add(tools);
             container.row();
+            container.add(mods);
             // add custom buttons
-            for (int i = 0; i < customs.size; i++) {
+            for(int i = 0; i < customs.size; i++){
                 container.add(customs.get(i));
-                if (i % 2 == 1) container.row();
+                if(i % 2 == 0) container.row();
             }
-
-            container.table(table -> {
-                table.defaults().set(container.defaults());
-
-                table.add(mods);
-                if(!ios) table.add(exit);
-            }).colspan(2);
+            if(!ios) container.add(exit);
         }
     }
 
@@ -293,7 +288,7 @@ public class MenuFragment{
         public final String text;
         /** Runnable ran when the button is clicked. Ignored on desktop if {@link #submenu} is not null. */
         public final Runnable runnable;
-        /** Submenu shown when this button is clicked. Used instead of {@link runnable} on desktop. */
+        /** Submenu shown when this button is clicked. Used instead of {@link #runnable} on desktop. */
         public final @Nullable Buttoni[] submenu;
 
         /** Constructs a simple menu button, which behaves the same way on desktop and mobile. */

--- a/core/src/mindustry/ui/fragments/MenuFragment.java
+++ b/core/src/mindustry/ui/fragments/MenuFragment.java
@@ -48,6 +48,7 @@ public class MenuFragment{
                 cont.name = "menu container";
 
                 if(!mobile){
+                    c.left();
                     buildDesktop();
                     Events.on(ResizeEvent.class, event -> buildDesktop());
                 }else{
@@ -58,8 +59,7 @@ public class MenuFragment{
                 pane.setOverscroll(false, false);
                 pane.setFadeScrollBars(true);
                 pane.setupFadeScrollBars(0.2f, 1f);
-                pane.setScrollBarPositions(true, false);
-            });
+            }).grow();
         });
 
         parent.fill(c -> c.bottom().right().button(Icon.discord, new ImageButtonStyle(){{

--- a/servers_v7.json
+++ b/servers_v7.json
@@ -122,6 +122,6 @@
   },
   {
     "name": "LightDustry",
-    "address": ["lightdustry.ddns.net:28583", "lightdustry.ddns.net:6567", "lightdustry.ddns.net:6568"]
+    "address": ["lightdustry.ddns.net:28583", "lightdusy.ddns.net:6567", "lightdusy.ddns.net:6568"]
   }
 ]


### PR DESCRIPTION
Added support for custom main menu buttons, similarly to custom categories in SettingsMenuDialog. Mods can register new menu buttons by using one of the `MenuFragment.addButton` methods, e.g. `Vars.ui.menufrag.addButton("die", Icon.none, () -> throw Error())`. For convenience, the quit button is always kept in the bottom right / bottom part of the menu, so the custom buttons are inserted between it and other buttons.

MenuFragment.Buttoni was made public and is now used to store the registered "button definitions"... I'm not sure if this is the best approach, but it works.

For example, running the following code in the console
![Miserable_situation_20220918_170317](https://user-images.githubusercontent.com/69920617/190913841-b3e21f6a-ae42-4713-87f2-68d9174f2dfa.png)
Results in this:
![Miserable_situation_20220918_174142](https://user-images.githubusercontent.com/69920617/190913951-72ee7d70-e4ac-4f9f-b17c-f9fd688aadd6.png)

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
