### PR TITLE
Expand getBlock functionality

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -2322,7 +2322,7 @@ lenum.payenter = Enter/land on the payload block the unit is on.
 lenum.flag = Numeric unit flag.
 lenum.mine = Mine at a position.
 lenum.build = Build a structure.
-lenum.getblock = Fetch a building and type at coordinates.\nUnit must be in range of position.\nSolid non-buildings will have the type [accent]@solid[].\nUse floor as a boolean to check for ores/floor tiles.
+lenum.getblock = Fetch a building, floor and type at coordinates.\nUnit must be in range of position.\nSolid non-buildings will have the type [accent]@solid[].
 lenum.within = Check if unit is near a position.
 lenum.boost = Start/stop boosting.
 

--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -2322,7 +2322,7 @@ lenum.payenter = Enter/land on the payload block the unit is on.
 lenum.flag = Numeric unit flag.
 lenum.mine = Mine at a position.
 lenum.build = Build a structure.
-lenum.getblock = Fetch a building and type at coordinates.\nUnit must be in range of position.\nSolid non-buildings will have the type [accent]@solid[].
+lenum.getblock = Fetch a building and type at coordinates.\nUnit must be in range of position.\nSolid non-buildings will have the type [accent]@solid[].\nUse floor as a boolean to check for ores/floor tiles
 lenum.within = Check if unit is near a position.
 lenum.boost = Start/stop boosting.
 

--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -2322,7 +2322,7 @@ lenum.payenter = Enter/land on the payload block the unit is on.
 lenum.flag = Numeric unit flag.
 lenum.mine = Mine at a position.
 lenum.build = Build a structure.
