### PR TITLE
Adding a new menu type.

### DIFF
--- a/core/src/mindustry/core/UI.java
+++ b/core/src/mindustry/core/UI.java
@@ -75,7 +75,7 @@ public class UI implements ApplicationListener, Loadable{
     public FullTextDialog fullText;
     public CampaignCompleteDialog campaignComplete;
 
-    public IntMap<Dialog> followedMenus;
+    public IntMap<Dialog> followUpMenus;
 
     public Cursor drillCursor, unloadCursor, targetCursor;
 
@@ -204,7 +204,7 @@ public class UI implements ApplicationListener, Loadable{
         logic = new LogicDialog();
         fullText = new FullTextDialog();
         campaignComplete = new CampaignCompleteDialog();
-        followedMenus = new IntMap<>();
+        followUpMenus = new IntMap<>();
 
         Group group = Core.scene.root;
 
@@ -632,9 +632,9 @@ public class UI implements ApplicationListener, Loadable{
         }}.show();
     }
 
-    /** Shows a menu that hides when another followed-menu is shown or when nothing is selected.
+    /** Shows a menu that hides when another followUp-menu is shown or when nothing is selected.
      * @see UI#showMenu(String, String, String[][], Intc) */
-    public void showFollowedMenu(int menuId, String title, String message, String[][] options, Intc callback) {
+    public void showFollowUpMenu(int menuId, String title, String message, String[][] options, Intc callback) {
         Dialog dialog = new Dialog("[accent]" + title){{
             setFillParent(true);
             removeChild(titleTable);
@@ -663,31 +663,29 @@ public class UI implements ApplicationListener, Loadable{
 
                         String optionName = optionsRow[i];
                         int finalOption = option;
-                        buttonRow.button(optionName, () -> {
-                            if(followedMenus.containsKey(menuId)) return; // avoids a button getting clicked twice
-                            callback.get(finalOption);
-                        }).size(i == optionsRow.length - 1 ? lastWidth : width, 50).pad(4);
+                        buttonRow.button(optionName, () -> callback.get(finalOption))
+                            .size(i == optionsRow.length - 1 ? lastWidth : width, 50).pad(4);
                         option++;
                     }
                 }
             }).growX();
             closeOnBack(() -> {
-                followedMenus.remove(menuId);
+                followUpMenus.remove(menuId);
                 callback.get(-1);
             });
         }};
 
-        Dialog oldDialog = followedMenus.remove(menuId);
+        Dialog oldDialog = followUpMenus.remove(menuId);
         if(oldDialog != null){
             dialog.show(Core.scene, null);
             oldDialog.hide(null);
         }else dialog.show();
-        followedMenus.put(menuId, dialog);
+        followUpMenus.put(menuId, dialog);
     }
 
