### PR TITLE
Parse singular consumes

### DIFF
--- a/core/src/mindustry/mod/ClassMap.java
+++ b/core/src/mindustry/mod/ClassMap.java
@@ -459,6 +459,8 @@ public class ClassMap{
         classes.put("DrawTurret", mindustry.world.draw.DrawTurret.class);
         classes.put("DrawWarmupRegion", mindustry.world.draw.DrawWarmupRegion.class);
         classes.put("DrawWeave", mindustry.world.draw.DrawWeave.class);
+        classes.put("ConsumeCoolant", mindustry.world.consumers.ConsumeCoolant.class);
+        classes.put("ConsumeLiquidFlammable", mindustry.world.consumers.ConsumeLiquidFlammable.class);
         classes.put("Block", mindustry.world.Block.class);
     }
 }

--- a/core/src/mindustry/mod/ContentParser.java
+++ b/core/src/mindustry/mod/ContentParser.java
@@ -296,6 +296,13 @@ public class ContentParser{
             weapon.name = currentMod.name + "-" + weapon.name;
             return weapon;
         });
+        put(Consume.class, (type, data) -> {
+            var oc = resolve(data.getString("type", ""), Consume.class);
+            data.remove("type");
+            var consume = make(oc);
+            readFields(consume, data);
+            return consume;
+        });
     }};
     /** Stores things that need to be parsed fully, e.g. reading fields of content.
      * This is done to accommodate binding of content names first.*/

--- a/core/src/mindustry/mod/ContentParser.java
+++ b/core/src/mindustry/mod/ContentParser.java
@@ -303,6 +303,13 @@ public class ContentParser{
             readFields(consume, data);
             return consume;
         });
+        put(ConsumeLiquidBase.class, (type, data) -> {
+            var oc = resolve(data.getString("type", ""), ConsumeLiquidBase.class);
+            data.remove("type");
+            var consume = make(oc);
+            readFields(consume, data);
+            return consume;
+        });
     }};
     /** Stores things that need to be parsed fully, e.g. reading fields of content.
      * This is done to accommodate binding of content names first.*/

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -925,6 +925,10 @@ public class Block extends UnlockableContent implements Senseable{
         return consumers.length == 0 ? (T)consumeBuilder.find(filter) : (T)Structs.find(consumers, filter);
     }
 
+    public boolean hasConsumer(Consume cons){
+        return consumeBuilder.contains(cons);
+    }
+
     public void removeConsumer(Consume cons){
         if(consumers.length > 0){
             throw new IllegalStateException("You can only remove consumers before init(). After init(), all consumers have already been initialized.");

--- a/core/src/mindustry/world/blocks/defense/turrets/BaseTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/BaseTurret.java
@@ -51,6 +51,9 @@ public class BaseTurret extends Block{
             coolant.update = false;
             coolant.booster = true;
             coolant.optional = true;
+
+            //json parsing does not add to consumes
+            if(!hasConsumer(coolant)) consume(coolant);
         }
 
         placeOverlapRange = Math.max(placeOverlapRange, range + placeOverlapMargin);


### PR DESCRIPTION
For things like turret coolant, so that json mods can set the coolant to singular liquids similar to how Erekir turrets only consume water.

Test Mod: [testmod.zip](https://github.com/Anuken/Mindustry/files/11133100/testmod.zip)

![image](https://user-images.githubusercontent.com/54301439/229373554-7cd8abcb-1749-4dca-a9f1-4fbe41725ab8.png)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
  - [X] Turret coolants
  - [ ] Are there any other blocks with special singular consumes?
- [ ] Properly updated ClassMap
