### PR TITLE
Don't set lighting if the preset has noLighting = true

### DIFF
--- a/core/src/mindustry/game/Universe.java
+++ b/core/src/mindustry/game/Universe.java
@@ -84,10 +84,11 @@ public class Universe{
 
         if(state.hasSector() && state.getSector().planet.updateLighting){
             boolean disable = state.getSector().preset != null && state.getSector().preset.noLighting;
+            if(disable) return;
             var planet = state.getSector().planet;
             //update sector light
             float light = state.getSector().getLight();
-            float alpha = disable ? 1f : Mathf.clamp(Mathf.map(light, planet.lightSrcFrom, planet.lightSrcTo, planet.lightDstFrom, planet.lightDstTo));
+            float alpha = Mathf.clamp(Mathf.map(light, planet.lightSrcFrom, planet.lightSrcTo, planet.lightDstFrom, planet.lightDstTo));
 
             //assign and map so darkness is not 100% dark
             state.rules.ambientLight.a = 1f - alpha;

--- a/core/src/mindustry/game/Universe.java
+++ b/core/src/mindustry/game/Universe.java
@@ -82,9 +82,7 @@ public class Universe{
             }
         }
 
-        if(state.hasSector() && state.getSector().planet.updateLighting){
-            boolean disable = state.getSector().preset != null && state.getSector().preset.noLighting;
-            if(disable) return;
+        if(state.hasSector() && state.getSector().planet.updateLighting && !(state.getSector().preset != null && state.getSector().preset.noLighting)){
             var planet = state.getSector().planet;
             //update sector light
             float light = state.getSector().getLight();


### PR DESCRIPTION
Allows lighting in the preset or world processors to take over instead of being forced to disable lighting.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
