### PR TITLE
isBanned() check on canCreate()

### DIFF
--- a/core/src/mindustry/entities/Units.java
+++ b/core/src/mindustry/entities/Units.java
@@ -93,7 +93,7 @@ public class Units{
 
     /** @return whether a new instance of a unit of this team can be created. */
     public static boolean canCreate(Team team, UnitType type){
-        return team.data().countType(type) < getCap(team);
+        return team.data().countType(type) < getCap(team) && !type.isBanned();
     }
 
     public static int getCap(Team team){


### PR DESCRIPTION
So unit spawn ablilties, world processors and etc. can't create banned units

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
