### PR TITLE
Add hiddenMods in ConnectPacket event

### DIFF
--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -91,6 +91,7 @@ public class NetClient implements ApplicationListener{
             c.name = player.name;
             c.locale = locale;
             c.mods = mods.getModStrings();
+            c.allMods = mods.getAllModStrings();
             c.mobile = mobile;
             c.versionType = Version.type;
             c.color = player.color.rgba();

--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -91,7 +91,7 @@ public class NetClient implements ApplicationListener{
             c.name = player.name;
             c.locale = locale;
             c.mods = mods.getModStrings();
-            c.allMods = mods.getAllModStrings();
+            c.hiddenMods = mods.getHiddenModStrings();
             c.mobile = mobile;
             c.versionType = Version.type;
             c.color = player.color.rgba();

--- a/core/src/mindustry/core/NetServer.java
+++ b/core/src/mindustry/core/NetServer.java
@@ -197,6 +197,8 @@ public class NetServer implements ApplicationListener{
                 con.kick(result.toString(), 0);
             }
 
+            Events.fire(new PlayerMods(player, packet.allMods.copy()));
+
             if(!admins.isWhitelisted(packet.uuid, packet.usid)){
                 info.adminUsid = packet.usid;
                 info.lastName = packet.name;

--- a/core/src/mindustry/core/NetServer.java
+++ b/core/src/mindustry/core/NetServer.java
@@ -197,8 +197,6 @@ public class NetServer implements ApplicationListener{
                 con.kick(result.toString(), 0);
             }
 
-            Events.fire(new PlayerMods(player, packet.allMods.copy()));
-
             if(!admins.isWhitelisted(packet.uuid, packet.usid)){
                 info.adminUsid = packet.usid;
                 info.lastName = packet.name;

--- a/core/src/mindustry/game/EventType.java
+++ b/core/src/mindustry/game/EventType.java
@@ -1,7 +1,6 @@
 package mindustry.game;
 
 import arc.math.geom.*;
-import arc.struct.Seq;
 import arc.util.*;
 import mindustry.core.GameState.*;
 import mindustry.ctype.*;
@@ -686,16 +685,6 @@ public class EventType{
 
         public PlayerIpUnbanEvent(String ip){
             this.ip = ip;
-        }
-    }
-
-    public static class PlayerMods{
-        public final Player player;
-        public final Seq<String> mods;
-
-        public PlayerMods(Player player, Seq<String> mods){
-            this.player = player;
-            this.mods = mods;
         }
     }
 

--- a/core/src/mindustry/game/EventType.java
+++ b/core/src/mindustry/game/EventType.java
@@ -1,6 +1,7 @@
 package mindustry.game;
 
 import arc.math.geom.*;
+import arc.struct.Seq;
 import arc.util.*;
 import mindustry.core.GameState.*;
 import mindustry.ctype.*;
@@ -685,6 +686,16 @@ public class EventType{
 
         public PlayerIpUnbanEvent(String ip){
             this.ip = ip;
+        }
+    }
+
+    public static class PlayerMods{
+        public final Player player;
+        public final Seq<String> mods;
+
+        public PlayerMods(Player player, Seq<String> mods){
+            this.player = player;
+            this.mods = mods;
         }
     }
 

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -728,7 +728,7 @@ public class Mods implements Loadable{
         return mods.select(l -> !l.meta.hidden && l.enabled()).map(l -> l.name + ":" + l.meta.version);
     }
 
-    /** @return a list of mods and versions, in the format name:version. */
+    /** @return a list of all mods (include hidden mods) and versions, in the format name:version. */
     public Seq<String> getHiddenModStrings(){
         return mods.select(l -> l.meta.hidden && l.enabled()).map(l -> l.name + ":" + l.meta.version);
     }

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -728,6 +728,11 @@ public class Mods implements Loadable{
         return mods.select(l -> !l.meta.hidden && l.enabled()).map(l -> l.name + ":" + l.meta.version);
     }
 
+    /** @return a list of all mods (include hidden mods) and versions, in the format name:version. */
+    public Seq<String> getAllModStrings(){
+        return mods.select(LoadedMod::enabled).map(l -> l.name + ":" + l.meta.version);
+    }
+
     /** Makes a mod enabled or disabled. shifts it.*/
     public void setEnabled(LoadedMod mod, boolean enabled){
         if(mod.enabled() != enabled){

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -728,9 +728,9 @@ public class Mods implements Loadable{
         return mods.select(l -> !l.meta.hidden && l.enabled()).map(l -> l.name + ":" + l.meta.version);
     }
 
-    /** @return a list of all mods (include hidden mods) and versions, in the format name:version. */
-    public Seq<String> getAllModStrings(){
-        return mods.select(LoadedMod::enabled).map(l -> l.name + ":" + l.meta.version);
+    /** @return a list of mods and versions, in the format name:version. */
+    public Seq<String> getHiddenModStrings(){
+        return mods.select(l -> l.meta.hidden && l.enabled()).map(l -> l.name + ":" + l.meta.version);
     }
 
     /** Makes a mod enabled or disabled. shifts it.*/

--- a/core/src/mindustry/net/Packets.java
+++ b/core/src/mindustry/net/Packets.java
@@ -109,8 +109,7 @@ public class Packets{
     public static class ConnectPacket extends Packet{
         public int version;
         public String versionType;
-        public Seq<String> mods;
-        public Seq<String> allMods;
+        public Seq<String> mods, hiddenMods;
         public String name, locale, uuid, usid;
         public boolean mobile;
         public int color;

--- a/core/src/mindustry/net/Packets.java
+++ b/core/src/mindustry/net/Packets.java
@@ -110,6 +110,7 @@ public class Packets{
         public int version;
         public String versionType;
         public Seq<String> mods;
+        public Seq<String> allMods;
         public String name, locale, uuid, usid;
         public boolean mobile;
         public int color;


### PR DESCRIPTION
This event sends all mods (including hidden mods) to the server.

At the extreme, even if a modified client shows up and hides the list of mods being sent to the server, it's better than a server that has no idea what hidden mods the client is installing and making the game unfair.
It's common to use hidden mods to unlock blueprint bans and server rate limiters. (rip arc packet spam detector)

=============================================================
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
