### PR TITLE
Smoother Screenshake Reduction

### DIFF
--- a/core/src/mindustry/core/Renderer.java
+++ b/core/src/mindustry/core/Renderer.java
@@ -72,6 +72,8 @@ public class Renderer implements ApplicationListener{
     landPTimer,
     //intensity for screen shake
     shakeIntensity,
+    //reduction rate of screen shake
+    shakeReduction,
     //current duration of screen shake
     shakeTime;
     //for landTime > 0: if true, core is currently *launching*, otherwise landing.
@@ -83,14 +85,15 @@ public class Renderer implements ApplicationListener{
         Shaders.init();
 
         Events.on(ResetEvent.class, e -> {
-            shakeTime = shakeIntensity = 0f;
+            shakeTime = shakeIntensity = shakeReduction = 0f;
             camShakeOffset.setZero();
         });
     }
 
     public void shake(float intensity, float duration){
-        shakeIntensity = Math.max(shakeIntensity, intensity);
+        shakeIntensity = Math.max(shakeIntensity, Mathf.clamp(intensity, 0, 100));
         shakeTime = Math.max(shakeTime, duration);
+        shakeReduction = shakeIntensity / shakeTime;
     }
 
     public void addEnvRenderer(int mask, Runnable render){
@@ -210,7 +213,7 @@ public class Renderer implements ApplicationListener{
                 float intensity = shakeIntensity * (settings.getInt("screenshake", 4) / 4f) * 0.75f;
                 camShakeOffset.setToRandomDirection().scl(Mathf.random(intensity));
                 camera.position.add(camShakeOffset);
-                shakeIntensity -= 0.25f * Time.delta;
+                shakeIntensity -= shakeReduction * Time.delta;
                 shakeTime -= Time.delta;
                 shakeIntensity = Mathf.clamp(shakeIntensity, 0f, 100f);
             }else{

--- a/core/src/mindustry/core/Renderer.java
+++ b/core/src/mindustry/core/Renderer.java
@@ -93,7 +93,7 @@ public class Renderer implements ApplicationListener{
     public void shake(float intensity, float duration){
         shakeIntensity = Math.max(shakeIntensity, Mathf.clamp(intensity, 0, 100));
         shakeTime = Math.max(shakeTime, duration);
-        shakeReduction = shakeIntensity / shakeTime;
+        shakeReduction = Math.max(shakeReduction, shakeIntensity / shakeTime);
     }
 
     public void addEnvRenderer(int mask, Runnable render){


### PR DESCRIPTION
Screen shake will now properly respect the input duration. No longer will it awkwardly cut off the shake or fade away before the set duration ends.

Before:

https://user-images.githubusercontent.com/54301439/219851805-b3bc9158-8b52-4d45-9447-d5355acada42.mp4

After:

https://user-images.githubusercontent.com/54301439/219851841-2ad84fad-2b4e-48ee-b50c-7818a46bb2db.mp4

---

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
