### PR TITLE
Move Atomic Servers to DE Node

### DIFF
--- a/servers_v7.json
+++ b/servers_v7.json
@@ -258,6 +258,6 @@
   },
   {
     "name": "Atomic",
-    "address": ["atomic-lab.ddns.net:25709", "atomic-lab.ddns.net:25907", "atomic-de.ddns.net:35845"]
+    "address": ["atomic-de.ddns.net:35199", "atomic-de.ddns.net:35176", "atomic-de.ddns.net:35845"]
   }
 ]


### PR DESCRIPTION
VPS Provider nuked their US node by accident, this may or may not be a permanent migration.