### PR TITLE
Return salvo and swarmer to how they were before shoot changes

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -3404,6 +3404,7 @@ public class Blocks{
             reload = 30f;
             inaccuracy = 10f;
             range = 240f;
+            consumeAmmoOnce = false;
             size = 2;
             scaledHealth = 300;
             shootSound = Sounds.missile;
@@ -3466,6 +3467,7 @@ public class Blocks{
             size = 2;
             range = 190f;
             reload = 31f;
+            consumeAmmoOnce = false;
             ammoEjectBack = 3f;
             recoil = 3f;
             shake = 1f;


### PR DESCRIPTION
Since I've seen people talking about it in #balancing, here's a pr.
Sets `consumeAmmoOnce` to false on both salvo and swarmer so that they're back to 1 ammo per shot instead of 1 ammo per burst.
I assume this was an unintentional side effect with changing how shooting worked.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
