### PR TITLE
Selecting only 1 block as a schematic picks it instead

### DIFF
--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -21,7 +21,6 @@ import mindustry.game.Teams.*;
 import mindustry.gen.*;
 import mindustry.graphics.*;
 import mindustry.input.Placement.*;
-import mindustry.type.Category;
 import mindustry.ui.*;
 import mindustry.world.*;
 
@@ -519,9 +518,8 @@ public class DesktopInput extends InputHandler{
                     if(!build.block.oneBlockSchematic){
                         selectPlans.clear();
                         block = build.block;
-                        block.lastConfig = build.config;
+                        block.lastConfig = !build.block.copyConfig ? null : build.config;
                     }
-                    //currentCategory = input.block.category;
                 }
                 if(selectPlans.isEmpty()){
                     lastSchematic = null;

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -21,6 +21,7 @@ import mindustry.game.Teams.*;
 import mindustry.gen.*;
 import mindustry.graphics.*;
 import mindustry.input.Placement.*;
+import mindustry.type.Category;
 import mindustry.ui.*;
 import mindustry.world.*;
 
@@ -512,6 +513,16 @@ public class DesktopInput extends InputHandler{
             if(Core.input.keyRelease(Binding.schematic_select)){
                 lastSchematic = schematics.create(schemX, schemY, rawCursorX, rawCursorY);
                 useSchematic(lastSchematic);
+                if(selectPlans.size == 1){
+                    BuildPlan build = selectPlans.get(0);
+                    //check if we might want the one block to be a schematic instead
+                    if(!build.block.oneBlockSchematic){
+                        selectPlans.clear();
+                        block = build.block;
+                        block.lastConfig = build.config;
+                    }
+                    //currentCategory = input.block.category;
+                }
                 if(selectPlans.isEmpty()){
                     lastSchematic = null;
                 }

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -82,6 +82,8 @@ public class Block extends UnlockableContent implements Senseable{
     public boolean saveConfig = false;
     /** whether to allow copying the config through middle click */
     public boolean copyConfig = true;
+    /** Used to determine whether copying a selection with only one block should select the block or treat it as a schematic */
+    public boolean oneBlockSchematic = false;
     /** if true, double-tapping this configurable block clears configuration. */
     public boolean clearOnDoubleTap = false;
     /** whether this block has a tile entity that updates */

--- a/core/src/mindustry/world/blocks/logic/CanvasBlock.java
+++ b/core/src/mindustry/world/blocks/logic/CanvasBlock.java
@@ -33,6 +33,7 @@ public class CanvasBlock extends Block{
         destructible = true;
         canOverdrive = false;
         solid = true;
+        oneBlockSchematic = true;
 
         config(byte[].class, (CanvasBuild build, byte[] bytes) -> {
             if(build.data.length == bytes.length){

--- a/core/src/mindustry/world/blocks/logic/LogicBlock.java
+++ b/core/src/mindustry/world/blocks/logic/LogicBlock.java
@@ -45,6 +45,7 @@ public class LogicBlock extends Block{
         configurable = true;
         group = BlockGroup.logic;
         schematicPriority = 5;
+        oneBlockSchematic = true;
 
         //universal, no real requirements
         envEnabled = Env.any;

--- a/core/src/mindustry/world/blocks/logic/MessageBlock.java
+++ b/core/src/mindustry/world/blocks/logic/MessageBlock.java
@@ -34,6 +34,7 @@ public class MessageBlock extends Block{
         group = BlockGroup.logic;
         drawDisabled = false;
         envEnabled = Env.any;
+        oneBlockSchematic = true;
 
         config(String.class, (MessageBuild tile, String text) -> {
             if(text.length() > maxTextLength || !accessible()){


### PR DESCRIPTION
Selects the block so it can be used for dragging a line of the block and for the UI helpers such as the drill range one the Plasma Bores. Doesn't select the block instead if its something that you might want to save as a one block schematic such as a logic block. I coded this for mobile too originally but tbh it just felt easier to select the block the normal way instead of copying it so I didn't add that to the PR.

Note that unlike the Pick block hotkey this does not change the category on the block selector panel since afaik there isn't a nice way to do that without being in the PlacementFragment class, not sure if that's a deal breaker but I didn't notice any bugs as a result of that.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
