### PR TITLE
Fix Liquid Icon Scaling on Objective Dialogs

### DIFF
--- a/core/src/mindustry/editor/MapObjectivesDialog.java
+++ b/core/src/mindustry/editor/MapObjectivesDialog.java
@@ -98,7 +98,7 @@ public class MapObjectivesDialog extends BaseDialog{
         setInterpreter(UnlockableContent.class, (cont, name, type, field, remover, indexer, get, set) -> {
             name(cont, name, remover, indexer);
             cont.table(t -> t.left().button(
-                b -> b.image().size(iconSmall).update(i -> i.setDrawable(get.get().uiIcon)),
+                b -> b.image().size(iconSmall).scaling(Scaling.fit).update(i -> i.setDrawable(get.get().uiIcon)),
                 () -> showContentSelect(null, set, b -> (field != null && !field.isAnnotationPresent(Researchable.class)) || b.techNode != null)
             ).fill().pad(4)).growX().fillY();
         });
@@ -505,7 +505,7 @@ public class MapObjectivesDialog extends BaseDialog{
                 content.getBy(type).<UnlockableContent>as()
             )){
                 if(content.isHidden() || !check.get((T)content)) continue;
-                t.image(content == Blocks.air ? Icon.none.getRegion() : content.uiIcon).size(iconMed).pad(3)
+                t.image(content == Blocks.air ? Icon.none.getRegion() : content.uiIcon).size(iconMed).pad(3).scaling(Scaling.fit)
                     .with(b -> b.addListener(new HandCursorListener()))
                     .tooltip(content.localizedName).get().clicked(() -> {
                         cons.get((T)content);


### PR DESCRIPTION
Fixes stretched icons seen in the `Obtain` objective's content selector.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
