### PR TITLE
fix factory plan icon scaling, unhardcode node beam regions

### DIFF
--- a/core/src/mindustry/world/blocks/power/BeamNode.java
+++ b/core/src/mindustry/world/blocks/power/BeamNode.java
@@ -1,5 +1,6 @@
 package mindustry.world.blocks.power;
 
+import arc.Core;
 import arc.graphics.*;
 import arc.graphics.g2d.*;
 import arc.math.*;
@@ -22,8 +23,7 @@ import static mindustry.Vars.*;
 public class BeamNode extends PowerBlock{
     public int range = 5;
 
-    public @Load("power-beam") TextureRegion laser;
-    public @Load("power-beam-end") TextureRegion laserEnd;
+    public TextureRegion laser, laserEnd;
 
     public Color laserColor1 = Color.white;
     public Color laserColor2 = Color.valueOf("ffd9c2");
@@ -60,6 +60,14 @@ public class BeamNode extends PowerBlock{
         super.init();
 
         updateClipRadius((range + 1) * tilesize);
+    }
+
+    @Override
+    public void load(){
+        super.load();
+
+        laser = Core.atlas.find(name + "-beam", Core.atlas.find("power-beam"));
+        laserEnd = Core.atlas.find(name + "-beam-end", Core.atlas.find("power-beam-end"));
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/power/LongPowerNode.java
+++ b/core/src/mindustry/world/blocks/power/LongPowerNode.java
@@ -22,8 +22,8 @@ public class LongPowerNode extends PowerNode{
     public void load(){
         super.load();
 
-        laser = Core.atlas.find("power-beam");
-        laserEnd = Core.atlas.find("power-beam-end");
+        laser = Core.atlas.find(name + "-beam", Core.atlas.find("power-beam"));
+        laserEnd = Core.atlas.find(name + "-beam-end", Core.atlas.find("power-beam-end"));
     }
 
     public class LongPowerNodeBuild extends PowerNodeBuild{

--- a/core/src/mindustry/world/blocks/power/PowerNode.java
+++ b/core/src/mindustry/world/blocks/power/PowerNode.java
@@ -29,8 +29,7 @@ public class PowerNode extends PowerBlock{
     /** The maximum range of all power nodes on the map */
     protected static float maxRange;
 
-    public @Load("laser") TextureRegion laser;
-    public @Load("laser-end") TextureRegion laserEnd;
+    public TextureRegion laser, laserEnd;
     public float laserRange = 6;
     public int maxNodes = 3;
     public boolean autolink = true, drawRange = true;
@@ -145,6 +144,14 @@ public class PowerNode extends PowerBlock{
         super.init();
 
         clipSize = Math.max(clipSize, laserRange * tilesize);
+    }
+
+    @Override
+    public void load(){
+        super.load();
+
+        laser = Core.atlas.find(name + "-laser", Core.atlas.find("laser"));
+        laserEnd = Core.atlas.find(name + "-laser-end", Core.atlas.find("laser-end"));
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/units/UnitFactory.java
+++ b/core/src/mindustry/world/blocks/units/UnitFactory.java
@@ -122,7 +122,7 @@ public class UnitFactory extends UnitBlock{
                     }
 
                     if(plan.unit.unlockedNow()){
-                        t.image(plan.unit.uiIcon).size(40).pad(10f).left();
+                        t.image(plan.unit.uiIcon).size(40).pad(10f).left().scaling(Scaling.fit);
                         t.table(info -> {
                             info.add(plan.unit.localizedName).left();
                             info.row();


### PR DESCRIPTION
Currently the game just recolors the existing power beam regions when you change its color parameters, which tends to make getting the colors you want difficult.

Also fixes this
![image](https://user-images.githubusercontent.com/89076920/199205726-affb8984-06ce-40e6-8bf6-70f9eb77fdf4.png)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
