### PR TITLE
Index wall ores

### DIFF
--- a/core/src/mindustry/ai/BlockIndexer.java
+++ b/core/src/mindustry/ai/BlockIndexer.java
@@ -414,7 +414,7 @@ public class BlockIndexer{
                     var arr = ores[item.id][qx][qy];
                     if(arr != null && arr.size > 0){
                         Tile tile = world.tile(arr.first());
-                        if((floor && tile.block() == Blocks.air) || (wall && tile.block() != Blocks.air)){
+                        if((floor && tile.block() == Blocks.air) || (wall && tile.wallDrop() != null)){
                             float dst = Mathf.dst2(xp, yp, tile.worldx(), tile.worldy());
                             if(closest == null || dst < minDst){
                                 closest = tile;

--- a/core/src/mindustry/world/Tile.java
+++ b/core/src/mindustry/world/Tile.java
@@ -530,6 +530,10 @@ public class Tile implements Position, QuadTreeObject, Displayable{
         return state.teams.canInteract(team, team());
     }
 
+    public @Nullable Item itemDrop(){
+        return block != Blocks.air ? wallDrop() : drop();
+    }
+
     public @Nullable Item drop(){
         return overlay == Blocks.air || overlay.itemDrop == null ? floor.itemDrop : overlay.itemDrop;
     }


### PR DESCRIPTION
Include wall ores in ore indexing and be able to find them using `findClosestOre`–mining ai currently does not detect wall ores.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
