### PR TITLE
(draft) StatusEffect with level

### DIFF
--- a/core/src/mindustry/content/StatusEffects.java
+++ b/core/src/mindustry/content/StatusEffects.java
@@ -25,10 +25,10 @@ public class StatusEffects{
 
             init(() -> {
                 opposite(wet, freezing);
-                affinity(tarred, (unit, result, time) -> {
-                    unit.damagePierce(transitionDamage);
+                affinity(tarred, (unit, result, time, level) -> {
+                    unit.damagePierce(transitionDamage * (result.level + level) / 2);
                     Fx.burning.at(unit.x + Mathf.range(unit.bounds() / 2f), unit.y + Mathf.range(unit.bounds() / 2f));
-                    result.set(burning, Math.min(time + result.time, 300f));
+                    result.set(burning, Math.min(time + result.time, 300f), Math.max(result.level, level));
                 });
             });
         }};
@@ -43,8 +43,8 @@ public class StatusEffects{
             init(() -> {
                 opposite(melting, burning);
 
-                affinity(blasted, (unit, result, time) -> {
-                    unit.damagePierce(transitionDamage);
+                affinity(blasted, (unit, result, time, level) -> {
+                    unit.damagePierce(transitionDamage * (result.level + level) / 2);
                     if(unit.team == state.rules.waveTeam){
                         Events.fire(Trigger.blastFreeze);
                     }
@@ -79,11 +79,11 @@ public class StatusEffects{
             transitionDamage = 14;
 
             init(() -> {
-                affinity(shocked, (unit, result, time) -> {
+                affinity(shocked, (unit, result, time, level) -> {
                     float pierceFraction = 0.3f;
 
-                    unit.damagePierce(transitionDamage * pierceFraction);
-                    unit.damage(transitionDamage * (1f - pierceFraction));
+                    unit.damagePierce(transitionDamage * (result.level + level) / 2 * pierceFraction);
+                    unit.damage(transitionDamage * (result.level + level) / 2 * (1f - pierceFraction));
                     if(unit.team == state.rules.waveTeam){
                         Events.fire(Trigger.shock);
                     }
@@ -109,10 +109,10 @@ public class StatusEffects{
 
             init(() -> {
                 opposite(wet, freezing);
-                affinity(tarred, (unit, result, time) -> {
-                    unit.damagePierce(8f);
+                affinity(tarred, (unit, result, time, level) -> {
+                    unit.damagePierce(8f * (result.level + level) / 2);
                     Fx.burning.at(unit.x + Mathf.range(unit.bounds() / 2f), unit.y + Mathf.range(unit.bounds() / 2f));
-                    result.set(melting, Math.min(time + result.time, 200f));
+                    result.set(melting, Math.min(time + result.time, 200f), Math.max(result.level, level));
                 });
             });
         }};
@@ -146,8 +146,8 @@ public class StatusEffects{
             effect = Fx.oily;
 
             init(() -> {
-                affinity(melting, (unit, result, time) -> result.set(melting, result.time + time));
-                affinity(burning, (unit, result, time) -> result.set(burning, result.time + time));
+                affinity(melting, (unit, result, time, level) -> result.set(melting, result.time + time, Math.max(result.level, level)));
+                affinity(burning, (unit, result, time, level) -> result.set(burning, result.time + time, Math.max(result.level, level)));
             });
         }};
 

--- a/core/src/mindustry/entities/units/StatusEntry.java
+++ b/core/src/mindustry/entities/units/StatusEntry.java
@@ -5,10 +5,16 @@ import mindustry.type.*;
 public class StatusEntry{
     public StatusEffect effect;
     public float time;
+    public int level;
 
     public StatusEntry set(StatusEffect effect, float time){
+        return set(effect, time, 1);
+    }
+
+    public StatusEntry set(StatusEffect effect, float time, int level){
         this.effect = effect;
         this.time = time;
+        this.level = level;
         return this;
     }
 }


### PR DESCRIPTION
StatusEffect with `level` like `duration`.  Like `Fast II` `QuickBuild IV` which act like 4*Status

Also statusEffect like `burning` can damage `damage*level`.
Allow procssor and mods to do more modify to single unit.

TODO:
* `TypeIO` and Backwards compatibility
* may provide some base status like `Attack` `QuickReload` `QuickBuild`.
---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
