### PR TITLE
BetterPlanetSelection

### DIFF
--- a/core/src/mindustry/ui/dialogs/PlanetDialog.java
+++ b/core/src/mindustry/ui/dialogs/PlanetDialog.java
@@ -606,29 +606,46 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
             t.label(() -> mode == select ? "@sectors.select" : "").style(Styles.outlineLabel).color(Pal.accent);
         }),
         buttons,
-        //planet selection
+        // planet selection
         new Table(t -> {
             t.top().left();
-            if(content.planets().count(this::selectable) > 1){
-                t.table(Tex.pane, pt -> {
-                    pt.margin(4f);
-                    for(int i = 0; i < content.planets().size; i++){
-                        Planet planet = content.planets().get(i);
-                        if(selectable(planet)){
-                            pt.button(planet.localizedName, Icon.icons.get(planet.icon + "Small", Icon.icons.get(planet.icon, Icon.commandRallySmall)), Styles.flatTogglet, () -> {
-                                selected = null;
-                                launchSector = null;
-                                if(state.planet != planet){
-                                    newPresets.clear();
-                                    state.planet = planet;
-                                    rebuildExpand();
-                                }
-                                settings.put("lastplanet", planet.name);
-                            }).width(190).height(40).growX().update(bb -> bb.setChecked(state.planet == planet)).with(w -> w.marginLeft(10f)).get().getChildren().get(1).setColor(planet.iconColor);
-                            pt.row();
-                        }
+            ScrollPane pane = new ScrollPane(null, Styles.smallPane);
+            t.add(pane).colspan(2).row();
+            Table starsTable = new Table(Styles.black);
+            pane.setWidget(starsTable);
+            pane.setScrollingDisabled(true, false);
+            int starCount = 0;
+            for (Planet star : content.planets()) {
+                if (star.solarSystem != star) continue;
+                boolean hasSelectablePlanets = false;
+                for (Planet planet : content.planets()) {
+                    if (planet.solarSystem == star && selectable(planet)) {
+                        hasSelectablePlanets = true;
+                        break;
                     }
-                });
+                }
+                if (!hasSelectablePlanets) continue;
+                starCount++;
+                if (starCount > 1) starsTable.add(new Label(star.localizedName)).padLeft(10f).padBottom(10f).padTop(10f).left().width(190f).row();
+                Table planetTable = new Table();
+                starsTable.add(planetTable).left().row();
+                for (Planet planet : content.planets()) {
+                    if (planet.solarSystem == star && selectable(planet)) {
+                        Button planetButton = planetTable.button(planet.localizedName, Icon.icons.get(planet.icon + "Small", Icon.icons.get(planet.icon, Icon.commandRallySmall)), Styles.flatTogglet, () -> {
+                            selected = null;
+                            launchSector = null;
+                            if (state.planet != planet) {
+                                newPresets.clear();
+                                state.planet = planet;
+                                rebuildExpand();
+                            }
+                            settings.put("lastplanet", planet.name);
+                        }).width(200).height(40).update(bb -> bb.setChecked(state.planet == planet)).with(w -> w.marginLeft(10f)).get();
+                        planetButton.getChildren().get(1).setColor(planet.iconColor);
+                        planetButton.setColor(planet.iconColor);
+                        planetTable.background(Tex.pane).row();
+                    }
+                }
             }
         }),
 


### PR DESCRIPTION
Better looking UI for planet selection:

- **Buttons are now also colored in the color of the planet icon**

- **If the modification has its own star system, then the planet selection buttons belonging to this system will be placed in a separate category with the name of the star that is the center of the system.**

Demonstration:

> **Without modifications that have their own star systems:**
> ![java_0yWdsh9m8r](https://user-images.githubusercontent.com/96493687/230769548-7d0b0e51-9b66-49dd-9a27-cccbb8fa0ad6.gif)

> **With modifications that have their own star systems:**
> ![java_S4x8dL1fiM](https://user-images.githubusercontent.com/96493687/230769602-c1156158-022e-40a3-8cec-0f2ec7e8f44e.gif)
> _Modifications used: FOS, Omaloon_

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
