### PR TITLE
Better handling of missiles splitting to other missiles (Done correctly this time)

### DIFF
--- a/core/src/mindustry/ai/types/MissileAI.java
+++ b/core/src/mindustry/ai/types/MissileAI.java
@@ -14,7 +14,7 @@ public class MissileAI extends AIController{
 
         float time = unit instanceof TimedKillc t ? t.time() : 1000000f;
 
-        if(time >= unit.type.homingDelay && shooter != null){
+        if(time >= unit.type.homingDelay && shooter != null && !shooter.dead()){
             unit.lookAt(shooter.aimX, shooter.aimY);
         }
 

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -554,7 +554,7 @@ public class BulletType extends Content implements Cloneable{
 
     public void init(Bullet b){
 
-        if(killShooter && b.owner() instanceof Healthc h){
+        if(killShooter && b.owner() instanceof Healthc h && !h.dead()){
             h.kill();
         }
 
@@ -726,6 +726,10 @@ public class BulletType extends Content implements Cloneable{
     }
 
     public @Nullable Bullet create(@Nullable Entityc owner, Team team, float x, float y, float angle, float damage, float velocityScl, float lifetimeScl, Object data, @Nullable Mover mover, float aimX, float aimY){
+        return create(owner, owner, team, x, y, angle, damage, velocityScl, lifetimeScl, data, mover, aimX, aimY);
+    }
+
+    public @Nullable Bullet create(@Nullable Entityc owner, @Nullable Entityc shooter, Team team, float x, float y, float angle, float damage, float velocityScl, float lifetimeScl, Object data, @Nullable Mover mover, float aimX, float aimY){
         if(spawnUnit != null){
             //don't spawn units clientside!
             if(!net.client()){
@@ -738,17 +742,19 @@ public class BulletType extends Content implements Cloneable{
                 }
                 //assign unit owner
                 if(spawned.controller() instanceof MissileAI ai){
-                    if(owner instanceof Unit unit){
+                    if(shooter instanceof Unit unit){
                         ai.shooter = unit;
                     }
 
-                    if(owner instanceof ControlBlock control){
+                    if(shooter instanceof ControlBlock control){
                         ai.shooter = control.unit();
                     }
 
                 }
                 spawned.add();
             }
+            //Since bullet init is never called, handle killing shooter here
+            if(killShooter && owner instanceof Healthc h && !h.dead()) h.kill();
 
             //no bullet returned
             return null;

--- a/core/src/mindustry/type/Weapon.java
+++ b/core/src/mindustry/type/Weapon.java
@@ -10,6 +10,7 @@ import arc.math.geom.*;
 import arc.scene.ui.layout.*;
 import arc.struct.*;
 import arc.util.*;
+import mindustry.ai.types.*;
 import mindustry.annotations.Annotations.*;
 import mindustry.audio.*;
 import mindustry.content.*;
@@ -456,7 +457,8 @@ public class Weapon implements Cloneable{
         lifeScl = bullet.scaleLife ? Mathf.clamp(Mathf.dst(bulletX, bulletY, mount.aimX, mount.aimY) / bullet.range) : 1f,
         angle = angleOffset + shootAngle + Mathf.range(inaccuracy + bullet.inaccuracy);
 
-        mount.bullet = bullet.create(unit, unit.team, bulletX, bulletY, angle, -1f, (1f - velocityRnd) + Mathf.random(velocityRnd), lifeScl, null, mover, mount.aimX, mount.aimY);
+        Entityc shooter = unit.controller() instanceof MissileAI ai ? ai.shooter : unit; //Pass the missile's shooter down to its bullets
+        mount.bullet = bullet.create(unit, shooter, unit.team, bulletX, bulletY, angle, -1f, (1f - velocityRnd) + Mathf.random(velocityRnd), lifeScl, null, mover, mount.aimX, mount.aimY);
         handleBullet(unit, mount, mount.bullet);
 
         if(!continuous){


### PR DESCRIPTION
- Pass a shooter separate to owner into `BulletType#create`. `killShooter` kills the `owner` while the `shooter` is passed into the missile ai
- `killShooter` no longer kills already dead units
- `MissileAI` no longer aims at shooter's aim pos if the shooter is dead

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
  - [X] Missile-shooting units do not kill themselves
  - [X] Case 1: Missile unit's weapon's bullet is another missile unit.
    - `UnitTypes.disrupt.weapons.first().bullet.spawnUnit.weapons.first().bullet = UnitTypes.quell.weapons.first().bullet`
    - Spawned units follow the original disrupt's aim.
  - [X] Case 2: Missile unit's weapon's bullet's frags produce missile units.
    - `UnitTypes.disrupt.weapons.first().bullet.spawnUnit.weapons.first().bullet.fragBullet = UnitTypes.quell.weapons.first().bullet`
    - Spawned units do not follow the original disrupt's aim, but also do not track towards 0, 0 anymore.
      - Since the bullet's owner is the missile, it then passes that missile down as the next missile's shooter, however since I made `MissileAI` not rotate towards aim pos if the shooter is dead, it does not track toward 0, 0.