### PR TITLE
Fix armor piercing ignoring status effect health multiplier

### DIFF
--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -143,7 +143,7 @@ public class BulletType extends Content implements Cloneable{
     public boolean fragOnHit = true;
     /** If false, this bullet will not create fraags when absorbed by a shield. */
     public boolean fragOnAbsorb = true;
-    /** If true, unit armor is ignored in damage calculations. Ignored for building armor. */
+    /** If true, unit armor is ignored in damage calculations. */
     public boolean pierceArmor = false;
     /** Whether status and despawnHit should automatically be set. */
     public boolean setDefaults = true;

--- a/core/src/mindustry/entities/comp/ShieldComp.java
+++ b/core/src/mindustry/entities/comp/ShieldComp.java
@@ -41,7 +41,7 @@ abstract class ShieldComp implements Healthc, Posc{
         }
     }
 
-    private void rawDamage(float amount){
+    protected void rawDamage(float amount){
         boolean hadShields = shield > 0.0001f;
 
         if(hadShields){

--- a/core/src/mindustry/entities/comp/ShieldComp.java
+++ b/core/src/mindustry/entities/comp/ShieldComp.java
@@ -34,7 +34,7 @@ abstract class ShieldComp implements Healthc, Posc{
     public void damagePierce(float amount, boolean withEffect){
         float pre = hitTime;
 
-        rawDamage(amount);
+        rawDamage(amount / healthMultiplier);
 
         if(!withEffect){
             hitTime = pre;


### PR DESCRIPTION
Was originally just a pr to make `rawDamage` protected so for overriding reasons, but then I noticed the problem and fixed it in the meantime.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
