### PR TITLE
Make payload blocks run `onDestroyed()` of the block payload it carries when destroyed.

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -1224,6 +1224,7 @@ rules.unitdamagemultiplier = Unit Damage Multiplier
 rules.unitcrashdamagemultiplier = Unit Crash Damage Multiplier
 rules.solarmultiplier = Solar Power Multiplier
 rules.unitcapvariable = Cores Contribute To Unit Cap
+rules.unitpayloadsexplode = Carried Payloads Explode With The Unit
 rules.unitcap = Base Unit Cap
 rules.limitarea = Limit Map Area
 rules.enemycorebuildradius = Enemy Core No-Build Radius:[lightgray] (tiles)

--- a/core/src/mindustry/entities/comp/PayloadComp.java
+++ b/core/src/mindustry/entities/comp/PayloadComp.java
@@ -62,7 +62,7 @@ abstract class PayloadComp implements Posc, Rotc, Hitboxc, Unitc{
 
     @Override
     public void destroy(){
-        payloads.each(Payload::destroyed);
+        if(Vars.state.rules.unitPayloadsExplode) payloads.each(Payload::destroyed);
     }
 
     float payloadUsed(){

--- a/core/src/mindustry/entities/comp/PayloadComp.java
+++ b/core/src/mindustry/entities/comp/PayloadComp.java
@@ -60,6 +60,11 @@ abstract class PayloadComp implements Posc, Rotc, Hitboxc, Unitc{
         }
     }
 
+    @Override
+    public void destroy(){
+        payloads.each(Payload::destroyed);
+    }
+
     float payloadUsed(){
         return payloads.sumf(p -> p.size() * p.size());
     }

--- a/core/src/mindustry/game/Rules.java
+++ b/core/src/mindustry/game/Rules.java
@@ -55,6 +55,8 @@ public class Rules{
     public boolean unitAmmo = false;
     /** EXPERIMENTAL! If true, blocks will update in units and share power. */
     public boolean unitPayloadUpdate = false;
+    /** If true, units' payloads are destroy()ed when the unit is destroyed. */
+    public boolean unitPayloadsExplode = false;
     /** Whether cores add to unit limit */
     public boolean unitCapVariable = true;
     /** If true, unit spawn points are shown. */

--- a/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
+++ b/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
@@ -194,6 +194,7 @@ public class CustomRulesDialog extends BaseDialog{
         title("@rules.title.unit");
         //check("@rules.unitammo", b -> rules.unitAmmo = b, () -> rules.unitAmmo);
         check("@rules.unitcapvariable", b -> rules.unitCapVariable = b, () -> rules.unitCapVariable);
+        check("@rules.unitpayloadsexplode", b -> rules.unitPayloadsExplode = b, () -> rules.unitPayloadsExplode);
         numberi("@rules.unitcap", f -> rules.unitCap = f, () -> rules.unitCap, -999, 999);
         number("@rules.unitdamagemultiplier", f -> rules.unitDamageMultiplier = f, () -> rules.unitDamageMultiplier);
         number("@rules.unitcrashdamagemultiplier", f -> rules.unitCrashDamageMultiplier = f, () -> rules.unitCrashDamageMultiplier);

--- a/core/src/mindustry/world/blocks/payloads/BuildPayload.java
+++ b/core/src/mindustry/world/blocks/payloads/BuildPayload.java
@@ -52,6 +52,11 @@ public class BuildPayload implements Payload{
     }
 
     @Override
+    public void destroyed(){
+        build.onDestroyed();
+    }
+
+    @Override
     public ItemStack[] requirements(){
         return build.block.requirements;
     }

--- a/core/src/mindustry/world/blocks/payloads/Payload.java
+++ b/core/src/mindustry/world/blocks/payloads/Payload.java
@@ -54,6 +54,8 @@ public interface Payload extends Position{
         return 0f;
     }
 
+    default void destroyed(){};
+
     /** writes the payload for saving. */
     void write(Writes write);
 

--- a/core/src/mindustry/world/blocks/payloads/PayloadBlock.java
+++ b/core/src/mindustry/world/blocks/payloads/PayloadBlock.java
@@ -150,6 +150,12 @@ public class PayloadBlock extends Block{
             }
         }
 
+        @Override
+        public void onDestroyed(){
+            if(payload != null) payload.destroyed();
+            super.onDestroyed();
+        }
+
         public boolean blends(int direction){
             return PayloadBlock.blends(this, direction);
         }

--- a/core/src/mindustry/world/blocks/payloads/PayloadConveyor.java
+++ b/core/src/mindustry/world/blocks/payloads/PayloadConveyor.java
@@ -189,6 +189,12 @@ public class PayloadConveyor extends Block{
         }
 
         @Override
+        public void onDestroyed(){
+            if(item != null) item.destroyed();
+            super.onDestroyed();
+        }
+
+        @Override
         public void draw(){
             super.draw();
 


### PR DESCRIPTION
Before: 

https://user-images.githubusercontent.com/54301439/216706630-0b8fe7e3-137a-45b9-b006-535831b291fc.mp4

After:

https://user-images.githubusercontent.com/54301439/216706638-da9354fd-36bd-4349-9657-792634ec89b8.mp4

---

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
