### PR TITLE
Use Base64 to Encode schematic filename

### DIFF
--- a/core/src/mindustry/game/Schematics.java
+++ b/core/src/mindustry/game/Schematics.java
@@ -36,6 +36,8 @@ import mindustry.world.blocks.storage.CoreBlock.*;
 import mindustry.world.meta.*;
 
 import java.io.*;
+import java.nio.charset.*;
+import java.util.*;
 import java.util.zip.*;
 
 import static mindustry.Vars.*;
@@ -136,6 +138,10 @@ public class Schematics implements Loadable{
 
         try{
             Schematic s = read(file);
+            String expectedFilename = Base64.getUrlEncoder().encodeToString(s.name().getBytes(StandardCharsets.UTF_8));
+            if(!file.file().getName().split("_")[0].equals(expectedFilename)){//check if filename is compliant
+                file.moveTo(findFile(expectedFilename));
+            }
             all.add(s);
             checkLoadout(s, true);
 


### PR DESCRIPTION
Some "unsafe" strings would be replaced with the same form. For example, “啊” and 额" would be replaced with "_", this may cause some problems in opera schematic files manually. So, use Base64 to encode filename and this also avoid "finding file" for many times.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
