### PR TITLE
Include int[] in readObject/writeObject

### DIFF
--- a/core/src/mindustry/io/TypeIO.java
+++ b/core/src/mindustry/io/TypeIO.java
@@ -93,9 +93,6 @@ public class TypeIO{
             write.b((byte)14);
             write.i(b.length);
             write.b(b);
-        }else if(object instanceof int[] i){
-            write.b((byte)21);
-            writeInts(write, i);
         }else if(object instanceof boolean[] b){
             write.b(16);
             write.i(b.length);
@@ -122,6 +119,9 @@ public class TypeIO{
         }else if(object instanceof Team t){
             write.b((byte)20);
             write.b(t.id);
+        }else if(object instanceof int[] i){
+            write.b((byte)21);
+            writeInts(write, i);
         }else if(object instanceof Object[] objs){
             write.b((byte)22);
             write.i(objs.length);

--- a/core/src/mindustry/io/TypeIO.java
+++ b/core/src/mindustry/io/TypeIO.java
@@ -93,6 +93,9 @@ public class TypeIO{
             write.b((byte)14);
             write.i(b.length);
             write.b(b);
+        }else if(object instanceof int[] i){
+            write.b((byte)21);
+            writeInts(write, i);
         }else if(object instanceof boolean[] b){
             write.b(16);
             write.i(b.length);
@@ -184,6 +187,7 @@ public class TypeIO{
             }
             case 19 -> new Vec2(read.f(), read.f());
             case 20 -> Team.all[read.ub()];
+            case 21 -> readInts(read);
             default -> throw new IllegalArgumentException("Unknown object type: " + type);
         };
     }

--- a/core/src/mindustry/io/TypeIO.java
+++ b/core/src/mindustry/io/TypeIO.java
@@ -122,6 +122,12 @@ public class TypeIO{
         }else if(object instanceof Team t){
             write.b((byte)20);
             write.b(t.id);
+        }else if(object instanceof Object[] objs){
+            write.b((byte)22);
+            write.i(objs.length);
+            for(Object obj : objs){
+                writeObject(write, obj);
+            }
         }else{
             throw new IllegalArgumentException("Unknown object type: " + object.getClass());
         }
@@ -188,6 +194,12 @@ public class TypeIO{
             case 19 -> new Vec2(read.f(), read.f());
             case 20 -> Team.all[read.ub()];
             case 21 -> readInts(read);
+            case 22 -> {
+                int objlen = read.i();
+                Object[] objs = new Object[objlen];
+                for(int i = 0; i < objlen; i++) objs[i] = readObjectBoxed(read, box);
+                yield objs;
+            }
             default -> throw new IllegalArgumentException("Unknown object type: " + type);
         };
     }


### PR DESCRIPTION
I use int[] for storing multiple different data types, but they can't be properly saved in a schem.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
(Tested by saving a schem with my test dummies and sandbox walls, closing the game, reopening, and placing that schem.)
