### PR TITLE
CRASH FIX: logic + payload router

### DIFF
--- a/core/src/mindustry/world/blocks/payloads/PayloadConveyor.java
+++ b/core/src/mindustry/world/blocks/payloads/PayloadConveyor.java
@@ -150,10 +150,11 @@ public class PayloadConveyor extends Block{
                 boolean had = item != null;
 
                 if(valid && stepAccepted != curStep && item != null){
-                    if(next != null){
-                        //trigger update forward
-                        next.updateTile();
+                    //trigger update forward
+                    if(next != null) next.updateTile();
 
+                    // next could be a LogicBlock and can config this building, potentially causing `next` to be null.
+                    if(next != null){
                         //TODO add self to queue of next conveyor, then check if this conveyor was selected next frame - selection happens deterministically
                         if(next.acceptPayload(this, item)){
                             //move forward.


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.

This is a bug fixed.
This affects multiplayer and singleplayer.
I first encountered it on 2r2t.
This is caused by a `NullPointerException`.
Explanation is in comments just in case someone else ever encounters it and gets confused.

Replicating this bug is easy:
1. Have this configuration. Note that the hyperproc is binded to the router.
    ![Screenshot_2022-12-26-22-46-27-23_13f989b68d7412e5a177fb13b36ac66f](https://user-images.githubusercontent.com/68312688/209565127-d158ea16-e319-44c7-8380-99d0969f7133.jpg)
2. Copy this code to the logic processor:
    ```
    control config router1 0 0 0 0
    control config router1 1 0 0 0
    ```
3. Wait for some time.