### PR TITLE
let DrawRegion drawer can draw regions rotate with building rotation

### DIFF
--- a/core/src/mindustry/world/draw/DrawRegion.java
+++ b/core/src/mindustry/world/draw/DrawRegion.java
@@ -41,9 +41,9 @@ public class DrawRegion extends DrawBlock{
         float z = Draw.z();
         if(layer > 0) Draw.z(layer);
         if(spinSprite){
-            Drawf.spinSprite(region, build.x + x, build.y + y, build.totalProgress() * rotateSpeed + rotation + buildingRotate ? build.rotdeg() : 0);
+            Drawf.spinSprite(region, build.x + x, build.y + y, build.totalProgress() * rotateSpeed + rotation + (buildingRotate ? build.rotdeg() : 0));
         }else{
-            Draw.rect(region, build.x + x, build.y + y, build.totalProgress() * rotateSpeed + rotation + buildingRotate ? build.rotdeg() : 0);
+            Draw.rect(region, build.x + x, build.y + y, build.totalProgress() * rotateSpeed + rotation + (buildingRotate ? build.rotdeg() : 0));
         }
         Draw.z(z);
     }

--- a/core/src/mindustry/world/draw/DrawRegion.java
+++ b/core/src/mindustry/world/draw/DrawRegion.java
@@ -51,7 +51,7 @@ public class DrawRegion extends DrawBlock{
     @Override
     public void drawPlan(Block block, BuildPlan plan, Eachable<BuildPlan> list){
         if(!drawPlan) return;
-        Draw.rect(region, plan.drawx(), plan.drawy(),  buildingRotate ? plan.rotation * 90f : 0);
+        Draw.rect(region, plan.drawx(), plan.drawy(), (buildingRotate ? plan.rotation * 90f : 0));
     }
 
     @Override

--- a/core/src/mindustry/world/draw/DrawRegion.java
+++ b/core/src/mindustry/world/draw/DrawRegion.java
@@ -13,6 +13,7 @@ public class DrawRegion extends DrawBlock{
     public String suffix = "";
     public boolean spinSprite = false;
     public boolean drawPlan = true;
+    public boolean buildingRotate = false;
     public float rotateSpeed, x, y, rotation;
     /** Any number <=0 disables layer changes. */
     public float layer = -1;
@@ -40,9 +41,9 @@ public class DrawRegion extends DrawBlock{
         float z = Draw.z();
         if(layer > 0) Draw.z(layer);
         if(spinSprite){
-            Drawf.spinSprite(region, build.x + x, build.y + y, build.totalProgress() * rotateSpeed + rotation);
+            Drawf.spinSprite(region, build.x + x, build.y + y, build.totalProgress() * rotateSpeed + rotation + buildingRotate ? build.rotdeg() : 0);
         }else{
-            Draw.rect(region, build.x + x, build.y + y, build.totalProgress() * rotateSpeed + rotation);
+            Draw.rect(region, build.x + x, build.y + y, build.totalProgress() * rotateSpeed + rotation + buildingRotate ? build.rotdeg() : 0);
         }
         Draw.z(z);
     }
@@ -50,7 +51,7 @@ public class DrawRegion extends DrawBlock{
     @Override
     public void drawPlan(Block block, BuildPlan plan, Eachable<BuildPlan> list){
         if(!drawPlan) return;
-        Draw.rect(region, plan.drawx(), plan.drawy());
+        Draw.rect(region, plan.drawx(), plan.drawy(),  buildingRotate ? plan.rotation * 90f : 0);
     }
 
     @Override


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

create a variable buildingRotate that can select whether the region will rotate with building rotation or not
make modders needn't to use DrawSideRegion to make this effect

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
