### PR TITLE
Interval bullets for continuous bullets

### DIFF
--- a/core/src/mindustry/entities/bullet/ContinuousBulletType.java
+++ b/core/src/mindustry/entities/bullet/ContinuousBulletType.java
@@ -74,6 +74,8 @@ public class ContinuousBulletType extends BulletType{
         if(shake > 0){
             Effect.shake(shake, shake, b);
         }
+
+        updateBulletInterval(b);
     }
 
     public void applyDamage(Bullet b){

--- a/core/src/mindustry/entities/bullet/PointLaserBulletType.java
+++ b/core/src/mindustry/entities/bullet/PointLaserBulletType.java
@@ -75,7 +75,9 @@ public class PointLaserBulletType extends BulletType{
 
     @Override
     public void update(Bullet b){
-        super.update(b);
+        updateTrail(b);
+        updateTrailEffects(b);
+        updateBulletInterval(b);
 
         if(b.timer.get(0, damageInterval)){
             Damage.collidePoint(b, b.team, hitEffect, b.aimX, b.aimY);
@@ -113,6 +115,15 @@ public class PointLaserBulletType extends BulletType{
             }
             b.trail.length = trailLength;
             b.trail.update(b.aimX, b.aimY, b.fslope() * (1f - (trailSinMag > 0 ? Mathf.absin(Time.time, trailSinScl, trailSinMag) : 0f)));
+        }
+    }
+
+    public void updateBulletInterval(Bullet b){
+        if(intervalBullet != null && b.time >= intervalDelay && b.timer.get(2, bulletInterval)){
+            float ang = b.rotation();
+            for(int i = 0; i < intervalBullets; i++){
+                intervalBullet.create(b, b.aimX, b.aimY, ang + Mathf.range(intervalRandomSpread) + intervalAngle + ((i - (intervalBullets - 1f)/2f) * intervalSpread));
+            }
         }
     }
 }


### PR DESCRIPTION
`ContinuousBulletType`s now spawn interval bullets, and `PointLaserBulletType` interval bullets now spawn at the tip instead of at the base.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
