### PR TITLE
Fix hjson batteries without a drawer crashing the game

### DIFF
--- a/core/src/mindustry/world/blocks/power/Battery.java
+++ b/core/src/mindustry/world/blocks/power/Battery.java
@@ -14,9 +14,18 @@ import mindustry.world.meta.*;
 import static mindustry.Vars.*;
 
 public class Battery extends PowerDistributor{
-    public DrawBlock drawer;
-
+    public DrawBlock drawer = new DrawMulti(
+        new DrawDefault(),
+        new DrawPower(){{
+            emptyLightColor = Color.valueOf("f8c266");
+            fullLightColor = Color.valueOf("fb9567");
+        }},
+        new DrawRegion("-top")
+    );
+    
+    @Deprecated
     public Color emptyLightColor = Color.valueOf("f8c266");
+    @Deprecated
     public Color fullLightColor = Color.valueOf("fb9567");
 
     @Deprecated
@@ -33,18 +42,6 @@ public class Battery extends PowerDistributor{
         destructible = true;
         //batteries don't need to update
         update = false;
-    }
-
-    @Override
-    public void init(){
-        super.init();
-
-        if(drawer == null){
-            drawer = new DrawMulti(new DrawDefault(), new DrawPower(){{
-                emptyLightColor = Battery.this.emptyLightColor;
-                fullLightColor = Battery.this.fullLightColor;
-            }}, new DrawRegion("-top"));
-        }
     }
 
     @Override


### PR DESCRIPTION
Is `init` not called before `load`?

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
