### PR TITLE
fix player name color on minimap

### DIFF
--- a/core/src/mindustry/graphics/MinimapRenderer.java
+++ b/core/src/mindustry/graphics/MinimapRenderer.java
@@ -141,7 +141,7 @@ public class MinimapRenderer{
                     float rx = player.x / (world.width() * tilesize) * w;
                     float ry = player.y / (world.height() * tilesize) * h;
 
-                    drawLabel(x + rx, y + ry, player.name, player.team().color);
+                    drawLabel(x + rx, y + ry, player.coloredName(), player.team().color);
                 }
             }
         }


### PR DESCRIPTION
So now players without color codes in their names look like this
![image](https://user-images.githubusercontent.com/79508138/193468130-a9bce95e-c599-485c-ae9d-d3e3311d720f.png)
![image](https://user-images.githubusercontent.com/79508138/193468152-ce8ed577-3070-4f06-abda-7843025ceeab.png)

But i fixed it ;-;

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable. (Didn't test, but should i?)
