### PR TITLE
Bullet despawn unit shenanigans

### DIFF
--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -493,13 +493,11 @@ public class BulletType extends Content implements Cloneable{
     }
 
     public void createUnits(Bullet b, float x, float y){
-        if(Mathf.chance(despawnUnitChance)){
-            if(despawnUnit != null){
-                for(int i = 0; i < despawnUnitCount; i++){
-                    Tmp.v1.rnd(Mathf.random(despawnUnitRadius));
-                    var u = despawnUnit.spawn(b.team, x + Tmp.v1.x, y + Tmp.v1.y);
-                    u.rotation = faceOutwards ? Tmp.v1.angle() : b.rotation();
-                }
+        if(despawnUnit != null && Mathf.chance(despawnUnitChance)){
+            for(int i = 0; i < despawnUnitCount; i++){
+                Tmp.v1.rnd(Mathf.random(despawnUnitRadius));
+                var u = despawnUnit.spawn(b.team, x + Tmp.v1.x, y + Tmp.v1.y);
+                u.rotation = faceOutwards ? Tmp.v1.angle() : b.rotation();
             }
         }
     }

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -194,6 +194,8 @@ public class BulletType extends Content implements Cloneable{
     public @Nullable UnitType spawnUnit;
     /** Unit spawned when this bullet hits something or despawns due to it hitting the end of its lifetime. */
     public @Nullable UnitType despawnUnit;
+    /** The chance for despawn units to spawn. */
+    public float despawnUnitChance = 1;
     /** Amount of units spawned when this bullet despawns. */
     public int despawnUnitCount = 1;
     /** Random offset distance from the original bullet despawn/hit coordinate. */
@@ -491,11 +493,13 @@ public class BulletType extends Content implements Cloneable{
     }
 
     public void createUnits(Bullet b, float x, float y){
-        if(despawnUnit != null){
-            for(int i = 0; i < despawnUnitCount; i++){
-                Tmp.v1.rnd(Mathf.random(despawnUnitRadius));
-                var u = despawnUnit.spawn(b.team, x + Tmp.v1.x, y + Tmp.v1.y);
-                u.rotation = faceOutwards ? Tmp.v1.angle() : b.rotation();
+        if(Mathf.chance(despawnUnitChance)){
+            if(despawnUnit != null){
+                for(int i = 0; i < despawnUnitCount; i++){
+                    Tmp.v1.rnd(Mathf.random(despawnUnitRadius));
+                    var u = despawnUnit.spawn(b.team, x + Tmp.v1.x, y + Tmp.v1.y);
+                    u.rotation = faceOutwards ? Tmp.v1.angle() : b.rotation();
+                }
             }
         }
     }

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -198,6 +198,8 @@ public class BulletType extends Content implements Cloneable{
     public int despawnUnitCount = 1;
     /** Random offset distance from the original bullet despawn/hit coordinate. */
     public float despawnUnitRadius = 0.1f;
+    /** If true, units spawned when this bullet despawns face away from the bullet instead of the same direction as the bullet. */
+    public boolean faceOutwards = false;
     /** Extra visual parts for this bullet. */
     public Seq<DrawPart> parts = new Seq<>();
 
@@ -491,7 +493,9 @@ public class BulletType extends Content implements Cloneable{
     public void createUnits(Bullet b, float x, float y){
         if(despawnUnit != null){
             for(int i = 0; i < despawnUnitCount; i++){
-                despawnUnit.spawn(b.team, x + Mathf.range(despawnUnitRadius), y + Mathf.range(despawnUnitRadius));
+                Tmp.v1.rnd(Mathf.random(despawnUnitRadius));
+                var u = despawnUnit.spawn(b.team, x + Tmp.v1.x, y + Tmp.v1.y);
+                u.rotation = faceOutwards ? Tmp.v1.angle() : b.rotation();
             }
         }
     }


### PR DESCRIPTION
- Proper bullet despawn unit facing direction.
  - Similar to `SpawnDeathAbility` with a `faceOutward` boolean.
- `despawnUnitChance` - A chance to spawn the despawn units.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
