### PR TITLE
StateValues-ammo should not repeatly indent

### DIFF
--- a/core/src/mindustry/world/meta/StatValues.java
+++ b/core/src/mindustry/world/meta/StatValues.java
@@ -413,7 +413,7 @@ public class StatValues{
 
                         ammo(ObjectMap.of(t, type.fragBullet), indent + 1, false).display(bt);
                     }
-                }).padTop(compact ? 0 : -9).padLeft(indent * 8).left().get().background(compact ? null : Tex.underline);
+                }).padTop(compact ? 0 : -9).padLeft(8).left().get().background(compact ? null : Tex.underline);
 
                 table.row();
             }


### PR DESCRIPTION
As each ammo table are inherited from the previous table, there's no need for add indent multipier again.
 With mods that have lots of fragBullet, indent * 8f would cause a awful curve indent (like 0,1,3,6,10,15, 21...)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
