### PR TITLE
ClientServerConnectEvent

### DIFF
--- a/core/src/mindustry/game/EventType.java
+++ b/core/src/mindustry/game/EventType.java
@@ -162,6 +162,16 @@ public class EventType{
         }
     }
 
+    public static class ClientServerConnectEvent{
+        public final String ip;
+        public final int port;
+
+        public ClientServerConnectEvent(String ip, int port){
+            this.ip = ip;
+            this.port = port;
+        }
+    }
+
     /** Consider using Menus.registerMenu instead. */
     public static class MenuOptionChooseEvent{
         public final Player player;

--- a/core/src/mindustry/net/Net.java
+++ b/core/src/mindustry/net/Net.java
@@ -5,6 +5,7 @@ import arc.func.*;
 import arc.net.*;
 import arc.struct.*;
 import arc.util.*;
+import mindustry.game.EventType.*;
 import mindustry.gen.*;
 import mindustry.net.Packets.*;
 import mindustry.net.Streamable.*;
@@ -154,6 +155,7 @@ public class Net{
     public void connect(String ip, int port, Runnable success){
         try{
             if(!active){
+                Events.fire(new ClientServerConnectEvent(ip, port));
                 provider.connectClient(ip, port, success);
                 active = true;
                 server = false;


### PR DESCRIPTION
Since `ClientPreConnectEvent` exists, which is fired when you click on a server in the server list, how about `ClientServerConnectEvent`, which is fired when you connect to the server.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable. (Not sure how I would test this.)
