### PR TITLE
Introduced protections against "zip slip" attacks 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -415,6 +415,8 @@ project(":tools"){
         implementation arcModule("natives:natives-desktop")
         implementation arcModule("natives:natives-freetype-desktop")
         implementation arcModule("backends:backend-headless")
+
+        implementation("io.github.pixee:java-security-toolkit:1.0.7")
     }
 }
 

--- a/tools/src/mindustry/tools/ScriptMainGenerator.java
+++ b/tools/src/mindustry/tools/ScriptMainGenerator.java
@@ -10,6 +10,7 @@ import arc.graphics.gl.*;
 import arc.math.*;
 import arc.struct.*;
 import arc.util.*;
+import io.github.pixee.security.ZipSecurity;
 import mindustry.game.*;
 import mindustry.gen.*;
 import mindustry.io.*;
@@ -140,7 +141,7 @@ public class ScriptMainGenerator{
         if(!directory.exists()) return classes;
 
         if(directory.getName().endsWith(".jar")){
-            ZipInputStream zip = new ZipInputStream(new FileInputStream(directory));
+            ZipInputStream zip = ZipSecurity.createHardenedInputStream(new FileInputStream(directory));
             for(ZipEntry entry = zip.getNextEntry(); entry != null; entry = zip.getNextEntry()){
                 if(!entry.isDirectory() && entry.getName().endsWith(".class")){
                     String className = entry.getName().replace('/', '.');


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

## Details About Security Recommendation -  From: [Pixeebot](https://www.pixee.ai/)
* This change updates all new instances of [ZipInputStream](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/zip/ZipInputStream.html) to protect against malicious entries that attempt to escape their "file root" and overwrite other files on the running filesystem.

Normally, when you're using `ZipInputStream` it's because you're processing zip files. That code might look like this:

```java
File file = new File(unzipTargetDirectory, zipEntry.getName()); // use file name from zip entry
InputStream is = zip.getInputStream(zipEntry); // get the contents of the zip entry
IOUtils.copy(is, new FileOutputStream(file)); // write the contents to the provided file name
```

This looks fine when it encounters a normal zip entry within a zip file, looking something like this pseudo-data:
```binary
path: data/names.txt
contents: Zeus\nHelen\nLeda...
```

However, there's nothing to prevent an attacker from sending an evil entry in the zip that looks more like this:
```binary
path: ../../../../../etc/passwd
contents: root::0:0:root:/:/bin/sh
```

Yes, in the above code, which looks like [every](https://stackoverflow.com/a/23870468) [piece](https://stackoverflow.com/a/51285801) of [zip-processing](https://kodejava.org/how-do-i-decompress-a-zip-file-using-zipinputstream/)  code you can [find](https://www.tabnine.com/code/java/classes/java.util.zip.ZipInputStream) on the [Internet](https://www.baeldung.com/java-compress-and-uncompress), attackers could overwrite any files to which the application has access. This rule replaces the standard `ZipInputStream` with a hardened subclass which prevents access to entry paths that attempt to traverse directories above the current directory (which no normal zip file should ever do.) Our changes end up looking something like this:

```diff
+ import io.github.pixee.security.ZipSecurity;
  ...
- var zip = new ZipInputStream(is, StandardCharsets.UTF_8);
+ var zip = ZipSecurity.createHardenedInputStream(is, StandardCharsets.UTF_8);
```
Powered by: [pixeebot](https://docs.pixee.ai/installing/) (codemod ID: [pixee:java/harden-zip-entry-paths](https://docs.pixee.ai/codemods/java/pixee_java_harden-zip-entry-paths)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-zc%2FMindustry%7Cdbbf65979d5492de15942aff4ea59518a6ea4018)

<!--{"type":"DRIP","codemod":"pixee:java/harden-zip-entry-paths"}-->