### PR TITLE
Precision errors in float to string methods

### DIFF
--- a/core/src/mindustry/world/meta/StatValues.java
+++ b/core/src/mindustry/world/meta/StatValues.java
@@ -34,15 +34,13 @@ public class StatValues{
         return table ->  table.add(!value ? "@no" : "@yes");
     }
 
-    /** @deprecated Use Strings.autoFixed(value, 2) instead. */
-    @Deprecated
     public static String fixValue(float value){
         return Strings.autoFixed(value, 2);
     }
 
     public static StatValue squared(float value, StatUnit unit){
         return table -> {
-            String fixed = Strings.autoFixed(value, 2);
+            String fixed = fixValue(value);
             table.add(fixed + "x" + fixed);
             table.add((unit.space ? " " : "") + unit.localized());
         };
@@ -50,7 +48,7 @@ public class StatValues{
 
     public static StatValue number(float value, StatUnit unit, boolean merge){
         return table -> {
-            String l1 = (unit.icon == null ? "" : unit.icon + " ") + Strings.autoFixed(value, 2), l2 = (unit.space ? " " : "") + unit.localized();
+            String l1 = (unit.icon == null ? "" : unit.icon + " ") + fixValue(value), l2 = (unit.space ? " " : "") + unit.localized();
 
             if(merge){
                 table.add(l1 + l2);

--- a/core/src/mindustry/world/meta/StatValues.java
+++ b/core/src/mindustry/world/meta/StatValues.java
@@ -34,14 +34,15 @@ public class StatValues{
         return table ->  table.add(!value ? "@no" : "@yes");
     }
 
+    /** @deprecated Use Strings.autoFixed(value, 2) instead. */
+    @Deprecated
     public static String fixValue(float value){
-        int precision = Math.abs((int)value - value) <= 0.001f ? 0 : Math.abs((int)(value * 10) - value * 10) <= 0.001f ? 1 : 2;
-        return Strings.fixed(value, precision);
+        return Strings.autoFixed(value, 2);
     }
 
     public static StatValue squared(float value, StatUnit unit){
         return table -> {
-            String fixed = fixValue(value);
+            String fixed = Strings.autoFixed(value, 2);
             table.add(fixed + "x" + fixed);
             table.add((unit.space ? " " : "") + unit.localized());
         };
@@ -49,7 +50,7 @@ public class StatValues{
 
     public static StatValue number(float value, StatUnit unit, boolean merge){
         return table -> {
-            String l1 = (unit.icon == null ? "" : unit.icon + " ") + fixValue(value), l2 = (unit.space ? " " : "") + unit.localized();
+            String l1 = (unit.icon == null ? "" : unit.icon + " ") + Strings.autoFixed(value, 2), l2 = (unit.space ? " " : "") + unit.localized();
 
             if(merge){
                 table.add(l1 + l2);


### PR DESCRIPTION
Related to Anuken/Arc#124, "About the other autoFixed()" paragraph. Since the pull request got accepted, it is necessary to copy the changes from Arc's `autoFixed(value, maxPrecision)` to Mindustry's `fixValue(value)` to make sure a correct precision is used.

The two methods were practically the same, so I replaced all occurrences of `fixValue()` with `autoFixed()` and made `fixValue()` deprecated. As far as I know `fixValue()` was used only in the StatValues class and nowhere else (not even some mods I briefly checked). I was tempted to delete it altogether, but decided to deprecate it instead since it is a public method.

I managed to find only 2 stats that were not displayed properly before the fix: Precept's speed (4.80 -> 4.8) and healing from Overdrive status (0.60 -> 0.6).

----

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
