### PR TITLE
Delist omega for spoofing player count

### DIFF
--- a/servers_v7.json
+++ b/servers_v7.json
@@ -32,10 +32,6 @@
     "address": ["hexpvp.ml", "kycb42148.ddns.net:6614"]
   },
   {
-    "name": "Omega Hub",
-    "address": ["n7.mindustry.me", "n7.mindustry.me:6570", "n1.mindustry.me:6568", "n1.mindustry.me:6570", "n1.mindustry.me:6571", "n1.mindustry.me:6573", "n1.mindustry.me", "n1.mindustry.me:6599", "n1.mindustry.me:6774", "n1.mindustry.me:6608", "n1.mindustry.me:6572"]
-  },
-  {
     "name": "KMWStudios",
     "address": ["meowland.ru"]
   },


### PR DESCRIPTION
The hub's player count is spoofed. It shows over double the number of players that are actually connected to any of their servers. They also count the players twice by counting them in both the hub and the other servers in the server list.