### PR TITLE
Update servers_v7.json

### DIFF
--- a/servers_v7.json
+++ b/servers_v7.json
@@ -146,5 +146,9 @@
   {
     "name": "EasyPlay.su",
     "address": ["easyplay.su"]
+  },
+  {
+    "name": "Sectorized",
+    "address": ["sectorized.freeddns.org"]
   }
 ]


### PR DESCRIPTION
Currently still in v6 but as soon as v7 is the official version on Steam tomorrow i will migrate to v7, please add the address/ddns beforehand so my users dont have to wait for the server to be added tomorrow. Thank you! (Currently Sectorized v7 is reachable under the port 6568, so sectorized.freeddns.org:6568 but i will change to port back to the default mindustry port tomorrow)
