### PR TITLE
Fix server auto pause when gameover

### DIFF
--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -191,7 +191,12 @@ public class ServerControl implements ApplicationListener{
 
                 info("Selected next map to be @.", Strings.stripColors(map.name()));
 
-                play(true, () -> world.loadMap(map, map.applyRules(lastMode)));
+                play(true, () -> {
+                    world.loadMap(map, map.applyRules(lastMode));
+                    if(Config.autoPause.bool() && Groups.player.isEmpty()){
+                        Core.app.post(() -> state.set(State.paused));
+                    }
+                });
             }else{
                 netServer.kickAll(KickReason.gameover);
                 state.set(State.menu);
@@ -202,12 +207,6 @@ public class ServerControl implements ApplicationListener{
         //reset autosave on world load
         Events.on(WorldLoadEvent.class, e -> {
             autosaveCount.reset(0, Config.autosaveSpacing.num() * 60);
-            
-            //auto server pause when no players online
-            if(!state.isPaused() && Config.autoPause.bool() && Groups.player.size() == 1){
-                state.set(State.paused);
-                autoPaused = true;
-            }
         });
 
         //autosave periodically

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -202,6 +202,11 @@ public class ServerControl implements ApplicationListener{
         //reset autosave on world load
         Events.on(WorldLoadEvent.class, e -> {
             autosaveCount.reset(0, Config.autosaveSpacing.num() * 60);
+            
+            //auto server pause when no players online
+            if(!state.isPaused() && Config.autoPause.bool() && Groups.player.size() == 1){
+                state.set(State.paused);
+            }
         });
 
         //autosave periodically

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -206,6 +206,7 @@ public class ServerControl implements ApplicationListener{
             //auto server pause when no players online
             if(!state.isPaused() && Config.autoPause.bool() && Groups.player.size() == 1){
                 state.set(State.paused);
+                autoPaused = true;
             }
         });
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/44261958/214690366-556772ab-81ca-499a-85f9-0ac04b7330eb.png)

I found a problem where the server doesn't auto pause when the gameover even if no players when the server is an attack map with units.

==================================================================

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
