### PR TITLE
Arbitrary Block Sorting & De-Enum Categories

### DIFF
--- a/core/src/mindustry/type/Category.java
+++ b/core/src/mindustry/type/Category.java
@@ -1,34 +1,70 @@
 package mindustry.type;
 
-public enum Category{
-    /** Offensive turrets. */
-    turret,
-    /** Blocks that produce raw resources, such as drills. */
-    production,
-    /** Blocks that move items around. */
-    distribution,
-    /** Blocks that move liquids around. */
-    liquid,
-    /** Blocks that generate or transport power. */
-    power,
-    /** Walls and other defensive structures. */
-    defense,
-    /** Blocks that craft things. */
-    crafting,
-    /** Blocks that create units. */
-    units,
-    /** Things for storage or passive effects. */
-    effect,
-    /** Blocks related to logic. */
-    logic;
+import arc.struct.*;
+import mindustry.world.*;
 
-    public static final Category[] all = values();
+public class Category implements Comparable<Category>{
+    public static final Seq<Category> all = new Seq<>();
+
+    public static Category
+
+    /** Offensive turrets. */
+    turret = new Category("turret"),
+    /** Blocks that produce raw resources, such as drills. */
+    production = new Category("production"),
+    /** Blocks that move items around. */
+    distribution = new Category("distribution"),
+    /** Blocks that move liquids around. */
+    liquid = new Category("liquid"),
+    /** Blocks that generate or transport power. */
+    power = new Category("power"),
+    /** Walls and other defensive structures. */
+    defense = new Category("defense"),
+    /** Blocks that craft things. */
+    crafting = new Category("crafting"),
+    /** Blocks that create units. */
+    units = new Category("units"),
+    /** Things for storage or passive effects. */
+    effect = new Category("effect"),
+    /** Blocks related to logic. */
+    logic = new Category("logic");
+
+    public int id;
+    public String name;
+    public Seq<Block> blocks = new Seq<>();
+
+    public Category(String name){
+        id = all.size;
+        this.name = name;
+        all.add(this);
+    }
+
+    public void add(Block b){
+        int index = -1;
+        for(int i = 0; i < blocks.size; i++){
+            if(blocks.get(i).uiPosition > b.uiPosition){
+                index = i;
+                break;
+            }
+        }
+
+        if(index == -1){
+            blocks.add(b);
+        }else{
+            blocks.insert(index, b);
+        }
+    }
 
     public Category prev(){
-        return all[(ordinal() - 1 + all.length) % all.length];
+        return all.get((id - 1 + all.size) % all.size);
     }
 
     public Category next(){
-        return all[(ordinal() + 1) % all.length];
+        return all.get((id + 1) % all.size);
+    }
+
+    @Override
+    public int compareTo(Category o){
+        return id - o.id;
     }
 }

--- a/core/src/mindustry/ui/fragments/PlacementFragment.java
+++ b/core/src/mindustry/ui/fragments/PlacementFragment.java
@@ -36,7 +36,7 @@ public class PlacementFragment{
 
     Seq<Block> returnArray = new Seq<>(), returnArray2 = new Seq<>();
     Seq<Category> returnCatArray = new Seq<>();
-    boolean[] categoryEmpty = new boolean[Category.all.length];
+    boolean[] categoryEmpty = new boolean[Category.all.size];
     ObjectMap<Category,Block> selectedBlocks = new ObjectMap<>();
     ObjectFloatMap<Category> scrollPositions = new ObjectFloatMap<>();
     @Nullable Block menuHoverBlock;
@@ -182,8 +182,8 @@ public class PlacementFragment{
                     }
                 }else if(blockSelectEnd || Time.timeSinceMillis(blockSelectSeqMillis) > 400){ //1st number of combo, select category
                     //select only visible categories
-                    if(!getUnlockedByCategory(Category.all[i]).isEmpty()){
-                        currentCategory = Category.all[i];
+                    if(!getUnlockedByCategory(Category.all.get(i)).isEmpty()){
+                        currentCategory = Category.all.get(i);
                         if(input.block != null){
                             input.block = getSelectedBlock(currentCategory);
                         }
@@ -212,7 +212,7 @@ public class PlacementFragment{
         if(Core.input.keyTap(Binding.category_prev)){
             do{
                 currentCategory = currentCategory.prev();
-            }while(categoryEmpty[currentCategory.ordinal()]);
+            }while(categoryEmpty[currentCategory.id]);
             input.block = getSelectedBlock(currentCategory);
             return true;
         }
@@ -220,7 +220,7 @@ public class PlacementFragment{
         if(Core.input.keyTap(Binding.category_next)){
             do{
                 currentCategory = currentCategory.next();
-            }while(categoryEmpty[currentCategory.ordinal()]);
+            }while(categoryEmpty[currentCategory.id]);
             input.block = getSelectedBlock(currentCategory);
             return true;
         }
@@ -338,7 +338,7 @@ public class PlacementFragment{
                                     Seq<Block> blocks = getByCategory(currentCategory);
                                     for(int i = 0; i < blocks.size; i++){
                                         if(blocks.get(i) == displayBlock && (i + 1) / 10 - 1 < blockSelect.length){
-                                            keyCombo = Core.bundle.format("placement.blockselectkeys", Core.keybinds.get(blockSelect[currentCategory.ordinal()]).key.toString())
+                                            keyCombo = Core.bundle.format("placement.blockselectkeys", Core.keybinds.get(blockSelect[currentCategory.id]).key.toString())
                                                 + (i < 10 ? "" : Core.keybinds.get(blockSelect[(i + 1) / 10 - 1]).key.toString() + ",")
                                                 + Core.keybinds.get(blockSelect[i % 10]).key.toString() + "]";
                                             break;
@@ -577,16 +577,16 @@ public class PlacementFragment{
                         //update category empty values
                         for(Category cat : Category.all){
                             Seq<Block> blocks = getUnlockedByCategory(cat);
-                            categoryEmpty[cat.ordinal()] = blocks.isEmpty();
+                            categoryEmpty[cat.id] = blocks.isEmpty();
                         }
 
-                        boolean needsAssign = categoryEmpty[currentCategory.ordinal()];
+                        boolean needsAssign = categoryEmpty[currentCategory.id];
 
                         int f = 0;
                         for(Category cat : getCategories()){
                             if(f++ % 2 == 0) categories.row();
 
-                            if(categoryEmpty[cat.ordinal()]){
+                            if(categoryEmpty[cat.id]){
                                 categories.image(Styles.black6);
                                 continue;
                             }
@@ -596,13 +596,13 @@ public class PlacementFragment{
                                 needsAssign = false;
                             }
 
-                            categories.button(ui.getIcon(cat.name()), Styles.clearTogglei, () -> {
+                            categories.button(ui.getIcon(cat.name), Styles.clearTogglei, () -> {
                                 currentCategory = cat;
                                 if(control.input.block != null){
                                     control.input.block = getSelectedBlock(currentCategory);
                                 }
                                 rebuildCategory.run();
-                            }).group(group).update(i -> i.setChecked(currentCategory == cat)).name("category-" + cat.name());
+                            }).group(group).update(i -> i.setChecked(currentCategory == cat)).name("category-" + cat.name);
                         }
                     }).fillY().bottom().touchable(Touchable.enabled);
                 }
@@ -618,15 +618,15 @@ public class PlacementFragment{
     }
 
     Seq<Category> getCategories(){
-        return returnCatArray.clear().addAll(Category.all).sort((c1, c2) -> Boolean.compare(categoryEmpty[c1.ordinal()], categoryEmpty[c2.ordinal()]));
+        return returnCatArray.clear().addAll(Category.all).sort((c1, c2) -> Boolean.compare(categoryEmpty[c1.id], categoryEmpty[c2.id]));
     }
 
     Seq<Block> getByCategory(Category cat){
-        return returnArray.selectFrom(content.blocks(), block -> block.category == cat && block.isVisible() && block.environmentBuildable());
+        return returnArray.selectFrom(cat.blocks, block -> block.isVisible() && block.environmentBuildable());
     }
 
     Seq<Block> getUnlockedByCategory(Category cat){
-        return returnArray2.selectFrom(content.blocks(), block -> block.category == cat && block.isVisible() && unlocked(block)).sort((b1, b2) -> Boolean.compare(!b1.isPlaceable(), !b2.isPlaceable()));
+        return returnArray2.selectFrom(cat.blocks, block -> block.isVisible() && unlocked(block)).sort((b1, b2) -> Boolean.compare(!b1.isPlaceable(), !b2.isPlaceable()));
     }
 
     Block getSelectedBlock(Category cat){

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -304,6 +304,8 @@ public class Block extends UnlockableContent implements Senseable{
     public ItemStack[] requirements = {};
     /** Category in place menu. */
     public Category category = Category.distribution;
+    /** Arbitrary index for sorting in the place menu, defaults to NaN. If NaN, the block will assign one automatically on init() */
+    public float uiPosition = Float.NaN;
     /** Time to build this block in ticks; do not modify directly! */
     public float buildCost = 20f;
     /** Whether this block is visible and can currently be built. */
@@ -1206,6 +1208,11 @@ public class Block extends UnlockableContent implements Senseable{
         if(buildVisibility == BuildVisibility.sandboxOnly){
             hideDetails = false;
         }
+
+        if(Float.isNaN(uiPosition)){
+            uiPosition = category.blocks.size;
+        }
+        category.add(this);
     }
 
     @Override


### PR DESCRIPTION
Grants mods the ability to organize both their own blocks and vanilla blocks in the place menu without having to adjust load order. Also de-enumerates block categories, but does not add proper UI support for it.

Not a good example but notice how the hyper-processor has been moved in between the message block and the switch.
![image](https://user-images.githubusercontent.com/73060700/235351724-2d97ce5e-0ebf-4a27-9e7d-c15ca16eff77.png)

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
