### PR TITLE
Scale efficiency of attribute crafters

### DIFF
--- a/core/src/mindustry/world/blocks/production/AttributeCrafter.java
+++ b/core/src/mindustry/world/blocks/production/AttributeCrafter.java
@@ -39,9 +39,9 @@ public class AttributeCrafter extends GenericCrafter{
 
         addBar("efficiency", (AttributeCrafterBuild entity) ->
             new Bar(
-            () -> Core.bundle.format("bar.efficiency", (int)(entity.efficiencyMultiplier() * 100 * displayEfficiencyScale)),
+            () -> Core.bundle.format("bar.efficiency", (int)(entity.efficiencyScale() * 100 * displayEfficiencyScale)),
             () -> Pal.lightOrange,
-            entity::efficiencyMultiplier));
+            entity::efficiencyScale));
     }
 
     @Override
@@ -62,10 +62,11 @@ public class AttributeCrafter extends GenericCrafter{
 
         @Override
         public float getProgressIncrease(float base){
-            return super.getProgressIncrease(base) * efficiencyMultiplier();
+            return super.getProgressIncrease(base) * efficiencyScale();
         }
 
-        public float efficiencyMultiplier(){
+        @Override
+        public float efficiencyScale(){
             return baseEfficiency + Math.min(maxBoost, boostScale * attrsum) + attribute.env();
         }
 


### PR DESCRIPTION
Attribute crafters do not consume more liquid when boosted.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
