### PR TITLE
foreshadow overhaul

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -1025,6 +1025,7 @@ bullet.splashdamage = [stat]{0}[lightgray] area dmg ~ [stat]{1}[lightgray] tiles
 bullet.incendiary = [stat]incendiary
 bullet.homing = [stat]homing
 bullet.armorpierce = [stat]armor piercing
+bullet.maxdamagefraction = [stat]{0}%[lightgray] damage limit
 bullet.suppression = [stat]{0}[lightgray] seconds of repair suppression ~ [stat]{1}[lightgray] tiles
 bullet.interval = [stat]{0}/sec[lightgray] interval bullets:
 bullet.frags = [stat]{0}[lightgray]x frag bullets:

--- a/core/assets/icons/icons.properties
+++ b/core/assets/icons/icons.properties
@@ -587,4 +587,3 @@
 63095=ranai|ranai
 63094=cat|cat
 63093=world-switch|block-world-switch-ui
-63092=dynamic|status-dynamic-ui

--- a/core/assets/icons/icons.properties
+++ b/core/assets/icons/icons.properties
@@ -587,3 +587,4 @@
 63095=ranai|ranai
 63094=cat|cat
 63093=world-switch|block-world-switch-ui
+63092=dynamic|status-dynamic-ui

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -3849,16 +3849,19 @@ public class Blocks{
 
             requirements(Category.turret, with(Items.copper, 1000, Items.metaglass, 600, Items.surgeAlloy, 300, Items.plastanium, 200, Items.silicon, 600));
             ammo(
-                Items.surgeAlloy, new PointBulletType(){{
+                Items.surgeAlloy, new RailBulletType(){{
                     shootEffect = Fx.instShoot;
                     hitEffect = Fx.instHit;
+                    pierceEffect = Fx.railHit;
                     smokeEffect = Fx.smokeCloud;
-                    trailEffect = Fx.instTrail;
+                    pointEffect = Fx.instTrail;
                     despawnEffect = Fx.instBomb;
-                    trailSpacing = 20f;
+                    pointEffectSpace = 20f;
                     damage = 1350;
                     buildingDamageMultiplier = 0.2f;
-                    speed = brange;
+                    maxDamageFraction = 0.6f;
+                    pierceDamageFactor = 1f;
+                    length = brange;
                     hitShake = 6f;
                     ammoMultiplier = 1f;
                 }}

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -48,6 +48,8 @@ public class BulletType extends Content implements Cloneable{
     public int pierceCap = -1;
     /** Multiplier of damage decreased per health pierced. */
     public float pierceDamageFactor = 0f;
+    /** If positive, limits non-splash damage dealt to a fraction of the target's maximum health. */
+    public float maxDamageFraction = -1f;
     /** If false, this bullet isn't removed after pierceCap is exceeded. Expert usage only. */
     public boolean removeAfterPierce = true;
     /** For piercing lasers, setting this to true makes it get absorbed by plastanium walls. */
@@ -382,10 +384,16 @@ public class BulletType extends Content implements Cloneable{
         boolean wasDead = entity instanceof Unit u && u.dead;
 
         if(entity instanceof Healthc h){
+            float damage = b.damage;
+            if(maxDamageFraction > 0){
+                damage = Math.min(damage, h.maxHealth() * maxDamageFraction);
+                //cap health to effective health for handlePierce to handle it properly
+                health = Math.min(health, h.maxHealth() * maxDamageFraction);
+            }
             if(pierceArmor){
-                h.damagePierce(b.damage);
+                h.damagePierce(damage);
             }else{
-                h.damage(b.damage);
+                h.damage(damage);
             }
         }
 

--- a/core/src/mindustry/world/meta/StatValues.java
+++ b/core/src/mindustry/world/meta/StatValues.java
@@ -487,6 +487,10 @@ public class StatValues{
                         sep(bt, "@bullet.armorpierce");
                     }
 
+                    if(type.maxDamageFraction > 0){
+                        sep(bt, Core.bundle.format("bullet.maxdamagefraction", (int)(type.maxDamageFraction * 100))); 
+                    }
+
                     if(type.suppressionRange > 0){
                         sep(bt, Core.bundle.format("bullet.suppression", Strings.autoFixed(type.suppressionDuration / 60f, 2), Strings.fixed(type.suppressionRange / tilesize, 1)));
                     }


### PR DESCRIPTION
as per a #balancing discussion, makes foreshadow now use a RailBulletType and makes it deal at most as much damage as 60% of its target's max health
makes you able to use smaller units as meatshields for your larger units and makes foreshadow bad for killing smaller units
hold off on merging for a day so we can potentially discuss this more, it's fine if i say nothing by then
might break extremely hard attack maps which require you to use foreshadow to snipe nodes (...gigafort?) or pvp maps where advancing is so hard that you have to snipe enemy nodes

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
