### PR TITLE
Make an interface for blocks that spawn tethered units

### DIFF
--- a/core/src/mindustry/world/blocks/UnitTetherBlock.java
+++ b/core/src/mindustry/world/blocks/UnitTetherBlock.java
@@ -1,0 +1,5 @@
+package mindustry.world.blocks;
+
+public interface UnitTetherBlock{
+    void spawned(int id);
+}

--- a/core/src/mindustry/world/blocks/units/UnitCargoLoader.java
+++ b/core/src/mindustry/world/blocks/units/UnitCargoLoader.java
@@ -16,6 +16,7 @@ import mindustry.graphics.*;
 import mindustry.type.*;
 import mindustry.ui.*;
 import mindustry.world.*;
+import mindustry.world.blocks.*;
 
 import static mindustry.Vars.*;
 
@@ -75,12 +76,12 @@ public class UnitCargoLoader extends Block{
     }
 
     @Remote(called = Loc.server)
-    public static void cargoLoaderDroneSpawned(Tile tile, int id){
-        if(tile == null || !(tile.build instanceof UnitTransportSourceBuild build)) return;
+    public static void unitTetherBlockSpawned(Tile tile, int id){
+        if(tile == null || !(tile.build instanceof UnitTetherBlock build)) return;
         build.spawned(id);
     }
 
-    public class UnitTransportSourceBuild extends Building{
+    public class UnitTransportSourceBuild extends Building implements UnitTetherBlock{
         //needs to be "unboxed" after reading, since units are read after buildings.
         public int readUnitId = -1;
         public float buildProgress, totalProgress;
@@ -117,7 +118,7 @@ public class UnitCargoLoader extends Block{
                         unit.set(x, y);
                         unit.rotation = 90f;
                         unit.add();
-                        Call.cargoLoaderDroneSpawned(tile, unit.id);
+                        Call.unitTetherBlockSpawned(tile, unit.id);
                     }
                 }
             }


### PR DESCRIPTION
I've made my own blocks in my mod which has units tethered to buildings. Problem is, to run the `spawned` on them, a custom packet/call needs to be made for every single one of them. (I don't even know how to do that.)
With this interface, a single call can be used for all cases.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
