### PR TITLE
Remove duplicate server

### DIFF
--- a/servers_v7.json
+++ b/servers_v7.json
@@ -9,7 +9,7 @@
   },
   {
     "name": "SynapseOS",
-    "address": ["0nera.ru:7777", "185.178.45.224:7777"]
+    "address": ["0nera.ru:7777"]
   },
   {
     "name": "Voiddustry",


### PR DESCRIPTION
Those IPs are equal, pointing to one host and we don't need 2 literally same servers