### PR TITLE
Added gameData folder detection.

### DIFF
--- a/core/src/mindustry/ClientLauncher.java
+++ b/core/src/mindustry/ClientLauncher.java
@@ -21,6 +21,8 @@ import mindustry.mod.*;
 import mindustry.net.*;
 import mindustry.ui.*;
 
+import java.io.File;
+
 import static arc.Core.*;
 import static mindustry.Vars.*;
 
@@ -35,6 +37,15 @@ public abstract class ClientLauncher extends ApplicationCore implements Platform
     @Override
     public void setup(){
         String dataDir = OS.env("MINDUSTRY_DATA_DIR");
+
+        //if gameData directory exists, save game data to that folder.
+        String stringCustomDataDir = "gameData";
+        File fileCustomDataDir = new File(stringCustomDataDir);
+        boolean customDataDirExists = fileCustomDataDir.exists();
+        if(customDataDirExists){
+            dataDir = stringCustomDataDir ;
+        }
+
         if(dataDir != null){
             Core.settings.setDataDirectory(files.absolute(dataDir));
         }


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable (Windows 10/Ubuntu Desktop20.04).

## Scenario 

I just started playing this game, I absolutely love it. However, I am a very busy college student who goes from computer to computer. I wanted to save my game data without exporting and importing it. I carry the game around on a USB. in my Pull request I added the ability for the game to scan for a folder called `gameData` and use that instead of the default %appdata% in windows. I also did not want to keep settings the env variable. I have only been coding in java off and on as the semesters have required me, so my code may be a bit noobish. I hope this is a useful addition or at least the gateway to future development on this functionality. 