### PR TITLE
uncap foreshadow damage on shields

### DIFF
--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -386,9 +386,13 @@ public class BulletType extends Content implements Cloneable{
         if(entity instanceof Healthc h){
             float damage = b.damage;
             if(maxDamageFraction > 0){
-                damage = Math.min(damage, h.maxHealth() * maxDamageFraction);
+                float cap = h.maxHealth() * maxDamageFraction;
+                if(entity instanceof Shieldc s){
+                    cap += Math.max(s.shield(), 0f);
+                }
+                damage = Math.min(damage, cap);
                 //cap health to effective health for handlePierce to handle it properly
-                health = Math.min(health, h.maxHealth() * maxDamageFraction);
+                health = Math.min(health, cap);
             }
             if(pierceArmor){
                 h.damagePierce(damage);


### PR DESCRIPTION
as a follow-up to the foreshadow overhaul, make the foreshadow damage limit only apply to damage dealt to health
prevents just flying a scepter-shielded flare under an array of foreshadows and makes shielded-unit meatshields actually block shots

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
