### PR TITLE
Fix marker and bridge calculation game crashes, minor marker instruction fixes

### DIFF
--- a/core/src/mindustry/game/MapObjectives.java
+++ b/core/src/mindustry/game/MapObjectives.java
@@ -32,7 +32,7 @@ public class MapObjectives implements Iterable<MapObjective>, Eachable<MapObject
     public static final Seq<Prov<? extends MapObjective>> allObjectiveTypes = new Seq<>();
     public static final Seq<Prov<? extends ObjectiveMarker>> allMarkerTypes = new Seq<>();
     public static final ObjectMap<String, Prov<? extends ObjectiveMarker>> markerNameToType = new ObjectMap<>();
-    public static final Seq<String> allMarkerTypeNanes = new Seq<>();
+    public static final Seq<String> allMarkerTypeNames = new Seq<>();
 
     /**
      * All objectives the executor contains. Do not modify directly, ever!
@@ -87,7 +87,7 @@ public class MapObjectives implements Iterable<MapObjective>, Eachable<MapObject
 
             Class<? extends ObjectiveMarker> type = prov.get().getClass();
             String name = type.getSimpleName().replace("Marker", "");
-            allMarkerTypeNanes.add(Strings.camelize(name));
+            allMarkerTypeNames.add(Strings.camelize(name));
             markerNameToType.put(name, prov);
             markerNameToType.put(Strings.camelize(name), prov);
             JsonIO.classTag(Strings.camelize(name), type);
@@ -707,6 +707,9 @@ public class MapObjectives implements Iterable<MapObjective>, Eachable<MapObject
                 fetchedText = fetchText(text);
             }
 
+            // font size cannot be 0
+            if(Math.abs(fontSize) < 1e-5) return;
+
             WorldLabel.drawAt(fetchedText, pos.x, pos.y + radius + textHeight, Draw.z(), flags, fontSize);
         }
 
@@ -898,7 +901,8 @@ public class MapObjectives implements Iterable<MapObjective>, Eachable<MapObject
 
         @Override
         public void draw(){
-            if(hidden) return;
+            // font size cannot be 0
+            if(hidden || Math.abs(fontSize) < 1e-5) return;
 
             if(fetchedText == null){
                 fetchedText = fetchText(text);

--- a/core/src/mindustry/input/Placement.java
+++ b/core/src/mindustry/input/Placement.java
@@ -113,7 +113,7 @@ public class Placement{
     }
 
     public static void calculateBridges(Seq<BuildPlan> plans, ItemBridge bridge){
-        if(isSidePlace(plans)) return;
+        if(isSidePlace(plans) || plans.size == 0) return;
 
         //check for orthogonal placement + unlocked state
         if(!(plans.first().x == plans.peek().x || plans.first().y == plans.peek().y) || !bridge.unlockedNow()){
@@ -176,7 +176,7 @@ public class Placement{
     }
 
     public static void calculateBridges(Seq<BuildPlan> plans, DirectionBridge bridge, boolean hasJunction, Boolf<Block> same){
-        if(isSidePlace(plans)) return;
+        if(isSidePlace(plans) || plans.size == 0) return;
 
         //check for orthogonal placement + unlocked state
         if(!(plans.first().x == plans.peek().x || plans.first().y == plans.peek().y) || !bridge.unlockedNow()){

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -1862,7 +1862,7 @@ public class LExecutor{
             if(type == LMarkerControl.remove){
                 state.markers.remove(exec.numi(id));
             }else{
-                var marker = state.markers.get(id);
+                var marker = state.markers.get(exec.numi(id));
                 if(marker == null) return;
 
                 if(type == LMarkerControl.text){

--- a/core/src/mindustry/logic/LStatement.java
+++ b/core/src/mindustry/logic/LStatement.java
@@ -144,7 +144,7 @@ public abstract class LStatement{
                     if(p instanceof Enum e){
                         tooltip(c, e);
                     }
-                }).checked(current == p).group(group));
+                }).checked(current.equals(p)).group(group));
 
                 if(++i % cols == 0) t.row();
             }

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -1982,7 +1982,7 @@ public class LStatements{
 
     @RegisterStatement("makemarker")
     public static class MakeMarkerStatement extends LStatement{
-        public String id = "0", type = "Shape", x = "0", y = "0";
+        public String id = "0", type = "shape", x = "0", y = "0";
 
         @Override
         public void build(Table table){
@@ -1991,7 +1991,7 @@ public class LStatements{
             table.button(b -> {
                 b.label(() -> type);
 
-                b.clicked(() -> showSelect(b, MapObjectives.allMarkerTypeNanes.toArray(String.class), type, t -> {
+                b.clicked(() -> showSelect(b, MapObjectives.allMarkerTypeNames.toArray(String.class), type, t -> {
                     type = t;
                     build(table);
                 }, 2, cell -> cell.size(160, 50)));


### PR DESCRIPTION
1. Fix setting text markers font size to 0 crashing the game.
2. Fix bridge calculation with empty build plan crashing the game: occurs every time you try to place a conveyor/duct at (0, 0) world tile. Not sure the fix works properly because i don't fully understand how the bridge calculation works, so check it out.
3. Fix marker type selection table in Create Marker instruction not remembering which marker type was set before: one code line was comparing marker type strings with ==, so i replaced it with .equals(). I think this one shouldn't break other value comparsions, yes?

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
