### PR TITLE
Fix server always paused

### DIFF
--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -193,7 +193,7 @@ public class ServerControl implements ApplicationListener{
 
                 play(true, () -> {
                     world.loadMap(map, map.applyRules(lastMode));
-                    if(Config.autoPause.bool() && Groups.player.isEmpty()){
+                    if(Config.autoPause.bool() && autoPaused){
                         Core.app.post(() -> state.set(State.paused));
                     }
                 });


### PR DESCRIPTION
My mistake.
``Groups.player.isEmpty()`` is always ``true`` when map changed 😟 

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
