### PR TITLE
remove enabled() check in getMod() method

### DIFF
--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -84,7 +84,7 @@ public class Mods implements Loadable{
 
     /** @return the loaded mod found by class, or null if not found. */
     public @Nullable LoadedMod getMod(Class<? extends Mod> type){
-        return mods.find(m -> m.enabled() && m.main != null && m.main.getClass() == type);
+        return mods.find(m -> m.main != null && m.main.getClass() == type);
     }
 
     /** Imports an external mod file. Folders are not supported here. */


### PR DESCRIPTION
This method isn't used in mindustry code anywhere, so my PR won't break anything, but will allow a mod to find itself by its main class even if it's not yet enabled

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
