### PR TITLE
Allow fluid type configuration for ConsumeCoolant

### DIFF
--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -995,6 +995,10 @@ public class Block extends UnlockableContent implements Senseable{
         return consume(new ConsumeCoolant(amount));
     }
 
+    public ConsumeCoolant consumeCoolant(float amount, boolean allowLiquid, boolean allowGas){
+        return consume(new ConsumeCoolant(amount, allowLiquid, allowGas));
+    }
+
     public <T extends Consume> T consume(T consume){
         if(consume instanceof ConsumePower){
             //there can only be one power consumer

--- a/core/src/mindustry/world/consumers/ConsumeCoolant.java
+++ b/core/src/mindustry/world/consumers/ConsumeCoolant.java
@@ -3,9 +3,10 @@ package mindustry.world.consumers;
 /** A ConsumeLiquidFilter that consumes specific coolant, selected based on stats. */
 public class ConsumeCoolant extends ConsumeLiquidFilter{
     public float maxTemp = 0.5f, maxFlammability = 0.1f;
+    public boolean allowLiquid = true, allowGas = false;
 
     public ConsumeCoolant(float amount){
-        this.filter = liquid -> liquid.coolant && !liquid.gas && liquid.temperature <= maxTemp && liquid.flammability < maxFlammability;
+        this.filter = liquid -> liquid.coolant && (allowLiquid && !liquid.gas || allowGas && liquid.gas) && liquid.temperature <= maxTemp && liquid.flammability < maxFlammability;
         this.amount = amount;
     }
 

--- a/core/src/mindustry/world/consumers/ConsumeCoolant.java
+++ b/core/src/mindustry/world/consumers/ConsumeCoolant.java
@@ -5,9 +5,16 @@ public class ConsumeCoolant extends ConsumeLiquidFilter{
     public float maxTemp = 0.5f, maxFlammability = 0.1f;
     public boolean allowLiquid = true, allowGas = false;
 
-    public ConsumeCoolant(float amount){
-        this.filter = liquid -> liquid.coolant && (allowLiquid && !liquid.gas || allowGas && liquid.gas) && liquid.temperature <= maxTemp && liquid.flammability < maxFlammability;
+    public ConsumeCoolant(float amount, boolean allowLiquid, boolean allowGas){
+        this.allowLiquid = allowLiquid;
+        this.allowGas = allowGas;
+
+        this.filter = liquid -> liquid.coolant && (this.allowLiquid && !liquid.gas || this.allowGas && liquid.gas) && liquid.temperature <= maxTemp && liquid.flammability < maxFlammability;
         this.amount = amount;
+    }
+    
+    public ConsumeCoolant(float amount){
+        this(amount, true, false);
     }
 
     public ConsumeCoolant(){


### PR DESCRIPTION
Allows deciding what kinds of fluids can be used as coolant.

![image](https://github.com/Anuken/Mindustry/assets/54301439/a3ce2415-dfa8-4ed4-81a7-17542abc8685)

---

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
