### PR TITLE
Fix Anuken/Mindustry#8718

### DIFF
--- a/core/src/mindustry/input/MobileInput.java
+++ b/core/src/mindustry/input/MobileInput.java
@@ -415,7 +415,7 @@ public class MobileInput extends InputHandler implements GestureListener{
 
             //draw last placed plan
             if(!plan.breaking && plan == lastPlaced && plan.block != null){
-                int rot = block.planRotation(rotation);
+                int rot = plan.block.planRotation(rotation);
                 boolean valid = validPlace(tile.x, tile.y, plan.block, rot);
                 Draw.mixcol();
                 plan.block.drawPlace(tile.x, tile.y, rot, valid);


### PR DESCRIPTION
reference to DesktopInput.block is probably accidental
reasoning: it doesn't make much sense to get the plan rotation from that block in a loop through all plans, and that variable is not referenced in any nearby code

not tested because 📵

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
