### PR TITLE
Clear invalid payload ammo

### DIFF
--- a/core/src/mindustry/type/PayloadSeq.java
+++ b/core/src/mindustry/type/PayloadSeq.java
@@ -1,6 +1,8 @@
 package mindustry.type;
 
+import arc.func.*;
 import arc.struct.*;
+import arc.struct.ObjectIntMap.*;
 import arc.util.io.*;
 import mindustry.*;
 import mindustry.ctype.*;
@@ -26,6 +28,7 @@ public class PayloadSeq{
     }
 
     public void add(UnlockableContent block, int amount){
+        if(block == null) return;
         payloads.increment(block, amount);
         total += amount;
     }
@@ -40,6 +43,19 @@ public class PayloadSeq{
 
     public void remove(Seq<PayloadStack> stacks){
         stacks.each(b -> remove(b.item, b.amount));
+    }
+
+    /** @return this object */
+    public PayloadSeq removeAll(Boolf<UnlockableContent> pred){
+        Entries<UnlockableContent> iter = payloads.iterator();
+        while(iter.hasNext()){
+            Entry<UnlockableContent> e = iter.next();
+            if(pred.get(e.key)){
+                iter.remove();
+                total -= e.value;
+            }
+        }
+        return this;
     }
 
     public void clear(){
@@ -90,7 +106,7 @@ public class PayloadSeq{
         }else{
             //new format
             for(int i = 0; i < -amount; i++){
-                add((UnlockableContent)Vars.content.getBy(ContentType.all[read.ub()]).get(read.s()), read.i());
+                add(Vars.content.getByID(ContentType.all[read.ub()], read.s()), read.i());
             }
         }
 

--- a/core/src/mindustry/world/blocks/defense/turrets/PayloadAmmoTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/PayloadAmmoTurret.java
@@ -170,7 +170,7 @@ public class PayloadAmmoTurret extends Turret{
         public void read(Reads read, byte revision){
             super.read(read, revision);
             payloads.read(read);
-            //TODO remove invalid ammo
+            payloads.removeAll(u -> !ammoTypes.containsKey(u));
         }
     }
 }


### PR DESCRIPTION
Considering that I'm one of the few people who actually uses payload ammo turrets, I figured I would implement this so that my saves stop crashing every time I make new block.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
  - Tested by opening saves with my payload turrets after enabling/disabling [poly-1810/tantros-but-java](https://github.com/poly-1810/tantros-but-java), knowing that it loads before [MEEPofFaith/prog-mats-java](https://github.com/MEEPofFaith/prog-mats-java) and would offset the ids of the blocks I use for ammo.