### PR TITLE
Weird bullet creation things

### DIFF
--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -125,6 +125,10 @@ public class BulletType extends Content implements Cloneable{
     /** Whether to move the bullet back depending on delta to fix some delta-time related issues.
      * Do not change unless you know what you're doing. */
     public boolean backMove = true;
+    /** If true, the angle param in create is ignored. */
+    public boolean ignoreSpawnAngle = false;
+    /** Chance for this bullet to be created. */
+    public float createChance = 1;
     /** Bullet range positive override. */
     public float maxRange = -1f;
     /** When > 0, overrides range even if smaller than base range. */
@@ -730,6 +734,8 @@ public class BulletType extends Content implements Cloneable{
     }
 
     public @Nullable Bullet create(@Nullable Entityc owner, @Nullable Entityc shooter, Team team, float x, float y, float angle, float damage, float velocityScl, float lifetimeScl, Object data, @Nullable Mover mover, float aimX, float aimY){
+        if(!Mathf.chance(createChance)) return null;
+        if(ignoreSpawnAngle) angle = 0;
         if(spawnUnit != null){
             //don't spawn units clientside!
             if(!net.client()){


### PR DESCRIPTION
- `createChance`: Chance for the bullet to be spawned.
- `ignoreSpawnAngle`: If true, the spawn angle is always set to 0.

I don't know why Blu wants this (I especially don't see the use case with the second one) but it's something to keep my occupied so I might as well do it.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
