### PR TITLE
Ammo obliteration

### DIFF
--- a/core/src/mindustry/type/Weapon.java
+++ b/core/src/mindustry/type/Weapon.java
@@ -396,7 +396,7 @@ public class Weapon implements Cloneable{
         mount.warmup >= minWarmup && //must be warmed up
         unit.vel.len() >= minShootVelocity && //check velocity requirements
         (mount.reload <= 0.0001f || (alwaysContinuous && mount.bullet == null)) && //reload has to be 0, or it has to be an always-continuous weapon
-        Angles.within(rotate ? mount.rotation : unit.rotation + baseRotation, mount.targetRotation, shootCone) //has to be within the cone
+        (alwaysShooting || Angles.within(rotate ? mount.rotation : unit.rotation + baseRotation, mount.targetRotation, shootCone)) //has to be within the cone
         ){
             shoot(unit, mount, bulletX, bulletY, shootAngle);
 

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -83,6 +83,8 @@ public class Turret extends ReloadTurret{
     public boolean displayAmmoMultiplier = true;
     /** If false, 'under' blocks like conveyors are not targeted. */
     public boolean targetUnderBlocks = true;
+    /** If true, the turret will always shoot when it has ammo, regardless of targets in range or any control. */
+    public boolean alwaysShooting = false;
     /** Function for choosing which unit to target. */
     public Sortf unitSort = UnitSorts.closest;
     /** Filter for types of units to attack. */
@@ -304,7 +306,7 @@ public class Turret extends ReloadTurret{
         }
 
         public boolean isShooting(){
-            return (isControlled() ? unit.isShooting() : logicControlled() ? logicShooting : target != null);
+            return alwaysShooting || (isControlled() ? unit.isShooting() : logicControlled() ? logicShooting : target != null);
         }
 
         @Override
@@ -425,10 +427,15 @@ public class Turret extends ReloadTurret{
                         turnToTarget(targetRot);
                     }
 
-                    if(Angles.angleDist(rotation, targetRot) < shootCone && canShoot){
+                    if(!alwaysShooting && Angles.angleDist(rotation, targetRot) < shootCone && canShoot){
                         wasShooting = true;
                         updateShooting();
                     }
+                }
+
+                if(alwaysShooting){
+                    wasShooting = true;
+                    updateShooting();
                 }
             }
 


### PR DESCRIPTION
`alwaysShooting` for turrets similar to that of unit weapons.
![2023_04_08_11_42_39_DiscordCanary](https://user-images.githubusercontent.com/54301439/230790198-bc91ecd1-f081-4269-9475-cab08c8293ac.png)

Also fixes weapon `alwaysShooting` to actually work properly.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
  - [X] Works fine with item, power, and liquid turrets. (Tested on scatter, lancer, and wave)
  - [X] Works fine on continuous turrets. (Luster and sublimate)
  - [X] Tested with logic (Stops when disabled, still fires when logic says to not)
  - [X] Continues firing while player controlled.
  - [ ] Give me more edge cases.