### PR TITLE
Make PlayerInfo map public

### DIFF
--- a/core/src/mindustry/net/Administration.java
+++ b/core/src/mindustry/net/Administration.java
@@ -26,8 +26,8 @@ public class Administration{
 
 
     private boolean modified, loaded;
-    /** All player info. Maps UUIDs to info. This persists throughout restarts. Do not access directly. */
-    private ObjectMap<String, PlayerInfo> playerInfo = new ObjectMap<>();
+    /** All player info. Maps UUIDs to info. This persists throughout restarts. Do not modify directly. */
+    public ObjectMap<String, PlayerInfo> playerInfo = new ObjectMap<>();
 
     public Administration(){
         load();


### PR DESCRIPTION
Because I'm tired of using Reflect to access it (for example, to find a PlayerInfo by USID)

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
