### PR TITLE
Player unit spawns before core animation finishes

### DIFF
--- a/core/src/mindustry/core/Control.java
+++ b/core/src/mindustry/core/Control.java
@@ -193,7 +193,7 @@ public class Control implements ApplicationListener, Loadable{
             if(!settings.getBool("skipcoreanimation") && !state.rules.pvp){
                 coreDelay = coreLandDuration;
                 //delay player respawn so animation can play.
-                player.deathTimer = -80f;
+                player.deathTimer = Player.deathDelay - coredelay;
                 //TODO this sounds pretty bad due to conflict
                 if(settings.getInt("musicvol") > 0){
                     Musics.land.stop();


### PR DESCRIPTION
The time when the player unit spawns should now properly be in sync with when the core land animation finishes.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
