### PR TITLE
Unnecessary Drawer Icon Adding

### DIFF
--- a/core/src/mindustry/world/draw/DrawBlock.java
+++ b/core/src/mindustry/world/draw/DrawBlock.java
@@ -44,7 +44,7 @@ public abstract class DrawBlock{
 
     /** @return the generated icons to be used for this block. */
     public TextureRegion[] icons(Block block){
-        return new TextureRegion[]{block.region};
+        return new TextureRegion[]{};
     }
 
     public final TextureRegion[] finalIcons(Block block){

--- a/core/src/mindustry/world/draw/DrawBlock.java
+++ b/core/src/mindustry/world/draw/DrawBlock.java
@@ -55,7 +55,8 @@ public abstract class DrawBlock{
             }
             return out;
         }
-        return icons(block);
+        TextureRegion[] icons = icons(block);
+        return icons.length == 0 ? new TextureRegion[]{Core.atlas.find("error")} : icons;
     }
 
     public GenericCrafter expectCrafter(Block block){

--- a/core/src/mindustry/world/draw/DrawDefault.java
+++ b/core/src/mindustry/world/draw/DrawDefault.java
@@ -17,4 +17,9 @@ public class DrawDefault extends DrawBlock{
     public void drawPlan(Block block, BuildPlan plan, Eachable<BuildPlan> list){
         block.drawDefaultPlanRegion(plan, list);
     }
+
+    @Override
+    public TextureRegion[] icons(Block block){
+        return new TextureRegion[]{block.region};
+    }
 }

--- a/core/src/mindustry/world/draw/DrawLiquidOutputs.java
+++ b/core/src/mindustry/world/draw/DrawLiquidOutputs.java
@@ -53,10 +53,4 @@ public class DrawLiquidOutputs extends DrawBlock{
             }
         }
     }
-
-    //can't display these properly
-    @Override
-    public TextureRegion[] icons(Block block){
-        return new TextureRegion[]{};
-    }
 }


### PR DESCRIPTION
It doesn't make sense for drawers like `DrawLiquidTile` to return the block's region in its icons. Overriding in every such class doesn't make as much sense as simply changing the superclass. Since `icons(Block block)` now returns an empty array by default unless overridden, an extra check was added to `finalIcons(Block block)` to ensure that there's at least one region in the array.

---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
