### PR TITLE
Aegires Nerf

### DIFF
--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -2159,7 +2159,7 @@ public class UnitTypes{
                 weapons.add(new PointDefenseWeapon("point-defense-mount"){{
                     x = 12.5f;
                     y = mountY;
-                    reload = 6f;
+                    reload = 4f;
                     targetInterval = 8f;
                     targetSwitchInterval = 8f;
 
@@ -2167,7 +2167,7 @@ public class UnitTypes{
                         shootEffect = Fx.sparkShoot;
                         hitEffect = Fx.pointHit;
                         maxRange = 180f;
-                        damage = 25f;
+                        damage = 30f;
                     }};
                 }});
             }

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -2153,7 +2153,8 @@ public class UnitTypes{
             abilities.add(new EnergyFieldAbility(40f, 65f, 180f){{
                 statusDuration = 60f * 6f;
                 maxTargets = 25;
-                healPercent = 1f;
+                healPercent = 1.5f;
+                sameTypeHealMult = 0.5f;
             }});
 
             for(float mountY : new float[]{-18f, 14}){

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -2153,7 +2153,7 @@ public class UnitTypes{
             abilities.add(new EnergyFieldAbility(40f, 65f, 180f){{
                 statusDuration = 60f * 6f;
                 maxTargets = 25;
-                healPercent = 1f
+                healPercent = 1f;
             }});
 
             for(float mountY : new float[]{-18f, 14}){

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -2153,6 +2153,7 @@ public class UnitTypes{
             abilities.add(new EnergyFieldAbility(40f, 65f, 180f){{
                 statusDuration = 60f * 6f;
                 maxTargets = 25;
+                healPercent = 1f
             }});
 
             for(float mountY : new float[]{-18f, 14}){

--- a/core/src/mindustry/entities/abilities/EnergyFieldAbility.java
+++ b/core/src/mindustry/entities/abilities/EnergyFieldAbility.java
@@ -29,6 +29,8 @@ public class EnergyFieldAbility extends Ability{
     public boolean targetGround = true, targetAir = true, hitBuildings = true, hitUnits = true;
     public int maxTargets = 25;
     public float healPercent = 3f;
+    /** Multiplies healing to units of the same type by this amount. */
+    public float sameTypeHealMult = 1f;
 
     public float layer = Layer.bullet - 0.001f, blinkScl = 20f, blinkSize = 0.1f;
     public float effectRadius = 5f, sectorRad = 0.14f, rotateSpeed = 0.5f;
@@ -129,7 +131,8 @@ public class EnergyFieldAbility extends Ability{
                 if(((Teamc)other).team() == unit.team){
                     if(other.damaged()){
                         anyNearby = true;
-                        other.heal(healPercent / 100f * other.maxHealth());
+                        float healMult = (other instanceof Unit u && u.type == unit.type) ? sameTypeHealMult : 1f;
+                        other.heal(healPercent / 100f * other.maxHealth() * healMult);
                         healEffect.at(other);
                         damageEffect.at(rx, ry, 0f, color, other);
                         hitEffect.at(rx, ry, unit.angleTo(other), color);

--- a/core/src/mindustry/entities/abilities/EnergyFieldAbility.java
+++ b/core/src/mindustry/entities/abilities/EnergyFieldAbility.java
@@ -28,7 +28,7 @@ public class EnergyFieldAbility extends Ability{
     public float x, y;
     public boolean targetGround = true, targetAir = true, hitBuildings = true, hitUnits = true;
     public int maxTargets = 25;
-    public float healPercent = 1f;
+    public float healPercent = 3f;
 
     public float layer = Layer.bullet - 0.001f, blinkScl = 20f, blinkSize = 0.1f;
     public float effectRadius = 5f, sectorRad = 0.14f, rotateSpeed = 0.5f;

--- a/core/src/mindustry/entities/abilities/EnergyFieldAbility.java
+++ b/core/src/mindustry/entities/abilities/EnergyFieldAbility.java
@@ -28,7 +28,7 @@ public class EnergyFieldAbility extends Ability{
     public float x, y;
     public boolean targetGround = true, targetAir = true, hitBuildings = true, hitUnits = true;
     public int maxTargets = 25;
-    public float healPercent = 3f;
+    public float healPercent = 1f;
 
     public float layer = Layer.bullet - 0.001f, blinkScl = 20f, blinkSize = 0.1f;
     public float effectRadius = 5f, sectorRad = 0.14f, rotateSpeed = 0.5f;


### PR DESCRIPTION
Nerfed healing (3% to 1.5% on non-aegires, 0.5% on aegires) because 3% resulted in large groups of aegires healing eachother faster than damage (from endgame, surge tier defenses (aegires is phase tier)) could be dealt, 1 omura (a T5) has large issues trying to kill 2 aegires (T4s) when the healing is 3%
Buffed segments (reload 6 frames to 4 frames, 25 damage to 30 damage)
This is because aegires are overpowered as hell when in groups

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
