### PR TITLE
Fix Variable Reactor power output not being linear to heat input

### DIFF
--- a/core/src/mindustry/world/blocks/power/VariableReactor.java
+++ b/core/src/mindustry/world/blocks/power/VariableReactor.java
@@ -78,7 +78,7 @@ public class VariableReactor extends PowerGenerator{
         public void updateTile(){
             heat = calculateHeat(sideHeat);
 
-            productionEfficiency = Mathf.clamp(heat / maxHeat) * efficiency;
+            productionEfficiency = efficiency;
             warmup = Mathf.lerpDelta(warmup, productionEfficiency > 0 ? 1f : 0f, warmupSpeed);
 
             if(instability >= 1f){


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/54301439/191190556-4e6aff94-4eaf-48b7-81f9-1feff6d6920d.mp4

Now:

https://user-images.githubusercontent.com/54301439/191190577-ee18ff16-015d-455b-8af9-4d45867bfac1.mp4

---

Since `updateEfficiencyMultiplier()` already handles `heat / maxheat`, it shouldn't be multiplied by `heat / maxHeat` in `updateTile()`.
...I feel like I've seen someone mention this issue before but I can't find the original message.

---

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
