### PR TITLE
Fixing Call.menu() not hiding on option selection.

### DIFF
--- a/core/src/mindustry/core/UI.java
+++ b/core/src/mindustry/core/UI.java
@@ -594,7 +594,8 @@ public class UI implements ApplicationListener, Loadable{
         dialog.show();
     }
 
-    public Dialog newMenuDialog(String title, String message, String[][] options, Intc buttonListener, Runnable closeOnBack){
+    // TODO REPLACE INTEGER WITH arc.fun.IntCons(int, T) or something like that.
+    public Dialog newMenuDialog(String title, String message, String[][] options, Cons2<Integer, Dialog> buttonListener){
         return new Dialog(title){{
             setFillParent(true);
             removeChild(titleTable);
@@ -619,29 +620,30 @@ public class UI implements ApplicationListener, Loadable{
 
                         String optionName = optionsRow[i];
                         int finalOption = option;
-                        buttonRow.button(optionName, () -> buttonListener.get(finalOption))
+                        buttonRow.button(optionName, () -> buttonListener.get(finalOption, this))
                                 .size(i == optionsRow.length - 1 ? lastWidth : width, 50).pad(4);
                         option++;
                     }
                 }
             }).growX();
-            closeOnBack(closeOnBack);
         }};
     }
 
     /** Shows a menu that fires a callback when an option is selected. If nothing is selected, -1 is returned. */
     public void showMenu(String title, String message, String[][] options, Intc callback){
-        newMenuDialog(title, message, options, option -> {
+        Dialog dialog = newMenuDialog(title, message, options, (option, myself) -> {
             callback.get(option);
-            hide();
-        }, () -> callback.get(-1)).show();
+            myself.hide();
+        });
+        dialog.closeOnBack(() -> callback.get(-1));
+        dialog.show();
     }
 
     /** Shows a menu that hides when another followUp-menu is shown or when nothing is selected.
      * @see UI#showMenu(String, String, String[][], Intc) */
     public void showFollowUpMenu(int menuId, String title, String message, String[][] options, Intc callback) {
-
-        Dialog dialog = newMenuDialog(title, message, options, callback, () -> {
+        Dialog dialog = newMenuDialog(title, message, options, (option, myself) -> callback.get(option));
+        dialog.closeOnBack(() -> {
             followUpMenus.remove(menuId);
             callback.get(-1);
         });


### PR DESCRIPTION
*When 3 hours of testing gets thrown in the garbage by a single refactoring...*

I was calling `UI.hide()` instead of `Dialog.hide()`, now fixed.

**Tests ran before this PR**
- (Menu) if closeOnBack gets called.
- (Menu) if the buttonListener get called + if it has the correct option.
- (Menu) if hidden after the option selection.
- (FollowUpMenu) if closeOnBack gets called.
- (FollowUpMenu) if the button listener gets called + if it has the correct option.

I went with `Cons2<Integer, Dialog>` ([to replace](https://github.com/Anuken/Arc/pull/141)) instead of having a `boolean hideMenu` to allow easier maintenance (if ever needed) in the future.
(*Stupid example that gives the point: hiding the menu with no delay when `option = -2`.*)

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
