### PR TITLE
Don't destroyToDerelict privileged blocks

### DIFF
--- a/core/assets/contributors
+++ b/core/assets/contributors
@@ -161,3 +161,4 @@ SITUVNgcd
 Gabriel "red" Fondato
 Yoru Kitsune
 OpalSoPL
+BalaM314

--- a/core/src/mindustry/game/Teams.java
+++ b/core/src/mindustry/game/Teams.java
@@ -309,7 +309,7 @@ public class Teams{
             for(var b : builds){
                 if(b instanceof CoreBuild){
                     b.kill();
-                }else{
+                }else if(!b.block.privileged){
                     scheduleDerelict(b);
                 }
             }
@@ -331,7 +331,7 @@ public class Teams{
             }
 
             for(var build : builds){
-                if(build.within(x, y, range)){
+                if(build.within(x, y, range) && !build.block.privileged){
                     scheduleDerelict(build);
                 }
             }


### PR DESCRIPTION
Don't want world procs getting yeeted after a team dies in pvp
![image](https://github.com/Anuken/Mindustry/assets/71201189/71a96ac0-9848-44ee-bfda-ab01d3cb36ff)

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
