### PR TITLE
Make liquid routers unable to be picked up

### DIFF
--- a/core/src/mindustry/world/blocks/liquid/LiquidRouter.java
+++ b/core/src/mindustry/world/blocks/liquid/LiquidRouter.java
@@ -29,6 +29,11 @@ public class LiquidRouter extends LiquidBlock{
         }
 
         @Override
+        public boolean canPickup(){
+            return false;
+        }
+        
+        @Override
         public void draw(){
             Draw.rect(bottomRegion, x, y);
 


### PR DESCRIPTION
it's easy for erekir core units to kill any enemy, even without any turret or unit. it carries a liquid container full of ozone, and bombing the ground super quickly.even the collaris can only afford once, and dies in the second bomb.

it happens samely on mega and oil.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
