### PR TITLE
Removing mindustry.ddns.net

### DIFF
--- a/servers_v6.json
+++ b/servers_v6.json
@@ -53,7 +53,7 @@
   },
   {
     "name": "mindustry.ddns.net",
-    "address": ["mindustry.ddns.net", "mindustry.ddns.net:1000", "mindustry.ddns.net:2000", "mindustry.ddns.net:3000", "mindustry.ddns.net:4000"]
+    "address": ["mindustry.ddns.net:2500"]
   },
   {
     "name": "Surrealment v6",


### PR DESCRIPTION
The servers have switched to v7. (Except one)