### PR TITLE
Fix WorldReloader

### DIFF
--- a/core/src/mindustry/net/WorldReloader.java
+++ b/core/src/mindustry/net/WorldReloader.java
@@ -31,7 +31,7 @@ public class WorldReloader{
             logic.reset();
 
             Call.worldDataBegin();
-        }else {
+        }else{
             if(net.client()){
                 net.reset();
             }    

--- a/core/src/mindustry/net/WorldReloader.java
+++ b/core/src/mindustry/net/WorldReloader.java
@@ -31,8 +31,10 @@ public class WorldReloader{
             logic.reset();
 
             Call.worldDataBegin();
-        }else if(net.client()){
-            net.reset();
+        }else {
+            if(net.client()){
+                net.reset();
+            }    
             logic.reset();
         }
 

--- a/core/src/mindustry/net/WorldReloader.java
+++ b/core/src/mindustry/net/WorldReloader.java
@@ -31,7 +31,7 @@ public class WorldReloader{
             logic.reset();
 
             Call.worldDataBegin();
-        }else{
+        }else if(net.client()){
             net.reset();
             logic.reset();
         }


### PR DESCRIPTION
Fixed this exception (it appears when you try to use WorldReloader on a headless server, but the server is not hosted)
I mean this:
[E] java.lang.NullPointerException: Cannot invoke "mindustry.core.NetClient.disconnectNoReset()" because "mindustry.Vars.netClient" is null
        at mindustry.net.Net.reset(Net.java:194)
        at mindustry.net.WorldReloader.begin(WorldReloader.java:35)
        at darkdustry.utils.Utils.reloadWorld(Utils.java:87)
        at darkdustry.commands.ServerCommands.lambda$load$3(ServerCommands.java:64)
        at arc.util.TaskQueue.run(TaskQueue.java:17)
        at arc.backend.headless.HeadlessApplication.mainLoop(HeadlessApplication.java:81)
        at arc.backend.headless.HeadlessApplication$1.run(HeadlessApplication.java:52)

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
