### PR TITLE
Optimize `wait`/`message`

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -48,6 +48,7 @@ public class LExecutor{
     public Var[] vars = {};
     public Var counter;
     public int[] binds;
+    public boolean yield;
 
     public int iptIndex = -1;
     public LongSeq graphicsBuffer = new LongSeq();
@@ -1126,6 +1127,7 @@ public class LExecutor{
             }else{
                 //skip back to self.
                 exec.var(varCounter).numval --;
+                exec.yield = true;
             }
 
             if(state.updateId != frameId){
@@ -1141,6 +1143,7 @@ public class LExecutor{
         public void run(LExecutor exec){
             //skip back to self.
             exec.var(varCounter).numval --;
+            exec.yield = true;
         }
     }
 
@@ -1543,6 +1546,7 @@ public class LExecutor{
                 type == MessageType.toast && ui.hasAnnouncement()
             ){
                 exec.var(varCounter).numval --;
+                exec.yield = true;
                 return;
             }
 

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -1524,9 +1524,9 @@ public class LExecutor{
 
     public static class FlushMessageI implements LInstruction{
         public MessageType type = MessageType.announce;
-        public int duration, outSuccess, x, y;
+        public int duration, outSuccess;
 
-        public FlushMessageI(MessageType type, int duration, int outSuccess, int x, int y){
+        public FlushMessageI(MessageType type, int duration, int outSuccess){
             this.type = type;
             this.duration = duration;
         }
@@ -1565,7 +1565,6 @@ public class LExecutor{
                 case notify -> ui.hudfrag.showToast(Icon.info, text);
                 case announce -> ui.announce(text, exec.numf(duration));
                 case toast -> ui.showInfoToast(text, exec.numf(duration));
-                case label -> ui.showLabel(text, exec.numf(duration), World.unconv(exec.numf(x)), World.unconv(exec.numf(y)));
                 //TODO desync?
                 case mission -> state.rules.mission = text;
             }

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -1529,6 +1529,7 @@ public class LExecutor{
         public FlushMessageI(MessageType type, int duration, int outSuccess){
             this.type = type;
             this.duration = duration;
+            this.outSuccess = outSuccess;
         }
 
         public FlushMessageI(){

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -1455,7 +1455,7 @@ public class LStatements{
 
         @Override
         public LInstruction build(LAssembler builder){
-            return new FlushMessageI(type, builder.var(duration), outSuccess.isEmpty()?-1:builder.var(outSuccess));
+            return new FlushMessageI(type, builder.var(duration), builder.var(outSuccess));
         }
 
         @Override

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -1419,7 +1419,7 @@ public class LStatements{
     @RegisterStatement("message")
     public static class FlushMessageStatement extends LStatement{
         public MessageType type = MessageType.announce;
-        public String duration = "3";
+        public String duration = "3", outSuccess = "success", x = "100", y = "100";
 
         @Override
         public void build(Table table){
@@ -1438,12 +1438,23 @@ public class LStatements{
             }, Styles.logict, () -> {}).size(160f, 40f).padLeft(2).color(table.color);
 
             switch(type){
-                case announce, toast -> {
+                case label -> {
+                    table.add(" x ");
+                    fields(table, x, str -> x = str);
+                    table.add(" y ");
+                    fields(table, y, str -> y = str);
+                    table.add(" for ");
+                    fields(table, duration, str -> duration = str);
+                    table.add(" secs ");
+                }
+                case announce, toast  -> {
                     table.add(" for ");
                     fields(table, duration, str -> duration = str);
                     table.add(" secs ");
                 }
             }
+            table.add(" success ");
+            fields(table, outSuccess, str -> outSuccess = str);
         }
 
         @Override
@@ -1453,7 +1464,7 @@ public class LStatements{
 
         @Override
         public LInstruction build(LAssembler builder){
-            return new FlushMessageI(type, builder.var(duration));
+            return new FlushMessageI(type, builder.var(duration), builder.var(outSuccess), builder.var(x), builder.var(y));
         }
 
         @Override

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -1419,7 +1419,7 @@ public class LStatements{
     @RegisterStatement("message")
     public static class FlushMessageStatement extends LStatement{
         public MessageType type = MessageType.announce;
-        public String duration = "3", outSuccess = "success", x = "100", y = "100";
+        public String duration = "3", outSuccess = "success";
 
         @Override
         public void build(Table table){
@@ -1438,15 +1438,6 @@ public class LStatements{
             }, Styles.logict, () -> {}).size(160f, 40f).padLeft(2).color(table.color);
 
             switch(type){
-                case label -> {
-                    table.add(" x ");
-                    fields(table, x, str -> x = str);
-                    table.add(" y ");
-                    fields(table, y, str -> y = str);
-                    table.add(" for ");
-                    fields(table, duration, str -> duration = str);
-                    table.add(" secs ");
-                }
                 case announce, toast  -> {
                     table.add(" for ");
                     fields(table, duration, str -> duration = str);
@@ -1464,7 +1455,7 @@ public class LStatements{
 
         @Override
         public LInstruction build(LAssembler builder){
-            return new FlushMessageI(type, builder.var(duration), builder.var(outSuccess), builder.var(x), builder.var(y));
+            return new FlushMessageI(type, builder.var(duration), outSuccess.isEmpty()?-1:builder.var(outSuccess));
         }
 
         @Override

--- a/core/src/mindustry/logic/MessageType.java
+++ b/core/src/mindustry/logic/MessageType.java
@@ -4,7 +4,8 @@ public enum MessageType{
     notify,
     announce,
     toast,
-    mission;
+    mission,
+    label;
 
     public static final MessageType[] all = values();
 }

--- a/core/src/mindustry/logic/MessageType.java
+++ b/core/src/mindustry/logic/MessageType.java
@@ -4,8 +4,7 @@ public enum MessageType{
     notify,
     announce,
     toast,
-    mission,
-    label;
+    mission;
 
     public static final MessageType[] all = values();
 }

--- a/core/src/mindustry/world/blocks/logic/LogicBlock.java
+++ b/core/src/mindustry/world/blocks/logic/LogicBlock.java
@@ -514,6 +514,10 @@ public class LogicBlock extends Block{
                 for(int i = 0; i < (int)accumulator; i++){
                     executor.runOnce();
                     accumulator --;
+                    if(executor.yield){
+                        executor.yield = false;
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
1. `wait 0.001` use as yield, to ensure later instructions in the same tick
2. ~~`message label` can let map maker do many interesting things.~~(Duplicates with `marks`)
3. fix `message` not clear `textBuffer`
4. `message` now return `success` instead of waiting for available. (useful for message loop to flush latest info)
---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
