### PR TITLE
Update README.md with download widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![Logo](core/assets-raw/sprites/ui/logo.png)
 
 [![Build Status](https://github.com/Anuken/Mindustry/workflows/Tests/badge.svg?event=push)](https://github.com/Anuken/Mindustry/actions)
+[![Mindustry Downloads](https://www.appbrain.com/shield/io.anuke.mindustry.svg)](https://www.appbrain.com/app/mindustry/io.anuke.mindustry)
 [![Discord](https://img.shields.io/discord/391020510269669376.svg?logo=discord&logoColor=white&logoWidth=20&labelColor=7289DA&label=Discord&color=17cf48)](https://discord.gg/mindustry)  
 
 The automation tower defense RTS, written in Java.


### PR DESCRIPTION
Via AppBrain it's now possible to have a shield widget that shows the current download count and I thought that would be great to show on the first page so people can see how popular Mindustry is.

It looks like this:

![image](https://github.com/Anuken/Mindustry/assets/118610/73da4feb-6f2c-47b6-bb39-268376d264dd)

(no code changes so no tests done)
