### PR TITLE
Fixes Tanks rotating needlessly after attack commands

### DIFF
--- a/core/src/mindustry/entities/units/AIController.java
+++ b/core/src/mindustry/entities/units/AIController.java
@@ -315,8 +315,8 @@ public class AIController implements UnitController{
             vec.setLength(unit.speed() * length);
         }
 
-        //do not move when infinite vectors are used.
-        if(vec.isNaN() || vec.isInfinite()) return;
+        //do not move when infinite vectors are used or if its zero.
+        if(vec.isNaN() || vec.isInfinite() || vec.isZero()) return;
 
         if(!unit.type.omniMovement && unit.type.rotateMoveFirst){
             float angle = vec.angle();


### PR DESCRIPTION
Fixes tanks rotating to face the right if you ever do an attack command

In the video below the behavior the before is on the right and the after is on the left

https://user-images.githubusercontent.com/22408776/210198538-ea6b7b5e-fa70-4b0c-a327-efe753ac4b77.mp4

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.