### PR TITLE
meltdown properly overdrivable

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -3968,6 +3968,7 @@ public class Blocks{
                 hitColor = Pal.meltdownHit;
                 status = StatusEffects.melting;
                 drawSize = 420f;
+                timescaleDamage = true;
 
                 incendChance = 0.4f;
                 incendSpread = 5f;

--- a/core/src/mindustry/entities/bullet/ContinuousBulletType.java
+++ b/core/src/mindustry/entities/bullet/ContinuousBulletType.java
@@ -11,6 +11,8 @@ public class ContinuousBulletType extends BulletType{
     public float damageInterval = 5f;
     public boolean largeHit = false;
     public boolean continuous = true;
+    /** If a building fired this, whether to multiply damage by its timescale. */
+    public boolean timescaleDamage = false;
 
     {
         removeAfterPierce = false;
@@ -79,7 +81,12 @@ public class ContinuousBulletType extends BulletType{
     }
 
     public void applyDamage(Bullet b){
+        float damage = b.damage;
+        if(timescaleDamage && b.owner instanceof Building build){
+             b.damage *= build.timeScale();
+        }
         Damage.collideLine(b, b.team, hitEffect, b.x, b.y, b.rotation(), currentLength(b), largeHit, laserAbsorb, pierceCap);
+        b.damage = damage;
     }
 
     public float currentLength(Bullet b){

--- a/core/src/mindustry/world/blocks/defense/turrets/LaserTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/LaserTurret.java
@@ -78,7 +78,7 @@ public class LaserTurret extends PowerTurret{
                     entry.bullet.set(bulletX, bulletY);
                     entry.bullet.time = entry.bullet.type.lifetime * entry.bullet.type.optimalLifeFract;
                     entry.bullet.keepAlive = true;
-                    entry.life -= Time.delta / Math.max(efficiency, 0.00001f);
+                    entry.life -= Time.delta * timeScale / Math.max(efficiency, 0.00001f);
                 }
 
                 wasShooting = true;


### PR DESCRIPTION
makes meltdown scale damage depending on timescale and accelerate its entire firing cycle so that the portion of its time it actually spends firing stays the same

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