-    public void hideFollowedMenu(int menuId) {
-        if(!followedMenus.containsKey(menuId)) return;
-        followedMenus.remove(menuId).hide();
+    public void hideFollowUpMenu(int menuId) {
+        if(!followUpMenus.containsKey(menuId)) return;
+        followUpMenus.remove(menuId).hide();
     }
 
     /** Formats time with hours:minutes:seconds. */

--- a/core/src/mindustry/core/UI.java
+++ b/core/src/mindustry/core/UI.java
@@ -635,14 +635,10 @@ public class UI implements ApplicationListener, Loadable{
     /** Shows a menu that hides when another followUp-menu is shown or when nothing is selected.
      * @see UI#showMenu(String, String, String[][], Intc) */
     public void showFollowUpMenu(int menuId, String title, String message, String[][] options, Intc callback) {
-        Dialog dialog = new Dialog("[accent]" + title){{
+        Dialog dialog = new Dialog(title){{
             setFillParent(true);
             removeChild(titleTable);
             cont.add(titleTable).width(400f);
-
-            getStyle().titleFontColor = Color.white;
-            title.getStyle().fontColor = Color.white;
-            title.setStyle(title.getStyle());
 
             cont.row();
             cont.image().width(400f).pad(2).colspan(2).height(4f).color(Pal.accent).bottom();

--- a/core/src/mindustry/core/UI.java
+++ b/core/src/mindustry/core/UI.java
@@ -594,9 +594,8 @@ public class UI implements ApplicationListener, Loadable{
         dialog.show();
     }
 
-    /** Shows a menu that fires a callback when an option is selected. If nothing is selected, -1 is returned. */
-    public void showMenu(String title, String message, String[][] options, Intc callback){
-        new Dialog(title){{
+    public Dialog newMenuDialog(String title, String message, String[][] options, Intc buttonListener, Runnable closeOnBack){
+        return new Dialog(title){{
             setFillParent(true);
             removeChild(titleTable);
             cont.add(titleTable).width(400f);
@@ -620,62 +619,40 @@ public class UI implements ApplicationListener, Loadable{
 
                         String optionName = optionsRow[i];
                         int finalOption = option;
-                        buttonRow.button(optionName, () -> {
-                            callback.get(finalOption);
-                            hide();
-                        }).size(i == optionsRow.length - 1 ? lastWidth : width, 50).pad(4);
+                        buttonRow.button(optionName, () -> buttonListener.get(finalOption))
+                                .size(i == optionsRow.length - 1 ? lastWidth : width, 50).pad(4);
                         option++;
                     }
                 }
             }).growX();
-            closeOnBack(() -> callback.get(-1));
-        }}.show();
+            closeOnBack(closeOnBack);
+        }};
+    }
+
+    /** Shows a menu that fires a callback when an option is selected. If nothing is selected, -1 is returned. */
+    public void showMenu(String title, String message, String[][] options, Intc callback){
+        newMenuDialog(title, message, options, option -> {
+            callback.get(option);
+            hide();
+        }, () -> callback.get(-1)).show();
     }
 
     /** Shows a menu that hides when another followUp-menu is shown or when nothing is selected.
      * @see UI#showMenu(String, String, String[][], Intc) */
     public void showFollowUpMenu(int menuId, String title, String message, String[][] options, Intc callback) {
-        Dialog dialog = new Dialog(title){{
-            setFillParent(true);
-            removeChild(titleTable);
-            cont.add(titleTable).width(400f);
 
-            cont.row();
-            cont.image().width(400f).pad(2).colspan(2).height(4f).color(Pal.accent).bottom();
-            cont.row();
-            cont.pane(table -> {
-                table.add(message).width(400f).wrap().get().setAlignment(Align.center);
-                table.row();
-
-                int option = 0;
-                for(var optionsRow : options){
-                    Table buttonRow = table.row().table().get().row();
-                    int fullWidth = 400 - (optionsRow.length - 1) * 8; // adjust to count padding as well
-                    int width = fullWidth / optionsRow.length;
-                    int lastWidth = fullWidth - width * (optionsRow.length - 1); // take the rest of space for uneven table
-
-                    for(int i = 0; i < optionsRow.length; i++){
-                        if(optionsRow[i] == null) continue;
-
-                        String optionName = optionsRow[i];
-                        int finalOption = option;
-                        buttonRow.button(optionName, () -> callback.get(finalOption))
-                            .size(i == optionsRow.length - 1 ? lastWidth : width, 50).pad(4);
-                        option++;
-                    }
-                }
-            }).growX();
-            closeOnBack(() -> {
-                followUpMenus.remove(menuId);
-                callback.get(-1);
-            });
-        }};
+        Dialog dialog = newMenuDialog(title, message, options, callback, () -> {
+            followUpMenus.remove(menuId);
+            callback.get(-1);
+        });
 
         Dialog oldDialog = followUpMenus.remove(menuId);
         if(oldDialog != null){
             dialog.show(Core.scene, null);
             oldDialog.hide(null);
-        }else dialog.show();
+        }else{
+            dialog.show();
+        }
         followUpMenus.put(menuId, dialog);
     }
 

--- a/core/src/mindustry/ui/Menus.java
+++ b/core/src/mindustry/ui/Menus.java
@@ -37,16 +37,16 @@ public class Menus{
     }
 
     @Remote(variants = Variant.both)
-    public static void followedMenu(int menuId, String title, String message, String[][] options){
+    public static void followUpMenu(int menuId, String title, String message, String[][] options){
         if(title == null) title = "";
         if(options == null) options = new String[0][0];
 
-        ui.showFollowedMenu(menuId, title, message, options, (option) -> Call.menuChoose(player, menuId, option));
+        ui.showFollowUpMenu(menuId, title, message, options, (option) -> Call.menuChoose(player, menuId, option));
     }
 
     @Remote(variants = Variant.both)
-    public static void hideFollowedMenu(int menuId) {
-        ui.hideFollowedMenu(menuId);
+    public static void hideFollowUpMenu(int menuId) {
+        ui.hideFollowUpMenu(menuId);
     }
 
     @Remote(targets = Loc.both, called = Loc.both)

--- a/core/src/mindustry/ui/Menus.java
+++ b/core/src/mindustry/ui/Menus.java
@@ -36,6 +36,19 @@ public class Menus{
         ui.showMenu(title, message, options, (option) -> Call.menuChoose(player, menuId, option));
     }
 
+    @Remote(variants = Variant.both)
+    public static void followedMenu(int menuId, String title, String message, String[][] options){
+        if(title == null) title = "";
+        if(options == null) options = new String[0][0];
+
+        ui.showFollowedMenu(menuId, title, message, options, (option) -> Call.menuChoose(player, menuId, option));
+    }
+
+    @Remote(variants = Variant.both)
+    public static void hideFollowedMenu(int menuId) {
+        ui.hideFollowedMenu(menuId);
+    }
+
     @Remote(targets = Loc.both, called = Loc.both)
     public static void menuChoose(@Nullable Player player, int menuId, int option){
         if(player != null){


### PR DESCRIPTION
Added a new menu type that allows invisible transitions between different menus with the same id.
This opens the door for more interactive menus ..without giving players epilepsy.

- Works the same as a normal menu. (Uses `Dialog` and `Call.chooseMenu()`)
- Does **not** break plugins.
- The saved dialog is **always** freed in the end. (By client or server)

*I see no reasons why not to add it, since they work the same as normal menus and give developers more tools to work with.*

First video shows with the classic menu.
Second video shows with the new menu.
Third video shows a loading screen with the new menu.

[Before](https://user-images.githubusercontent.com/75242213/229166382-236cd355-9867-42ff-a0f4-961fb6c31979.mp4)

[After](https://user-images.githubusercontent.com/75242213/229166677-be141361-42a0-4c12-b2b6-accdf2e1ebe2.mp4)

[Loading](https://user-images.githubusercontent.com/75242213/229177746-49491f2f-abb9-445d-b713-1b8e87ac2f22.mp4)

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.