### PR TITLE
Add Atomic PvP

### DIFF
--- a/servers_v7.json
+++ b/servers_v7.json
@@ -258,6 +258,6 @@
   },
   {
     "name": "Atomic",
-    "address": ["atomic-lab.ddns.net:25709", "atomic-lab.ddns.net:25907"]
+    "address": ["atomic-lab.ddns.net:25709", "atomic-lab.ddns.net:25907", "atomic-de.ddns.net:35845"]
   }
 ]


### PR DESCRIPTION
A pvp server were (almost) all turrets have infinite ammo and cryo fluid. Maximize chaos. Hosted on Germany.