### PR TITLE
Removal of servers doing ilegal actions + affecting community

### DIFF
--- a/servers_be.json
+++ b/servers_be.json
@@ -22,9 +22,5 @@
   {
     "name": "Phoenix-Network",
     "address": ["be.phoenix-network.dev"]
-  },
-  {
-    "name": "Darkdustry",
-    "address": ["darkdustry.tk"]
   }
 ]

--- a/servers_v6.json
+++ b/servers_v6.json
@@ -8,6 +8,10 @@
     "address": ["recessive.net"]
   },
   {
+    "name": "EasyPlay",
+    "address": ["easyplay.su"]
+  },
+  {
     "name": "Tendhost",
     "address": ["tendhost.ddns.net", "smokeofanarchy.ru:7576"]
   },

--- a/servers_v6.json
+++ b/servers_v6.json
@@ -8,10 +8,6 @@
     "address": ["recessive.net"]
   },
   {
-    "name": "EasyPlay",
-    "address": ["easyplay.su"]
-  },
-    {
     "name": "Tendhost",
     "address": ["tendhost.ddns.net", "smokeofanarchy.ru:7576"]
   },

--- a/servers_v7.json
+++ b/servers_v7.json
@@ -40,10 +40,6 @@
     "address": ["meowland.ru"]
   },
   {
-    "name": "Darkdustry",
-    "address": ["darkdustry.tk", "darkdustry.tk:1500", "darkdustry.tk:2000", "darkdustry.tk:3000", "darkdustry.tk:4000", "darkdustry.tk:5000", "darkdustry.tk:6000", "darkdustry.tk:7000", "darkdustry.tk:8000", "darkdustry.tk:9000"] 
-  },
-  {
     "name": "Chaotic Neutral",
     "address": ["c-n.ddns.net:5555", "c-n.ddns.net:6666", "c-n.ddns.net:7777", "c-n.ddns.net:8888"]
   },
@@ -90,10 +86,6 @@
   {
     "name": "mindustry.ddns.net",
     "address": ["mindustry.ddns.net:1000", "mindustry.ddns.net:2000", "mindustry.ddns.net:3000", "mindustry.ddns.net:4000"]
-  },
-  {
-    "name": "EasyPlay.su",
-    "address": ["easyplay.su"]
   },
   {
     "name": "Sectorized",

--- a/servers_v7.json
+++ b/servers_v7.json
@@ -88,6 +88,10 @@
     "address": ["mindustry.ddns.net:1000", "mindustry.ddns.net:2000", "mindustry.ddns.net:3000", "mindustry.ddns.net:4000"]
   },
   {
+    "name": "EasyPlay.su",
+    "address": ["easyplay.su"]
+  },
+  {
     "name": "Sectorized",
     "address": ["sectorized.freeddns.org"]
   },


### PR DESCRIPTION
And once again, as you may have known, there has been bots on all the servers in serverlist
![image](https://user-images.githubusercontent.com/60143910/203155278-ae8f2890-b1cf-47e4-ad0d-d3ffc07c7e44.png)
(image from TheRadioactiveBanana#0545)
as far as we knew, they were using the following ip's:
20.228.150.178
20.242.52.106
20.237.254.138
prettymuch the entire /8 20.0.0.0 block
and some others like 172.173.xxx

At this point we knew the attackers were using Microsoft Azure, then [a fancy message was sent on the mindustry discord](https://discord.com/channels/391020510269669376/402527137229438996/1043877347608252456)
![image](https://user-images.githubusercontent.com/60143910/203156815-eb25bb47-3318-48a5-ab1f-084bca852f60.png)
![image](https://user-images.githubusercontent.com/60143910/203156866-fa48a594-2d42-409d-95e7-c4a8f97dd0d6.png)
![image](https://user-images.githubusercontent.com/60143910/203157285-276680bc-8b15-4599-b77d-bc8e8e8055a9.png)

One thing we did notice was that easyplay.su nor darkdustry was being attacked, they were the only servers to be empty from bots, this was really suspicious, shortly after that message was sent, the attack stopped and the bots switched to numbers
![image](https://user-images.githubusercontent.com/60143910/203157460-22e76b48-accb-4f2a-a873-e9a4e7bbae74.png)

Then, this happened
![image](https://user-images.githubusercontent.com/60143910/203157533-c2c97b00-7b7d-49f6-99f4-51fae74c8b92.png)
Darkness (darkdustry owner) admitted to trying to ddos the servers and helping with the bots (mentions names).


Now, this is truly not enough proof, but with the help of other servers, I'm sure this is pretty clear.
_Such servers shall be removed from the list due to committing felony acts (like dosing servers) or just making the community have a worse time so they check their servers for their own advantage, but well, it's up to Anuke._
