### PR TITLE
Fixed issue with Blocks scaledHealth

### DIFF
--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -1125,15 +1125,15 @@ public class Block extends UnlockableContent implements Senseable{
             boolean round = false;
             if(scaledHealth < 0){
                 scaledHealth = 40;
-
-                float scaling = 1f;
-                for(var stack : requirements){
-                    scaling += stack.item.healthScaling;
-                }
-
-                scaledHealth *= scaling;
-                round = true;
             }
+            
+            float scaling = 1f;
+            for(var stack : requirements){
+                scaling += stack.item.healthScaling;
+            }
+
+            scaledHealth *= scaling;
+            round = true;
 
             health = round ?
                 Mathf.round(size * size * scaledHealth, 5) :


### PR DESCRIPTION
The way it was, it would only use item healthScaling value if the Block had no scaledHealth value, but from what I understand, we want to scale scaledHealth WITH requirements' healthScaling.

Simply moved a brace to make sure the calculations we're made even if a scaledHealth value is given.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
