### PR TITLE
Additional block build over options

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -1180,6 +1180,7 @@ public class Blocks{
             craftTime = 10f;
             rotate = true;
             invertFlip = true;
+            group = BlockGroup.liquids;
 
             liquidCapacity = 50f;
 

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -2470,6 +2470,7 @@ public class Blocks{
         turbineCondenser = new ThermalGenerator("turbine-condenser"){{
             requirements(Category.power, with(Items.beryllium, 60));
             attribute = Attribute.steam;
+            group = BlockGroup.liquids;
             displayEfficiencyScale = 1f / 9f;
             minEfficiency = 9f - 0.0001f;
             powerProduction = 3f / 9f;
@@ -2764,6 +2765,7 @@ public class Blocks{
         ventCondenser = new AttributeCrafter("vent-condenser"){{
             requirements(Category.production, with(Items.graphite, 20, Items.beryllium, 60));
             attribute = Attribute.steam;
+            group = BlockGroup.liquids;
             minEfficiency = 9f - 0.0001f;
             baseEfficiency = 0f;
             displayEfficiency = false;

--- a/core/src/mindustry/world/blocks/distribution/DirectionalUnloader.java
+++ b/core/src/mindustry/world/blocks/distribution/DirectionalUnloader.java
@@ -28,6 +28,7 @@ public class DirectionalUnloader extends Block{
     public DirectionalUnloader(String name){
         super(name);
 
+        group = BlockGroup.transportation;
         update = true;
         solid = true;
         hasItems = true;

--- a/core/src/mindustry/world/blocks/payloads/PayloadConveyor.java
+++ b/core/src/mindustry/world/blocks/payloads/PayloadConveyor.java
@@ -24,7 +24,7 @@ public class PayloadConveyor extends Block{
 
     public PayloadConveyor(String name){
         super(name);
-        group = BlockGroup.transportation;
+        group = BlockGroup.payloads;
         size = 3;
         rotate = true;
         update = true;


### PR DESCRIPTION
This PR just assigns some blocks that didn't have a group to some existing block groups so that you can build them over their similar counterparts, except for payload conveyors/routers which was reassigned to the payload group instead of the transportation group. The use cases are below:

-Vent condensers can be built over turbine condensers and vice versa
-Duct unloaders and electrolyzers can be built over themselves for easier rotating
-Payload conveyors no longer assume you want to erase normal conveyors you're building over
-Payload blocks like loaders and unloaders can be built over Payload conveyors

From what I can tell the only other place block groups are used besides building over blocks is for the SuicideAI that crawlers have, however that doesn't matter for vent/turbine condensers and duct unloaders since they're on Erekir. Though payload conveyors can now be targeted but afaik that shouldn't be an issue.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
