### PR TITLE
Laser pierce fixes.

### DIFF
--- a/core/src/mindustry/entities/Damage.java
+++ b/core/src/mindustry/entities/Damage.java
@@ -137,6 +137,16 @@ public class Damage{
         return found ? tmpBuilding : null;
     }
 
+    public static float findLength(Bullet b, float length, boolean laser, int pierceCap){
+        if(pierceCap > 0){
+            length = findPierceLength(b, pierceCap, length);
+        }else if(laser){
+            length = findLaserLength(b, length);
+        }
+
+        return length;
+    }
+
     public static float findLaserLength(Bullet b, float length){
         vec.trnsExact(b.rotation(), length);
 
@@ -223,11 +233,7 @@ public class Damage{
      * Only enemies of the specified team are damaged.
      */
     public static void collideLine(Bullet hitter, Team team, Effect effect, float x, float y, float angle, float length, boolean large, boolean laser, int pierceCap){
-        if(pierceCap > 0){
-            length = findPierceLength(hitter, pierceCap, length);
-        }else if(laser){
-            length = findLaserLength(hitter, length);
-        }
+        length = findLength(hitter, length, laser, pierceCap);
 
         collidedBlocks.clear();
         vec.trnsExact(angle, length);

--- a/core/src/mindustry/entities/Damage.java
+++ b/core/src/mindustry/entities/Damage.java
@@ -139,7 +139,7 @@ public class Damage{
 
     public static float findLength(Bullet b, float length, boolean laser, int pierceCap){
         if(pierceCap > 0){
-            length = findPierceLength(b, pierceCap, length);
+            length = findPierceLength(b, pierceCap, laser, length);
         }else if(laser){
             length = findLaserLength(b, length);
         }
@@ -159,6 +159,10 @@ public class Damage{
     }
 
     public static float findPierceLength(Bullet b, int pierceCap, float length){
+        return findPierceLength(b, pierceCap, b.type.laserAbsorb, length);
+    }
+    
+    public static float findPierceLength(Bullet b, int pierceCap, boolean laser, float length){
         vec.trnsExact(b.rotation(), length);
         rect.setPosition(b.x, b.y).setSize(vec.x, vec.y).normalize().grow(3f);
 
@@ -173,7 +177,7 @@ public class Damage{
             if(build != null && build.team != b.team && build.collide(b) && b.checkUnderBuild(build, x * tilesize, y * tilesize)){
                 distances.add(b.dst(build));
 
-                if(b.type.laserAbsorb && build.absorbLasers()){
+                if(laser && build.absorbLasers()){
                     maxDst = Math.min(maxDst, b.dst(build));
                     return true;
                 }
@@ -199,7 +203,7 @@ public class Damage{
 
     /** Collides a bullet with blocks in a laser, taking into account absorption blocks. Resulting length is stored in the bullet's fdata. */
     public static float collideLaser(Bullet b, float length, boolean large, boolean laser, int pierceCap){
-        float resultLength = findPierceLength(b, pierceCap, length);
+        float resultLength = findPierceLength(b, pierceCap, laser, length);
 
         collideLine(b, b.team, b.type.hitEffect, b.x, b.y, b.rotation(), resultLength, large, laser, pierceCap);
 

--- a/core/src/mindustry/entities/Damage.java
+++ b/core/src/mindustry/entities/Damage.java
@@ -223,10 +223,10 @@ public class Damage{
      * Only enemies of the specified team are damaged.
      */
     public static void collideLine(Bullet hitter, Team team, Effect effect, float x, float y, float angle, float length, boolean large, boolean laser, int pierceCap){
-        if(laser){
-            length = findLaserLength(hitter, length);
-        }else if(pierceCap > 0){
+        if(pierceCap > 0){
             length = findPierceLength(hitter, pierceCap, length);
+        }else if(laser){
+            length = findLaserLength(hitter, length);
         }
 
         collidedBlocks.clear();

--- a/core/src/mindustry/entities/bullet/ContinuousFlameBulletType.java
+++ b/core/src/mindustry/entities/bullet/ContinuousFlameBulletType.java
@@ -57,7 +57,7 @@ public class ContinuousFlameBulletType extends ContinuousBulletType{
     @Override
     public void draw(Bullet b){
         float mult = b.fin(lengthInterp);
-        float realLength = (pierceCap <= 0 ? length : Damage.findPierceLength(b, pierceCap, length)) * mult;
+        float realLength = Damage.findLength(b, length * mult, laserAbsorb, pierceCap);
 
         float sin = Mathf.sin(Time.time, oscScl, oscMag);
 

--- a/core/src/mindustry/entities/bullet/ContinuousLaserBulletType.java
+++ b/core/src/mindustry/entities/bullet/ContinuousLaserBulletType.java
@@ -41,9 +41,8 @@ public class ContinuousLaserBulletType extends ContinuousBulletType{
 
     @Override
     public void draw(Bullet b){
-        float realLength = Damage.findLaserLength(b, length);
         float fout = Mathf.clamp(b.time > b.lifetime - fadeTime ? 1f - (b.time - (lifetime - fadeTime)) / fadeTime : 1f);
-        float baseLen = realLength * fout;
+        float realLength = Damage.findLength(b, length * fout, laserAbsorb, pierceCap);
         float rot = b.rotation();
 
         for(int i = 0; i < colors.length; i++){
@@ -55,17 +54,17 @@ public class ContinuousLaserBulletType extends ContinuousBulletType{
             float ellipseLenScl = Mathf.lerp(1 - i / (float)(colors.length), 1f, pointyScaling);
 
             Lines.stroke(stroke);
-            Lines.lineAngle(b.x, b.y, rot, baseLen - frontLength, false);
+            Lines.lineAngle(b.x, b.y, rot, realLength - frontLength, false);
 
             //back ellipse
             Drawf.flameFront(b.x, b.y, divisions, rot + 180f, backLength, stroke / 2f);
 
             //front ellipse
-            Tmp.v1.trnsExact(rot, baseLen - frontLength);
+            Tmp.v1.trnsExact(rot, realLength - frontLength);
             Drawf.flameFront(b.x + Tmp.v1.x, b.y + Tmp.v1.y, divisions, rot, frontLength * ellipseLenScl, stroke / 2f);
         }
 
-        Tmp.v1.trns(b.rotation(), baseLen * 1.1f);
+        Tmp.v1.trns(b.rotation(), realLength * 1.1f);
 
         Drawf.light(b.x, b.y, b.x + Tmp.v1.x, b.y + Tmp.v1.y, lightStroke, lightColor, 0.7f);
         Draw.reset();
@@ -76,4 +75,9 @@ public class ContinuousLaserBulletType extends ContinuousBulletType{
         //no light drawn here
     }
 
+    @Override
+    public float currentLength(Bullet b){
+        float fout = Mathf.clamp(b.time > b.lifetime - fadeTime ? 1f - (b.time - (lifetime - fadeTime)) / fadeTime : 1f);
+        return length * fout;
+    }
 }


### PR DESCRIPTION
- Flipped the check order in `collideLine` so that `laserAbsorb = true` doesn't make it ignore `pierceCap`.
- Added `currentLength` to `ContinuousLaserBulletType` so that the shrinking isn't just purely visual.
- Made `ContinuousLaserBulletType` and `ContinuousFlameBulletType` visuals accurate to their `currentLength`.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
