### PR TITLE
Fix aegires field ability

### DIFF
--- a/core/src/mindustry/entities/Units.java
+++ b/core/src/mindustry/entities/Units.java
@@ -408,7 +408,7 @@ public class Units{
         if(team != null){
             team.data().tree().intersect(x, y, width, height, cons);
         }else{
-            for(var other : state.teams.getActive()){
+            for(var other : state.teams.present){
                 other.tree().intersect(x, y, width, height, cons);
             }
         }


### PR DESCRIPTION
So basically it iterates all units of active team, ignoring all other units (for example, when Rules.canGameOver = false)

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
