### PR TITLE
remove unused entry in bundle.properties

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -1181,7 +1181,6 @@ rules.placerangecheck = Placement Range Check
 rules.enemyCheat = Infinite Enemy Team Resources
 rules.blockhealthmultiplier = Block Health Multiplier
 rules.blockdamagemultiplier = Block Damage Multiplier
-rules.hideBannedBlocks = Hide Banned Blocks
 rules.unitbuildspeedmultiplier = Unit Production Speed Multiplier
 rules.unitcostmultiplier = Unit Cost Multiplier
 rules.unithealthmultiplier = Unit Health Multiplier


### PR DESCRIPTION
Just removes an unnecessary bundle entry (I think) I noticed while translating. I took a look at the code and don't think I can see it used anywhere - but take that with quite a few grains of salt, I'm not an expert on anything here (it also runs just fine).

To clarify: I believe the code references `rules.hidebannedblocks`, which is in line 647 and capitalized differently.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
