### PR TITLE
Make `type` optional for units if the `template` already provides a type.

### DIFF
--- a/core/src/mindustry/mod/ContentParser.java
+++ b/core/src/mindustry/mod/ContentParser.java
@@ -461,12 +461,13 @@ public class ContentParser{
                 }
 
                 var typeVal = value.get("type");
+                if(unit.constructor == null || typeVal != null){
+                    if(typeVal != null && !typeVal.isString()){
+                        throw new RuntimeException("Unit '" + name + "' has an incorrect type. Types must be strings.");
+                    }
 
-                if(typeVal != null && !typeVal.isString()){
-                    throw new RuntimeException("Unit '" + name + "' has an incorrect type. Types must be strings.");
+                    unit.constructor = unitType(typeVal);
                 }
-
-                unit.constructor = unitType(typeVal);
             }else{
                 unit = locate(ContentType.unit, name);
             }


### PR DESCRIPTION
Makes it so that if the template already defines a constructor (Such as `MissileUnitType` setting the constructor to `TimedKillUnit`), then a `type: missile` afterwards wouldn't be necessary.

Test mod: [unittest.zip](https://github.com/Anuken/Mindustry/files/10609611/unittest.zip) (The turret is in the transportation tab and I'm too lazy to fix that.)

https://user-images.githubusercontent.com/54301439/216788556-9d8dfb83-c608-4cde-84c6-0269f605a5c3.mp4

---

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
