### PR TITLE
Adds select all unit production hotkey

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -1142,6 +1142,7 @@ keybind.diagonal_placement.name = Diagonal Placement
 keybind.pick.name = Pick Block
 keybind.break_block.name = Break Block
 keybind.select_all_units = Select All Units
+keybind.select_all_unit_factories = Select All Unit Factories
 keybind.deselect.name = Deselect
 keybind.pickupCargo.name = Pickup Cargo
 keybind.dropCargo.name = Drop Cargo

--- a/core/src/mindustry/input/Binding.java
+++ b/core/src/mindustry/input/Binding.java
@@ -20,6 +20,7 @@ public enum Binding implements KeyBind{
     break_block(KeyCode.mouseRight),
 
     select_all_units(KeyCode.g),
+    select_all_unit_factories(KeyCode.h),
 
     pickupCargo(KeyCode.leftBracket),
     dropCargo(KeyCode.rightBracket),

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -279,9 +279,20 @@ public class DesktopInput extends InputHandler{
 
         if(commandMode && input.keyTap(Binding.select_all_units) && !scene.hasField() && !scene.hasDialog()){
             selectedUnits.clear();
+            commandBuildings.clear();
             for(var unit : player.team().data().units){
                 if(unit.isCommandable()){
                     selectedUnits.add(unit);
+                }
+            }
+        }
+
+        if(commandMode && input.keyTap(Binding.select_all_unit_factories) && !scene.hasField() && !scene.hasDialog()){
+            selectedUnits.clear();
+            commandBuildings.clear();
+            for(var build : player.team().data().buildings){
+                if(build.block.commandable){
+                    commandBuildings.add(build);
                 }
             }
         }


### PR DESCRIPTION
Adds a hotkey for selecting all unit production. In many RTS games people will use a control group for their unit production buildings to rally units forwards so this is to replace the need for that.

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
