### PR TITLE
Add `Events.fire(Trigger.unitCommandChange)` in select/remove unit by type

### DIFF
--- a/core/src/mindustry/ui/fragments/PlacementFragment.java
+++ b/core/src/mindustry/ui/fragments/PlacementFragment.java
@@ -49,7 +49,7 @@ public class PlacementFragment{
     Stack mainStack;
     ScrollPane blockPane;
     Runnable rebuildCommand;
-    boolean blockSelectEnd, wasCommandMode, fireInRebuildCommand;
+    boolean blockSelectEnd, wasCommandMode;
     int blockSelectSeq;
     long blockSelectSeqMillis;
     Binding[] blockSelect = {
@@ -79,10 +79,9 @@ public class PlacementFragment{
         });
 
         Events.run(Trigger.unitCommandChange, () -> {
-            if(rebuildCommand != null && !fireInRebuildCommand){
+            if(rebuildCommand != null){
                 rebuildCommand.run();
             }
-            fireInRebuildCommand = false;
         });
 
         Events.on(UnlockEvent.class, event -> {
@@ -465,13 +464,11 @@ public class PlacementFragment{
                                             //left click -> select
                                             b.clicked(KeyCode.mouseLeft, () -> {
                                                 control.input.selectedUnits.removeAll(unit -> unit.type != type);
-                                                fireInRebuildCommand = true;
                                                 Events.fire(Trigger.unitCommandChange);
                                             });
                                             //right click -> remove
                                             b.clicked(KeyCode.mouseRight, () -> {
                                                 control.input.selectedUnits.removeAll(unit -> unit.type == type);
-                                                fireInRebuildCommand = true;
                                                 Events.fire(Trigger.unitCommandChange);
                                             });
 

--- a/core/src/mindustry/ui/fragments/PlacementFragment.java
+++ b/core/src/mindustry/ui/fragments/PlacementFragment.java
@@ -49,7 +49,7 @@ public class PlacementFragment{
     Stack mainStack;
     ScrollPane blockPane;
     Runnable rebuildCommand;
-    boolean blockSelectEnd, wasCommandMode;
+    boolean blockSelectEnd, wasCommandMode, fireInRebuildCommand;
     int blockSelectSeq;
     long blockSelectSeqMillis;
     Binding[] blockSelect = {
@@ -79,9 +79,10 @@ public class PlacementFragment{
         });
 
         Events.run(Trigger.unitCommandChange, () -> {
-            if(rebuildCommand != null){
+            if(rebuildCommand != null && !fireInRebuildCommand){
                 rebuildCommand.run();
             }
+            fireInRebuildCommand = false;
         });
 
         Events.on(UnlockEvent.class, event -> {
@@ -462,9 +463,17 @@ public class PlacementFragment{
                                             var listener = new ClickListener();
 
                                             //left click -> select
-                                            b.clicked(KeyCode.mouseLeft, () -> control.input.selectedUnits.removeAll(unit -> unit.type != type));
+                                            b.clicked(KeyCode.mouseLeft, () -> {
+                                                control.input.selectedUnits.removeAll(unit -> unit.type != type);
+                                                fireInRebuildCommand = true;
+                                                Events.fire(Trigger.unitCommandChange);
+                                            });
                                             //right click -> remove
-                                            b.clicked(KeyCode.mouseRight, () -> control.input.selectedUnits.removeAll(unit -> unit.type == type));
+                                            b.clicked(KeyCode.mouseRight, () -> {
+                                                control.input.selectedUnits.removeAll(unit -> unit.type == type);
+                                                fireInRebuildCommand = true;
+                                                Events.fire(Trigger.unitCommandChange);
+                                            });
 
                                             b.addListener(listener);
                                             b.addListener(new HandCursorListener());


### PR DESCRIPTION
- Added `Events.fire(Trigger.unitCommandChange)` to **left click - select** and **right click - remove**.
- ~~Added `boolean fireInRebuildCommand` to prevent infinite event loop with `rebuildCommand`.~~

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
