### PR TITLE
Scale planet grid to planet radius

### DIFF
--- a/core/src/mindustry/graphics/g3d/PlanetRenderer.java
+++ b/core/src/mindustry/graphics/g3d/PlanetRenderer.java
@@ -188,9 +188,10 @@ public class PlanetRenderer implements Disposable{
         }
 
         //render sector grid
-        Mesh mesh = outline(planet.grid.size);
+        float scaledOutlineRad = outlineRad * planet.radius;
+        Mesh mesh = outline(planet.grid.size, planet.radius);
         Shader shader = Shaders.planetGrid;
-        Vec3 tile = planet.intersect(cam.getMouseRay(), outlineRad);
+        Vec3 tile = planet.intersect(cam.getMouseRay(), scaledOutlineRad);
         Shaders.planetGrid.mouse.lerp(tile == null ? Vec3.Zero : tile.sub(planet.position).rotate(Vec3.Y, planet.getRotation()), 0.2f);
 
         shader.bind();
@@ -210,13 +211,14 @@ public class PlanetRenderer implements Disposable{
 
     public void drawArc(Planet planet, Vec3 a, Vec3 b, Color from, Color to, float length, float timeScale, int pointCount){
         //increase curve height when on opposite side of planet, so it doesn't tunnel through
+        float scaledOutlineRad = outlineRad * planet.radius;
         float dot = 1f - (Tmp.v32.set(a).nor().dot(Tmp.v33.set(b).nor()) + 1f)/2f;
 
         Vec3 avg = Tmp.v31.set(b).add(a).scl(0.5f);
         avg.setLength(planet.radius*(1f+length) + dot * 1.35f);
 
         points.clear();
-        points.addAll(Tmp.v33.set(b).setLength(outlineRad), Tmp.v31, Tmp.v34.set(a).setLength(outlineRad));
+        points.addAll(Tmp.v33.set(b).setLength(scaledOutlineRad), Tmp.v31, Tmp.v34.set(a).setLength(scaledOutlineRad));
         Tmp.bz3.set(points);
 
         for(int i = 0; i < pointCount + 1; i++){
@@ -231,8 +233,8 @@ public class PlanetRenderer implements Disposable{
     public void drawBorders(Sector sector, Color base, float alpha){
         Color color = Tmp.c1.set(base).a((base.a + 0.3f + Mathf.absin(Time.globalTime, 5f, 0.3f)) * alpha);
 
-        float r1 = 1f;
-        float r2 = outlineRad + 0.001f;
+        float r1 = 1f * sector.planet.radius;
+        float r2 = outlineRad * sector.planet.radius + 0.001f;
 
         for(int i = 0; i < sector.tile.corners.length; i++){
             Corner c = sector.tile.corners[i], next = sector.tile.corners[(i+1) % sector.tile.corners.length];
@@ -268,7 +270,7 @@ public class PlanetRenderer implements Disposable{
 
         projector.setPlane(
         //origin on sector position
-        Tmp.v33.set(sector.tile.v).setLength(outlineRad + length).rotate(Vec3.Y, rotation).add(sector.planet.position),
+        Tmp.v33.set(sector.tile.v).setLength((outlineRad + length) * sector.planet.radius).rotate(Vec3.Y, rotation).add(sector.planet.position),
         //face up
         sector.plane.project(Tmp.v32.set(sector.tile.v).add(Vec3.Y)).sub(sector.tile.v).rotate(Vec3.Y, rotation).nor(),
         //right vector
@@ -277,7 +279,7 @@ public class PlanetRenderer implements Disposable{
     }
 
     public void fill(Sector sector, Color color, float offset){
-        float rr = outlineRad + offset;
+        float rr = outlineRad * sector.planet.radius + offset;
         for(int i = 0; i < sector.tile.corners.length; i++){
             Corner c = sector.tile.corners[i], next = sector.tile.corners[(i+1) % sector.tile.corners.length];
             batch.tri(Tmp.v31.set(c.v).setLength(rr), Tmp.v32.set(next.v).setLength(rr), Tmp.v33.set(sector.tile.v).setLength(rr), color);
@@ -289,7 +291,7 @@ public class PlanetRenderer implements Disposable{
     }
 
     public void drawSelection(Sector sector, Color color, float stroke, float length){
-        float arad = outlineRad + length;
+        float arad = (outlineRad + length) * sector.planet.radius;
 
         for(int i = 0; i < sector.tile.corners.length; i++){
             Corner next = sector.tile.corners[(i + 1) % sector.tile.corners.length];
@@ -311,7 +313,7 @@ public class PlanetRenderer implements Disposable{
         }
     }
 
-    public Mesh outline(int size){
+    public Mesh outline(int size, float radiusScale){
         if(outlines[size] == null){
             outlines[size] = MeshBuilder.buildHex(new HexMesher(){
                 @Override
@@ -323,7 +325,7 @@ public class PlanetRenderer implements Disposable{
                 public Color getColor(Vec3 position){
                     return outlineColor;
                 }
-            }, size, true, outlineRad, 0.2f);
+            }, size, true, outlineRad * radiusScale, 0.2f);
         }
         return outlines[size];
     }

--- a/core/src/mindustry/graphics/g3d/PlanetRenderer.java
+++ b/core/src/mindustry/graphics/g3d/PlanetRenderer.java
@@ -272,7 +272,7 @@ public class PlanetRenderer implements Disposable{
         //origin on sector position
         Tmp.v33.set(sector.tile.v).setLength((outlineRad + length) * sector.planet.radius).rotate(Vec3.Y, rotation).add(sector.planet.position),
         //face up
-        sector.plane.project(Tmp.v32.set(sector.tile.v).add(Vec3.Y)).sub(sector.tile.v).rotate(Vec3.Y, rotation).nor(),
+        sector.plane.project(Tmp.v32.set(sector.tile.v).add(Vec3.Y)).sub(sector.tile.v, sector.planet.radius).rotate(Vec3.Y, rotation).nor(),
         //right vector
         Tmp.v31.set(Tmp.v32).rotate(Vec3.Y, -rotation).add(sector.tile.v).rotate(sector.tile.v, 90).sub(sector.tile.v).rotate(Vec3.Y, rotation).nor()
         );

--- a/core/src/mindustry/ui/dialogs/PlanetDialog.java
+++ b/core/src/mindustry/ui/dialogs/PlanetDialog.java
@@ -785,7 +785,7 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
             hoverLabel.touchable = Touchable.disabled;
             hoverLabel.color.a = state.uiAlpha;
 
-            Vec3 pos = planets.cam.project(Tmp.v31.set(hovered.tile.v).setLength(PlanetRenderer.outlineRad).rotate(Vec3.Y, -state.planet.getRotation()).add(state.planet.position));
+            Vec3 pos = planets.cam.project(Tmp.v31.set(hovered.tile.v).setLength(PlanetRenderer.outlineRad * state.planet.radius).rotate(Vec3.Y, -state.planet.getRotation()).add(state.planet.position));
             hoverLabel.setPosition(pos.x - Core.scene.marginLeft, pos.y - Core.scene.marginBottom, Align.center);
 
             hoverLabel.getText().setLength(0);
@@ -831,7 +831,7 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
         }
 
         if(state.planet.hasGrid()){
-            hovered = Core.scene.getDialog() == this ? state.planet.getSector(planets.cam.getMouseRay(), PlanetRenderer.outlineRad) : null;
+            hovered = Core.scene.getDialog() == this ? state.planet.getSector(planets.cam.getMouseRay(), PlanetRenderer.outlineRad * state.planet.radius) : null;
         }else if(state.planet.isLandable()){
             boolean wasNull = selected == null;
             //always have the first sector selected.


### PR DESCRIPTION
Scales planet grid to planet radius to support modded planets of different sizes. Also scales launch arc height to fit planet size.

The changes have no effect on serpulo or erekir, they only affect planets with a radius other than 1. Does not affect the number of sectors on planets.

Result for a small planet:
![Screenshot 2023-03-09 154013](https://user-images.githubusercontent.com/117922538/224065843-7a629c14-5a47-40b3-83d4-f326a2e4412d.png)

The same planet with Serpulo for scale:
![Screenshot 2023-03-09 154154](https://user-images.githubusercontent.com/117922538/224066037-c49b078c-ba59-420a-8128-629730c30413.png)
(PlanetDialog.debugSelect was turned on via console and is not part of the PR)

Large planet with sun for scale:
![Screenshot 2023-03-09 161858](https://user-images.githubusercontent.com/117922538/224069560-b41a9ad2-7d27-4c63-be9e-100226b23e63.png)


Mod used for testing:
https://github.com/Pasu4/the-moon

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
