### PR TITLE
Added angleOffset to DrawPistons

### DIFF
--- a/core/src/mindustry/world/draw/DrawPistons.java
+++ b/core/src/mindustry/world/draw/DrawPistons.java
@@ -9,7 +9,7 @@ import mindustry.gen.*;
 import mindustry.world.*;
 
 public class DrawPistons extends DrawBlock{
-    public float sinMag = 4f, sinScl = 6f, sinOffset = 50f, sideOffset = 0f, lenOffset = -1f;
+    public float sinMag = 4f, sinScl = 6f, sinOffset = 50f, sideOffset = 0f, lenOffset = -1f, angleOffset = 0f;
     public int sides = 4;
     public TextureRegion region1, region2, regiont;
 
@@ -22,7 +22,7 @@ public class DrawPistons extends DrawBlock{
     public void draw(Building build){
         for(int i = 0; i < sides; i++){
             float len = Mathf.absin(build.totalProgress() + sinOffset + sideOffset * sinScl * i, sinScl, sinMag) + lenOffset;
-            float angle = i * 360f / sides;
+            float angle = angleOffset + i * 360f / sides;
             TextureRegion reg =
                 regiont.found() && (Mathf.equal(angle, 315) || Mathf.equal(angle, 135)) ? regiont :
                 angle >= 135 && angle < 315 ? region2 : region1;


### PR DESCRIPTION
This change makes drawing circles of pistons that don't start aligned with world axes possible, useful for modding.

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
