### PR TITLE
Cleaner ItemTurret ammo bar

### DIFF
--- a/core/src/mindustry/world/blocks/defense/turrets/ItemTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/ItemTurret.java
@@ -52,6 +52,19 @@ public class ItemTurret extends Turret{
     }
 
     @Override
+    public void setBars(){
+        super.setBars();
+
+        addBar("ammo", (ItemTurretBuild entity) ->
+            new Bar(
+                "stat.ammo",
+                Pal.ammo,
+                () -> (float)entity.totalAmmo / maxAmmo
+            )
+        );
+    }
+
+    @Override
     public void init(){
         consume(new ConsumeItemFilter(i -> ammoTypes.containsKey(i)){
             @Override
@@ -98,14 +111,6 @@ public class ItemTurret extends Turret{
             unit.ammo((float)unit.type().ammoCapacity * totalAmmo / maxAmmo);
 
             super.updateTile();
-        }
-
-        @Override
-        public void displayBars(Table bars){
-            super.displayBars(bars);
-
-            bars.add(new Bar("stat.ammo", Pal.ammo, () -> (float)totalAmmo / maxAmmo)).growX();
-            bars.row();
         }
 
         @Override


### PR DESCRIPTION
Switched it to use `setBars` instead of overriding `displayBars`.
Why did it even do that in the first place anyways?

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
