### PR TITLE
Allow Universe to update all solar systems

### DIFF
--- a/core/src/mindustry/game/Universe.java
+++ b/core/src/mindustry/game/Universe.java
@@ -38,8 +38,10 @@ public class Universe{
 
     /** Update regardless of whether the player is in the campaign. */
     public void updateGlobal(){
-        //currently only updates one solar system
-        updatePlanet(Planets.sun);
+        for(Planet planet : content.planets()){
+            //update all parentless planets (solar system root), regardless of which one the player is in
+            if(planet.parent == null) updatePlanet(planet);
+        }
     }
 
     public int turn(){


### PR DESCRIPTION
Allow `Universe` to, instead of updating just `Planets.sun`, update all planets that have no `parent`.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