-lenum.getblock = Fetch a building and type at coordinates.\nUnit must be in range of position.\nSolid non-buildings will have the type [accent]@solid[].\nUse floor as a boolean to check for ores/floor tiles
+lenum.getblock = Fetch a building and type at coordinates.\nUnit must be in range of position.\nSolid non-buildings will have the type [accent]@solid[].\nUse floor as a boolean to check for ores/floor tiles.
 lenum.within = Check if unit is near a position.
 lenum.boost = Start/stop boosting.
 

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -510,20 +510,20 @@ public class LExecutor{
                         if(!unit.within(x1, y1, range)){
                             exec.setobj(p3, null);
                             exec.setobj(p4, null);
+                            exec.setobj(p5, null);
                         }else{
                             Tile tile = world.tileWorld(x1, y1);
                             if(tile == null){
                                 exec.setobj(p3, null);
+                                exec.setobj(p4, null);
+                                exec.setobj(p5, null);
                             }else{
-                                if(exec.bool(p5)){
-                                    //Allows reading of ore tiles if they are present (overlay is not air) otherwise returns the floor
-                                    exec.setobj(p3, tile.overlay() == Blocks.air ? tile.floor() : tile.overlay());
-                                }else{
-                                    //any environmental solid block is returned as StoneWall, aka "@solid"
-                                    Block block = !tile.synthetic() ? (tile.solid() ? Blocks.stoneWall : Blocks.air) : tile.block();
-                                    exec.setobj(p3, block);
-                                    }
-                                exec.setobj(p4, tile != null && tile.build != null ? tile.build : null);
+                                //any environmental solid block is returned as StoneWall, aka "@solid"
+                                Block block = !tile.synthetic() ? (tile.solid() ? Blocks.stoneWall : Blocks.air) : tile.block();
+                                exec.setobj(p3, block);
+                                exec.setobj(p4, tile.build != null ? tile.build : null);
+                                //Allows reading of ore tiles if they are present (overlay is not air) otherwise returns the floor
+                                exec.setobj(p5, tile.overlay() == Blocks.air ? tile.floor() : tile.overlay());
                             }
                         }
                     }

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -515,7 +515,7 @@ public class LExecutor{
                             if(tile == null){
                                 exec.setobj(p3, null);
                             }else{
-                                if(floor){
+                                if(exec.bool(p5)){
                                 exec.setobj(p3, tile.overlay() != null ? tile.floor() : tile.overlay());
                                 }else{
                                     //any environmental solid block is returned as StoneWall, aka "@solid"

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -516,7 +516,7 @@ public class LExecutor{
                                 exec.setobj(p3, null);
                             }else{
                                 if(exec.bool(p5)){
-                                    exec.setobj(p3, tile.overlay() == null ? tile.floor() : tile.overlay());
+                                    exec.setobj(p3, tile.overlay() == Blocks.air ? tile.floor() : tile.overlay());
                                 }else{
                                     //any environmental solid block is returned as StoneWall, aka "@solid"
                                     Block block = !tile.synthetic() ? (tile.solid() ? Blocks.stoneWall : Blocks.air) : tile.block();

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -512,10 +512,18 @@ public class LExecutor{
                             exec.setobj(p4, null);
                         }else{
                             Tile tile = world.tileWorld(x1, y1);
-                            //any environmental solid block is returned as StoneWall, aka "@solid"
-                            Block block = tile == null ? null : !tile.synthetic() ? (tile.solid() ? Blocks.stoneWall : Blocks.air) : tile.block();
-                            exec.setobj(p3, block);
-                            exec.setobj(p4, tile != null && tile.build != null ? tile.build : null);
+                            if(tile == null){
+                                exec.setobj(p3, null);
+                            }else{
+                                if(floor){
+                                exec.setobj(p3, tile.overlay() != null ? tile.floor() : tile.overlay());
+                                }else{
+                                    //any environmental solid block is returned as StoneWall, aka "@solid"
+                                    Block block = !tile.synthetic() ? (tile.solid() ? Blocks.stoneWall : Blocks.air) : tile.block();
+                                    exec.setobj(p3, block);
+                                    }
+                                exec.setobj(p4, tile != null && tile.build != null ? tile.build : null);
+                            }
                         }
                     }
                     case itemDrop -> {

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -516,6 +516,7 @@ public class LExecutor{
                                 exec.setobj(p3, null);
                             }else{
                                 if(exec.bool(p5)){
+                                    //Allows reading of ore tiles if they are present (overlay is not air) otherwise returns the floor
                                     exec.setobj(p3, tile.overlay() == Blocks.air ? tile.floor() : tile.overlay());
                                 }else{
                                     //any environmental solid block is returned as StoneWall, aka "@solid"

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -516,7 +516,7 @@ public class LExecutor{
                                 exec.setobj(p3, null);
                             }else{
                                 if(exec.bool(p5)){
-                                exec.setobj(p3, tile.overlay() != null ? tile.floor() : tile.overlay());
+                                    exec.setobj(p3, tile.overlay() == null ? tile.floor() : tile.overlay());
                                 }else{
                                     //any environmental solid block is returned as StoneWall, aka "@solid"
                                     Block block = !tile.synthetic() ? (tile.solid() ? Blocks.stoneWall : Blocks.air) : tile.block();

--- a/core/src/mindustry/logic/LUnitControl.java
+++ b/core/src/mindustry/logic/LUnitControl.java
@@ -16,7 +16,7 @@ public enum LUnitControl{
     mine("x", "y"),
     flag("value"),
     build("x", "y", "block", "rotation", "config"),
-    getBlock("x", "y", "type", "building"),
+    getBlock("x", "y", "type", "building", "floor"),
     within("x", "y", "radius", "result"),
     unbind;
 


### PR DESCRIPTION
Let's the player use getBlock to detect water, floor, and ore tiles.

A reimagining of pr #6956, but now it doesn't break old logic, and still adds the majority of its function.

~~Simply adds a boolean input to getBlock (in the same fashion as unitLocate's enemy boolean) that lets you choose to search for floor tiles instead of block tiles.~~ When used and a non-air overlay tile is present (ie. ores) it will default 'floor' to that, otherwise it will return the floor tile in 'floor'.

The main goal here was being able to make cool logic-based maps, detect water to allow (shitty) pathfinding, and have a more precise method of detecting ores.

Tested to make sure old logics are unchanged on this branch (simply because you already have 5 variables for unitControl thanks to build, all the considered problems are already solved)

Also changed the bundle description of getBlock to reflect this.

~~clearly me waiting two months to try this again was optimal, just attempting to squeeze this into v7~~

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.