### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -5,8 +5,12 @@ on:
     tags:
       - 'v*'
 
+permissions: {}
 jobs:
   deploy:
+    permissions:
+      contents: write # for release creation (svenstaro/upload-release-action)
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,9 @@ name: Pull Request Tests
 
 on: [pull_request, workflow_dispatch]
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   testPR:
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,8 +2,12 @@ name: Tests
 
 on: [push, workflow_dispatch]
 
+permissions: {}
 jobs:
   runPush:
+    permissions:
+      contents: write # for Update bundles
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.