### PR TITLE
Battery Graphical Updates

### DIFF
--- a/core/src/mindustry/mod/ClassMap.java
+++ b/core/src/mindustry/mod/ClassMap.java
@@ -448,6 +448,7 @@ public class ClassMap{
         classes.put("DrawParticles", mindustry.world.draw.DrawParticles.class);
         classes.put("DrawPistons", mindustry.world.draw.DrawPistons.class);
         classes.put("DrawPlasma", mindustry.world.draw.DrawPlasma.class);
+        classes.put("DrawPower", mindustry.world.draw.DrawPower.class);
         classes.put("DrawPulseShape", mindustry.world.draw.DrawPulseShape.class);
         classes.put("DrawPumpLiquid", mindustry.world.draw.DrawPumpLiquid.class);
         classes.put("DrawRegion", mindustry.world.draw.DrawRegion.class);

--- a/core/src/mindustry/world/blocks/power/Battery.java
+++ b/core/src/mindustry/world/blocks/power/Battery.java
@@ -4,17 +4,17 @@ import arc.graphics.*;
 import arc.graphics.g2d.*;
 import arc.math.*;
 import arc.struct.*;
+import arc.util.*;
 import mindustry.annotations.Annotations.*;
+import mindustry.entities.units.*;
 import mindustry.gen.*;
+import mindustry.world.draw.*;
 import mindustry.world.meta.*;
 
 import static mindustry.Vars.*;
 
 public class Battery extends PowerDistributor{
-    public @Load("@-top") TextureRegion topRegion;
-
-    public Color emptyLightColor = Color.valueOf("f8c266");
-    public Color fullLightColor = Color.valueOf("fb9567");
+    public DrawBlock drawer = new DrawMulti(new DrawDefault(), new DrawPower(), new DrawRegion("-top"));
 
     public Battery(String name){
         super(name);
@@ -29,14 +29,42 @@ public class Battery extends PowerDistributor{
         update = false;
     }
 
+    @Override
+    public void load(){
+        super.load();
+        drawer.load(this);
+    }
+
+    @Override
+    public void drawPlanRegion(BuildPlan plan, Eachable<BuildPlan> list){
+        drawer.drawPlan(this, plan, list);
+    }
+
+    @Override
+    public TextureRegion[] icons(){
+        return drawer.finalIcons(this);
+    }
+
+    @Override
+    public void getRegionsToOutline(Seq<TextureRegion> out){
+        drawer.getRegionsToOutline(this, out);
+    }
+
     public class BatteryBuild extends Building{
         @Override
         public void draw(){
-            Draw.color(emptyLightColor, fullLightColor, power.status);
-            Fill.square(x, y, (tilesize * size / 2f - 1) * Draw.xscl);
-            Draw.color();
+            drawer.draw(this);
+        }
 
-            Draw.rect(topRegion, x, y);
+        @Override
+        public void drawLight(){
+            super.drawLight();
+            drawer.drawLight(this);
+        }
+
+        @Override
+        public float warmup(){
+            return power.status;
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/power/Battery.java
+++ b/core/src/mindustry/world/blocks/power/Battery.java
@@ -14,7 +14,10 @@ import mindustry.world.meta.*;
 import static mindustry.Vars.*;
 
 public class Battery extends PowerDistributor{
-    public DrawBlock drawer = new DrawMulti(new DrawDefault(), new DrawPower(), new DrawRegion("-top"));
+    public DrawBlock drawer;
+
+    public Color emptyLightColor = Color.valueOf("f8c266");
+    public Color fullLightColor = Color.valueOf("fb9567");
 
     public Battery(String name){
         super(name);
@@ -27,6 +30,18 @@ public class Battery extends PowerDistributor{
         destructible = true;
         //batteries don't need to update
         update = false;
+    }
+
+    @Override
+    public void init(){
+        super.init();
+
+        if(drawer == null){
+            drawer = new DrawMulti(new DrawDefault(), new DrawPower(){{
+                emptyLightColor = Battery.this.emptyLightColor;
+                fullLightColor = Battery.this.fullLightColor;
+            }}, new DrawRegion("-top"));
+        }
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/power/Battery.java
+++ b/core/src/mindustry/world/blocks/power/Battery.java
@@ -19,6 +19,9 @@ public class Battery extends PowerDistributor{
     public Color emptyLightColor = Color.valueOf("f8c266");
     public Color fullLightColor = Color.valueOf("fb9567");
 
+    @Deprecated
+    public @Load("@-top") TextureRegion topRegion;
+
     public Battery(String name){
         super(name);
         outputsPower = true;

--- a/core/src/mindustry/world/draw/DrawPower.java
+++ b/core/src/mindustry/world/draw/DrawPower.java
@@ -1,0 +1,73 @@
+package mindustry.world.draw;
+
+import arc.*;
+import arc.graphics.*;
+import arc.graphics.g2d.*;
+import arc.util.*;
+import mindustry.entities.units.*;
+import mindustry.gen.*;
+import mindustry.world.*;
+
+import static mindustry.Vars.*;
+
+public class DrawPower extends DrawBlock{
+    public TextureRegion emptyRegion, fullRegion;
+    public String suffix = "-power";
+
+    public boolean drawPlan = true;
+    /** If false, fades between emptyRegion and fullRegion instead of mixcol between empty and full colors. */
+    public boolean mixcol = true;
+    public Color emptyLightColor = Color.valueOf("f8c266");
+    public Color fullLightColor = Color.valueOf("fb9567");
+
+    /** Any number <=0 disables layer changes. */
+    public float layer = -1;
+
+    public DrawPower(){
+    }
+
+    public DrawPower(String suffix){
+        this.suffix = suffix;
+    }
+
+    @Override
+    public void draw(Building build){
+        float z = Draw.z();
+        if(layer > 0) Draw.z(layer);
+        if(mixcol){
+            Draw.color(emptyLightColor, fullLightColor, build.power.status);
+            if(emptyRegion.found()){
+                Draw.rect(emptyRegion, build.x, build.y);
+            }else{
+                Fill.square(build.x, build.y, (tilesize * build.block.size / 2f - 1) * Draw.xscl);
+            }
+        }else{
+            Draw.rect(emptyRegion, build.x, build.y);
+            Draw.alpha(build.power.status);
+            Draw.rect(fullRegion, build.x, build.y);
+        }
+        Draw.color();
+        Draw.z(z);
+    }
+
+    @Override
+    public void drawPlan(Block block, BuildPlan plan, Eachable<BuildPlan> list){
+        if(!drawPlan || mixcol || !emptyRegion.found()) return;
+        Draw.rect(emptyRegion, plan.drawx(), plan.drawy());
+    }
+
+    @Override
+    public TextureRegion[] icons(Block block){
+        return !mixcol && emptyRegion.found() ? new TextureRegion[]{emptyRegion} : new TextureRegion[]{};
+    }
+
+    @Override
+    public void load(Block block){
+        if(mixcol){
+            emptyRegion = Core.atlas.find(block.name + suffix);
+        }else{
+            emptyRegion = Core.atlas.find(block.name + suffix + "-empty");
+            fullRegion = Core.atlas.find(block.name + suffix + "-full");
+        }
+    }
+}


### PR DESCRIPTION
![2023_02_20_12_02_34_DiscordCanary](https://user-images.githubusercontent.com/54301439/220202028-164893b8-37d0-4942-b6ee-3e3805fc4293.png)

https://user-images.githubusercontent.com/54301439/220202054-0e8736f6-14eb-41ec-8ed1-b4143a695495.mp4

---

- Batteries now use a drawer
- `warmup()` on batteries is now the power status
- Added `DrawPower`
  - 3 ways to draw power
    - If no sprite is given, it draws a full square like how batteries did.
    - If a sprite is given, it draws that sprite with the proper color.
    - If `mixcol` is false,  then it lerps between an `-empty` and `-full` sprite instead of coloring.

---

Test Mod: [batterytest.zip](https://github.com/Anuken/Mindustry/files/10787950/batterytest.zip)

---

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
