### PR TITLE
Set controller after setting spawnedByCore (fix UnitChangeEvent)

### DIFF
--- a/core/src/mindustry/world/blocks/storage/CoreBlock.java
+++ b/core/src/mindustry/world/blocks/storage/CoreBlock.java
@@ -66,18 +66,18 @@ public class CoreBlock extends StorageBlock{
 
     @Remote(called = Loc.server)
     public static void playerSpawn(Tile tile, Player player){
-        if(player == null || tile == null || !(tile.build instanceof CoreBuild entity)) return;
+        if(player == null || tile == null || !(tile.build instanceof CoreBuild core)) return;
 
-        CoreBlock block = (CoreBlock)tile.block();
-        if(entity.wasVisible){
-            Fx.spawn.at(entity);
+        UnitType spawnType = ((CoreBlock)core.block).unitType;
+        if(core.wasVisible){
+            Fx.spawn.at(core);
         }
 
-        player.set(entity);
+        player.set(core);
 
         if(!net.client()){
-            Unit unit = block.unitType.create(tile.team());
-            unit.set(entity);
+            Unit unit = spawnType.create(tile.team());
+            unit.set(core);
             unit.rotation(90f);
             unit.impulse(0f, 3f);
             unit.spawnedByCore(true);
@@ -86,7 +86,7 @@ public class CoreBlock extends StorageBlock{
         }
 
         if(state.isCampaign() && player == Vars.player){
-            block.unitType.unlock();
+            spawnType.unlock();
         }
     }
 

--- a/core/src/mindustry/world/blocks/storage/CoreBlock.java
+++ b/core/src/mindustry/world/blocks/storage/CoreBlock.java
@@ -80,8 +80,8 @@ public class CoreBlock extends StorageBlock{
             unit.set(entity);
             unit.rotation(90f);
             unit.impulse(0f, 3f);
-            unit.controller(player);
             unit.spawnedByCore(true);
+            unit.controller(player);
             unit.add();
         }
 


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

Currently, unit.spawnedByCore is not set correctly in UnitChangeEvent.
This is because the function that fires it (`unit.controller(player)`) does not seem to run any important code, but it actually runs player.unit(unit) which fires the event.
This was easily fixed by setting spawnedByCore first.

(Really weird edge case but it does matter, see [this plugin](https://github.com/BalaM314/fish-commands/blob/e8dc73303feed633ead3bd190f60fea924aa8bc1/scripts/players.ts#L123))

Before: (when respawning)
![image](https://user-images.githubusercontent.com/71201189/227706372-88c4ce6c-c6cb-4a62-bf25-c2e813586b10.png)
After: (when respawning)
![image](https://user-images.githubusercontent.com/71201189/227706377-9862a6a6-ec16-40d1-a10e-5f6a380a3ec5.png)


- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
