### PR TITLE
A couple of features for better planet modding

### DIFF
--- a/core/src/mindustry/content/Planets.java
+++ b/core/src/mindustry/content/Planets.java
@@ -68,6 +68,9 @@ public class Planets{
             hiddenItems.addAll(Items.serpuloItems).removeAll(Items.erekirItems);
             enemyBuildSpeedMultiplier = 0.4f;
 
+            //TODO disallowed for now
+            allowLaunchToNumbered = false;
+
             //TODO SHOULD there be lighting?
             updateLighting = false;
 

--- a/core/src/mindustry/maps/generators/PlanetGenerator.java
+++ b/core/src/mindustry/maps/generators/PlanetGenerator.java
@@ -55,7 +55,7 @@ public abstract class PlanetGenerator extends BasicGenerator implements HexMeshe
 
     /** @return whether to allow landing on the specified procedural sector */
     public boolean allowLanding(Sector sector){
-        return sector.hasBase() || sector.near().contains(Sector::hasBase);
+        return sector.planet.allowLaunchToNumbered && (sector.hasBase() || sector.near().contains(Sector::hasBase));
     }
 
     public void addWeather(Sector sector, Rules rules){

--- a/core/src/mindustry/maps/planet/ErekirPlanetGenerator.java
+++ b/core/src/mindustry/maps/planet/ErekirPlanetGenerator.java
@@ -62,12 +62,6 @@ public class ErekirPlanetGenerator extends PlanetGenerator{
         return 2000 * 1.07f * 6f / 5f;
     }
 
-    @Override
-    public boolean allowLanding(Sector sector){
-        //TODO disallowed for now
-        return false;
-    }
-
     float rawHeight(Vec3 position){
         return Simplex.noise3d(seed, octaves, persistence, 1f/heightScl, 10f + position.x, 10f + position.y, 10f + position.z);
     }

--- a/core/src/mindustry/type/Planet.java
+++ b/core/src/mindustry/type/Planet.java
@@ -115,6 +115,8 @@ public class Planet extends UnlockableContent{
     public boolean prebuildBase = true;
     /** If true, waves are created on sector loss. TODO remove. */
     public boolean allowWaves = false;
+    /** If false, players are unable to land on this planet's numbered sectors. */
+    public boolean allowLaunchToNumbered = true;
     /** Icon as displayed in the planet selection dialog. This is a string, as drawables are null at load time. */
     public String icon = "planet";
     /** Default core block for launching. */

--- a/core/src/mindustry/type/Planet.java
+++ b/core/src/mindustry/type/Planet.java
@@ -13,6 +13,7 @@ import mindustry.content.*;
 import mindustry.content.TechTree.*;
 import mindustry.ctype.*;
 import mindustry.game.*;
+import mindustry.game.EventType.ContentInitEvent;
 import mindustry.graphics.*;
 import mindustry.graphics.g3d.*;
 import mindustry.graphics.g3d.PlanetGrid.*;
@@ -130,8 +131,10 @@ public class Planet extends UnlockableContent{
     public @Nullable TechNode techTree;
     /** TODO remove? Planets that can be launched to from this one. Made mutual in init(). */
     public Seq<Planet> launchCandidates = new Seq<>();
-    /** Items not available on this planet. */
+    /** Items not available on this planet. Left out for backwards compatibility. */
     public Seq<Item> hiddenItems = new Seq<>();
+    /** The only items available on this planet, if defined. */
+    public Seq<Item> itemWhitelist = new Seq<>();
     /** Content (usually planet-specific) that is unlocked upon landing here. */
     public Seq<UnlockableContent> unlockedOnLand = new Seq<>();
     /** Loads the mesh. Clientside only. Defaults to a boring sphere mesh. */
@@ -158,6 +161,13 @@ public class Planet extends UnlockableContent{
             parent.children.add(this);
             parent.updateTotalRadius();
         }
+
+        //if an item whitelist exists, add everything else not in that whitelist to hidden items
+        Events.on(ContentInitEvent.class, e -> {
+            if (itemWhitelist.size > 0){
+                hiddenItems.addAll(content.items().copy().filter(i -> !itemWhitelist.contains(i)));
+            }
+        });
 
         //calculate solar system
         for(solarSystem = this; solarSystem.parent != null; solarSystem = solarSystem.parent);

--- a/core/src/mindustry/type/Planet.java
+++ b/core/src/mindustry/type/Planet.java
@@ -167,7 +167,7 @@ public class Planet extends UnlockableContent{
         //if an item whitelist exists, add everything else not in that whitelist to hidden items
         Events.on(ContentInitEvent.class, e -> {
             if (itemWhitelist.size > 0){
-                hiddenItems.addAll(content.items().copy().filter(i -> !itemWhitelist.contains(i)));
+                hiddenItems.addAll(content.items().select(i -> !itemWhitelist.contains(i)));
             }
         });
 

--- a/core/src/mindustry/type/Planet.java
+++ b/core/src/mindustry/type/Planet.java
@@ -166,7 +166,7 @@ public class Planet extends UnlockableContent{
 
         //if an item whitelist exists, add everything else not in that whitelist to hidden items
         Events.on(ContentInitEvent.class, e -> {
-            if (itemWhitelist.size > 0){
+            if(itemWhitelist.size > 0){
                 hiddenItems.addAll(content.items().select(i -> !itemWhitelist.contains(i)));
             }
         });


### PR DESCRIPTION
1) `itemWhitelist`:
This makes it so that every other item not included in this list will be hidden from a planet (including modded items).

2) `allowLaunchToNumbered`:
If false, procedurally generated sectors are not landable by any normal means. This field was also set to false for Erekir.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
