### PR TITLE
add `@server` to logic

### DIFF
--- a/core/src/mindustry/logic/GlobalVars.java
+++ b/core/src/mindustry/logic/GlobalVars.java
@@ -27,7 +27,7 @@ public class GlobalVars{
     public static final Rand rand = new Rand();
 
     //non-constants that depend on state
-    private static int varTime, varTick, varSecond, varMinute, varWave, varWaveTime, varMaster;
+    private static int varTime, varTick, varSecond, varMinute, varWave, varWaveTime, varServer;
 
     private ObjectIntMap<String> namesToIds = new ObjectIntMap<>();
     private Seq<Var> vars = new Seq<>(Var.class);
@@ -56,7 +56,7 @@ public class GlobalVars{
         varWave = put("@waveNumber", 0);
         varWaveTime = put("@waveTime", 0);
 
-        varMaster = put("@master", 0);
+        varMaster = put("@server", 0);
 
         //special enums
         put("@ctrlProcessor", ctrlProcessor);
@@ -151,7 +151,7 @@ public class GlobalVars{
         vars.items[varWaveTime].numval = state.wavetime / 60f;
 
         //network
-        vars.items[varMaster].numval = (net.server() || !net.active()) ? 1 : 0;
+        vars.items[varServer].numval = (net.server() || !net.active()) ? 1 : 0;
     }
 
     /** @return a piece of content based on its logic ID. This is not equivalent to content ID. */

--- a/core/src/mindustry/logic/GlobalVars.java
+++ b/core/src/mindustry/logic/GlobalVars.java
@@ -27,7 +27,7 @@ public class GlobalVars{
     public static final Rand rand = new Rand();
 
     //non-constants that depend on state
-    private static int varTime, varTick, varSecond, varMinute, varWave, varWaveTime;
+    private static int varTime, varTick, varSecond, varMinute, varWave, varWaveTime, varMaster;
 
     private ObjectIntMap<String> namesToIds = new ObjectIntMap<>();
     private Seq<Var> vars = new Seq<>(Var.class);
@@ -55,6 +55,8 @@ public class GlobalVars{
         varMinute = put("@minute", 0);
         varWave = put("@waveNumber", 0);
         varWaveTime = put("@waveTime", 0);
+
+        varMaster = put("@master", 0);
 
         //special enums
         put("@ctrlProcessor", ctrlProcessor);
@@ -147,6 +149,9 @@ public class GlobalVars{
         //wave state
         vars.items[varWave].numval = state.wave;
         vars.items[varWaveTime].numval = state.wavetime / 60f;
+
+        //network
+        vars.items[varMaster].numval = (Vars.net.server() || !Vars.net.active()) ? 1 : 0;
     }
 
     /** @return a piece of content based on its logic ID. This is not equivalent to content ID. */

--- a/core/src/mindustry/logic/GlobalVars.java
+++ b/core/src/mindustry/logic/GlobalVars.java
@@ -151,7 +151,7 @@ public class GlobalVars{
         vars.items[varWaveTime].numval = state.wavetime / 60f;
 
         //network
-        vars.items[varMaster].numval = (Vars.net.server() || !Vars.net.active()) ? 1 : 0;
+        vars.items[varMaster].numval = (net.server() || !net.active()) ? 1 : 0;
     }
 
     /** @return a piece of content based on its logic ID. This is not equivalent to content ID. */

--- a/core/src/mindustry/logic/GlobalVars.java
+++ b/core/src/mindustry/logic/GlobalVars.java
@@ -56,7 +56,7 @@ public class GlobalVars{
         varWave = put("@waveNumber", 0);
         varWaveTime = put("@waveTime", 0);
 
-        varMaster = put("@server", 0);
+        varServer = put("@server", 0);
 
         //special enums
         put("@ctrlProcessor", ctrlProcessor);


### PR DESCRIPTION
**@server**: means server, room owner, local

There are many logic operations only work in server, like `setblock`.  
And it's useful to sync variables with `syncI` with such pattern.  
```js
//init variables
while (true) {
    if (@server) {
        //read memory
        //operation
    }
    //sync
    //display and write memory
}
```

---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
