### PR TITLE
Make Collaris‘ frag bullet unable to collide with air units

### DIFF
--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -3497,6 +3497,8 @@ public class UnitTypes{
                         trailWidth = 2.2f;
                         trailLength = 7;
                         trailChance = -1f;
+                        
+                        collidesAir = false;
 
                         despawnEffect = Fx.none;
                         splashDamage = 50f;


### PR DESCRIPTION
Since it *cannot* target air ... so make it be totally unable to damage air units

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
