### PR TITLE
Better Ammo Stats Display

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -952,7 +952,7 @@ ability.unitspawn = {0} Factory
 ability.shieldregenfield = Shield Regen Field
 ability.movelightning = Movement Lightning
 ability.shieldarc = Shield Arc
-ability.suppressionfield = Regen Suppression Field
+ability.suppressionfield = Repair Suppression Field
 ability.energyfield = Energy Field: [accent]{0}[] damage ~ [accent]{1}[] blocks / [accent]{2}[] targets
 
 bar.onlycoredeposit = Only Core Depositing Allowed
@@ -989,10 +989,11 @@ bar.strength = [stat]{0}[lightgray]x strength
 units.processorcontrol = [lightgray]Processor Controlled
 
 bullet.damage = [stat]{0}[lightgray] damage
-bullet.splashdamage = [stat]{0}[lightgray] area dmg ~[stat] {1}[lightgray] tiles
+bullet.splashdamage = [stat]{0}[lightgray] area dmg ~ [stat]{1}[lightgray] tiles
 bullet.incendiary = [stat]incendiary
 bullet.homing = [stat]homing
 bullet.armorpierce = [stat]armor piercing
+bullet.suppression = [stat]{0} sec[lightgray] repair suppression ~ [stat]{1}[lightgray] tiles
 bullet.interval = [stat]{0}/sec[lightgray] interval bullets:
 bullet.frags = [stat]{0}[lightgray]x frag bullets:
 bullet.lightning = [stat]{0}[lightgray]x lightning ~ [stat]{1}[lightgray] damage

--- a/core/src/mindustry/entities/bullet/PointLaserBulletType.java
+++ b/core/src/mindustry/entities/bullet/PointLaserBulletType.java
@@ -46,6 +46,11 @@ public class PointLaserBulletType extends BulletType{
     }
 
     @Override
+    public float continuousDamage(){
+        return damage / damageInterval * 60f;
+    }
+
+    @Override
     public float estimateDPS(){
         return damage * 100f / damageInterval * 3f;
     }

--- a/core/src/mindustry/world/meta/StatValues.java
+++ b/core/src/mindustry/world/meta/StatValues.java
@@ -292,9 +292,11 @@ public class StatValues{
                     continue;
                 }
 
+                TextureRegion region = !weapon.name.isEmpty() ? Core.atlas.find(weapon.name + "-preview", weapon.region) : null;
+
                 table.table(Styles.grayPanel, w -> {
                     w.left().top().defaults().padRight(3).left();
-                    if(!weapon.name.equals("") && weapon.region.found()) w.image(weapon.region).size(60).scaling(Scaling.bounded).left().top();
+                    if(region != null && region.found()) w.image(region).size(60).scaling(Scaling.bounded).left().top();
                     w.row();
 
                     weapon.addStats(unit, w);

--- a/core/src/mindustry/world/meta/StatValues.java
+++ b/core/src/mindustry/world/meta/StatValues.java
@@ -403,6 +403,10 @@ public class StatValues{
                         sep(bt, "@bullet.armorpierce");
                     }
 
+                    if(type.suppressionRange > 0){
+                        sep(bt, Core.bundle.format("bullet.suppression", Strings.fixed(type.suppressionDuration / 60f, 2), Strings.fixed(type.suppressionRange / tilesize, 1)));
+                    }
+
                     if(type.status != StatusEffects.none){
                         sep(bt, (type.status.minfo.mod == null ? type.status.emoji() : "") + "[stat]" + type.status.localizedName + (type.status.reactive ? "" : "[lightgray] ~ [stat]" + ((int)(type.statusDuration / 60f)) + "[lightgray] " + Core.bundle.get("unit.seconds")));
                     }

--- a/core/src/mindustry/world/meta/StatValues.java
+++ b/core/src/mindustry/world/meta/StatValues.java
@@ -292,15 +292,13 @@ public class StatValues{
                     continue;
                 }
 
-                TextureRegion region = !weapon.name.equals("") && weapon.region.found() ? weapon.region : Core.atlas.find("clear");
-
-                table.image(region).size(60).scaling(Scaling.bounded).right().top();
-
-                table.table(Tex.underline, w -> {
-                    w.left().defaults().padRight(3).left();
+                table.table(Styles.grayPanel, w -> {
+                    w.left().top().defaults().padRight(3).left();
+                    if(!weapon.name.equals("") && weapon.region.found()) w.image(weapon.region).size(60).scaling(Scaling.bounded).left().top();
+                    w.row();
 
                     weapon.addStats(unit, w);
-                }).padTop(-9).left();
+                }).growX().pad(5).margin(10);
                 table.row();
             }
         };
@@ -332,14 +330,16 @@ public class StatValues{
                     continue;
                 }
 
-                //no point in displaying unit icon twice
-                if(!compact && !(t instanceof Turret)){
-                    table.image(icon(t)).size(3 * 8).padRight(4).right().scaling(Scaling.fit).top();
-                    table.add(t.localizedName).padRight(10).left().top();
-                }
-
-                table.table(bt -> {
+                table.table(Styles.grayPanel, bt -> {
                     bt.left().top().defaults().padRight(3).left();
+                    //no point in displaying unit icon twice
+                    if(!compact && !(t instanceof Turret)){
+                        bt.table(title -> {
+                            title.image(icon(t)).size(3 * 8).padRight(4).right().scaling(Scaling.fit).top();
+                            title.add(t.localizedName).padRight(10).left().top();
+                        });
+                        bt.row();
+                    }
 
                     if(type.damage > 0 && (type.collides || type.splashDamage <= 0)){
                         if(type.continuousDamage() > 0){
@@ -442,8 +442,7 @@ public class StatValues{
                         bt.row();
                         bt.add(coll);
                     }
-                }).padTop(compact ? 0 : -9).padLeft(indent * 8).left().get().background(compact ? null : Tex.underline);
-
+                }).padLeft(indent * 8).growX().pad(5).margin(compact ? 0 : 10);
                 table.row();
             }
         };

--- a/core/src/mindustry/world/meta/StatValues.java
+++ b/core/src/mindustry/world/meta/StatValues.java
@@ -406,7 +406,7 @@ public class StatValues{
                     }
 
                     if(type.suppressionRange > 0){
-                        sep(bt, Core.bundle.format("bullet.suppression", Strings.fixed(type.suppressionDuration / 60f, 2), Strings.fixed(type.suppressionRange / tilesize, 1)));
+                        sep(bt, Core.bundle.format("bullet.suppression", Strings.autoFixed(type.suppressionDuration / 60f, 2), Strings.fixed(type.suppressionRange / tilesize, 1)));
                     }
 
                     if(type.status != StatusEffects.none){


### PR DESCRIPTION
Made ammo stats display in boxes similar to unit factory recipes.
![2023_03_25_15_55_45_javaw](https://user-images.githubusercontent.com/54301439/227747681-005c384c-35f2-454e-9e00-e22d6d240d3c.png)
![2023_03_25_16_07_57_javaw](https://user-images.githubusercontent.com/54301439/227747683-8ad1b759-36fe-473b-93d2-1d53003dacf3.png)

---
Added suppression to bullet stats
![2023_03_25_19_13_36_javaw](https://user-images.githubusercontent.com/54301439/227751541-a2fea153-d454-48c2-b380-6c0094fe4f67.png)
(Also reworded it from "regen" to "repair" to more accurately convey that build towers are also affected)

---
`PointBulletType`s now properly display damage
![2023_03_25_16_48_57_javaw](https://user-images.githubusercontent.com/54301439/227747743-aec63f78-47fd-4f24-9695-4a1c656a421b.png)

---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
