### PR TITLE
Fixes copying buildings from within the fog of war

### DIFF
--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -510,10 +510,15 @@ public class DesktopInput extends InputHandler{
 
         if( !Core.scene.hasKeyboard() && selectX == -1 && selectY == -1 && schemX != -1 && schemY != -1){
             if(Core.input.keyRelease(Binding.schematic_select)){
-                lastSchematic = schematics.create(schemX, schemY, rawCursorX, rawCursorY);
-                useSchematic(lastSchematic);
-                if(selectPlans.isEmpty()){
-                    lastSchematic = null;
+                if(fogControl.isVisibleTile(player.team(), rawCursorX, rawCursorY) &&
+                    fogControl.isVisibleTile(player.team(), schemX, rawCursorY) &&
+                    fogControl.isVisibleTile(player.team(), rawCursorX, schemY) &&
+                    fogControl.isVisibleTile(player.team(), schemX, schemY)){
+                    lastSchematic = schematics.create(schemX, schemY, rawCursorX, rawCursorY);
+                    useSchematic(lastSchematic);
+                    if(selectPlans.isEmpty()){
+                        lastSchematic = null;
+                    }
                 }
                 schemX = -1;
                 schemY = -1;

--- a/core/src/mindustry/input/MobileInput.java
+++ b/core/src/mindustry/input/MobileInput.java
@@ -527,8 +527,13 @@ public class MobileInput extends InputHandler implements GestureListener{
             lineMode = false;
         }else if(mode == schematicSelect){
             selectPlans.clear();
-            lastSchematic = schematics.create(lineStartX, lineStartY, lastLineX, lastLineY);
-            useSchematic(lastSchematic);
+            if(fogControl.isVisibleTile(player.team(), lineStartX, lineStartY) &&
+                    fogControl.isVisibleTile(player.team(), lastLineX, lineStartY) &&
+                    fogControl.isVisibleTile(player.team(), lineStartX, lastLineY) &&
+                    fogControl.isVisibleTile(player.team(), lastLineX, lastLineY)){
+                lastSchematic = schematics.create(lineStartX, lineStartY, lastLineX, lastLineY);
+                useSchematic(lastSchematic);
+            }
             if(selectPlans.isEmpty()){
                 lastSchematic = null;
             }


### PR DESCRIPTION
This prevents players from copying buildings from within the fog of war but no idea if this is the best way of going about this since I'm new here. The pick building button(middle mouse button by default) doesn't work through fog of war also so its fine.

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
- [ ] Testing this on mobile
