### PR TITLE
Revert "Properly handle missile units shooting more missile units"

### DIFF
--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -554,7 +554,7 @@ public class BulletType extends Content implements Cloneable{
 
     public void init(Bullet b){
 
-        if(killShooter && b.owner() instanceof Healthc h && !h.dead()){
+        if(killShooter && b.owner() instanceof Healthc h){
             h.kill();
         }
 
@@ -700,6 +700,7 @@ public class BulletType extends Content implements Cloneable{
         return create(owner, team, x, y, angle, -1, velocityScl, lifetimeScl, null);
     }
 
+
     public @Nullable Bullet create(Entityc owner, Team team, float x, float y, float angle, float velocityScl, float lifetimeScl, Mover mover){
         return create(owner, team, x, y, angle, -1, velocityScl, lifetimeScl, null, mover);
     }
@@ -731,26 +732,23 @@ public class BulletType extends Content implements Cloneable{
                 Unit spawned = spawnUnit.create(team);
                 spawned.set(x, y);
                 spawned.rotation = angle;
-
                 //immediately spawn at top speed, since it was launched
                 if(spawnUnit.missileAccelTime <= 0f){
                     spawned.vel.trns(angle, spawnUnit.speed);
                 }
-                
                 //assign unit owner
                 if(spawned.controller() instanceof MissileAI ai){
                     if(owner instanceof Unit unit){
                         ai.shooter = unit;
                     }
+
                     if(owner instanceof ControlBlock control){
                         ai.shooter = control.unit();
                     }
+
                 }
                 spawned.add();
             }
-
-            //Since bullet init is never called, handle killing shooter here
-            if(killShooter && owner instanceof Healthc h && !h.dead()) h.kill();
 
             //no bullet returned
             return null;

--- a/core/src/mindustry/type/Weapon.java
+++ b/core/src/mindustry/type/Weapon.java
@@ -10,7 +10,6 @@ import arc.math.geom.*;
 import arc.scene.ui.layout.*;
 import arc.struct.*;
 import arc.util.*;
-import mindustry.ai.types.*;
 import mindustry.annotations.Annotations.*;
 import mindustry.audio.*;
 import mindustry.content.*;
@@ -457,8 +456,7 @@ public class Weapon implements Cloneable{
         lifeScl = bullet.scaleLife ? Mathf.clamp(Mathf.dst(bulletX, bulletY, mount.aimX, mount.aimY) / bullet.range) : 1f,
         angle = angleOffset + shootAngle + Mathf.range(inaccuracy + bullet.inaccuracy);
 
-        Entityc shooter = unit.controller() instanceof MissileAI ai ? ai.shooter : unit; //Pass the missile's shooter down to its bullets
-        mount.bullet = bullet.create(shooter, unit.team, bulletX, bulletY, angle, -1f, (1f - velocityRnd) + Mathf.random(velocityRnd), lifeScl, null, mover, mount.aimX, mount.aimY);
+        mount.bullet = bullet.create(unit, unit.team, bulletX, bulletY, angle, -1f, (1f - velocityRnd) + Mathf.random(velocityRnd), lifeScl, null, mover, mount.aimX, mount.aimY);
         handleBullet(unit, mount, mount.bullet);
 
         if(!continuous){


### PR DESCRIPTION
Reverts Anuken/Mindustry#8359

So, uh, the "passing own `shooter`" thing is making missile units exploding killing their *shooter* instead of themselves.