### PR TITLE
Minor ban/unban instruction and join dialog changes

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -1459,7 +1459,9 @@ public class LExecutor{
                 case ban -> {
                     Object cont = exec.obj(value);
                     if(cont instanceof Block b){
+                        boolean update = !state.rules.bannedBlocks.contains(b);
                         state.rules.bannedBlocks.add(b);
+                        if(!headless && update) ui.hudfrag.blockfrag.rebuild();
                     }else if(cont instanceof UnitType u){
                         state.rules.bannedUnits.add(u);
                     }
@@ -1467,7 +1469,9 @@ public class LExecutor{
                 case unban -> {
                     Object cont = exec.obj(value);
                     if(cont instanceof Block b){
+                        boolean update = state.rules.bannedBlocks.contains(b);
                         state.rules.bannedBlocks.remove(b);
+                        if(!headless && update) ui.hudfrag.blockfrag.rebuild();
                     }else if(cont instanceof UnitType u){
                         state.rules.bannedUnits.remove(u);
                     }

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -1459,9 +1459,8 @@ public class LExecutor{
                 case ban -> {
                     Object cont = exec.obj(value);
                     if(cont instanceof Block b){
-                        boolean update = !state.rules.bannedBlocks.contains(b);
-                        state.rules.bannedBlocks.add(b);
-                        if(!headless && update) ui.hudfrag.blockfrag.rebuild();
+                        // Rebuild PlacementFragment if anything has changed
+                        if(state.rules.bannedBlocks.add(b) && !headless) ui.hudfrag.blockfrag.rebuild();
                     }else if(cont instanceof UnitType u){
                         state.rules.bannedUnits.add(u);
                     }
@@ -1469,9 +1468,7 @@ public class LExecutor{
                 case unban -> {
                     Object cont = exec.obj(value);
                     if(cont instanceof Block b){
-                        boolean update = state.rules.bannedBlocks.contains(b);
-                        state.rules.bannedBlocks.remove(b);
-                        if(!headless && update) ui.hudfrag.blockfrag.rebuild();
+                        if(state.rules.bannedBlocks.remove(b) && !headless) ui.hudfrag.blockfrag.rebuild();
                     }else if(cont instanceof UnitType u){
                         state.rules.bannedUnits.remove(u);
                     }

--- a/core/src/mindustry/ui/dialogs/JoinDialog.java
+++ b/core/src/mindustry/ui/dialogs/JoinDialog.java
@@ -247,29 +247,12 @@ public class JoinDialog extends BaseDialog{
     void setupServer(Server server, Host host){
         server.lastHost = host;
         server.content.clear();
-        buildServer(host, server.content);
+        buildServer(host, server.content, false);
     }
 
-    void buildServer(Host host, Table content){
+    void buildServer(Host host, Table content, boolean inner){
         content.top().left();
-        String versionString;
-
-        if(host.version == -1){
-            versionString = Core.bundle.format("server.version", Core.bundle.get("server.custombuild"), "");
-        }else if(host.version == 0){
-            versionString = Core.bundle.get("server.outdated");
-        }else if(host.version < Version.build && Version.build != -1){
-            versionString = Core.bundle.get("server.outdated") + "\n" +
-            Core.bundle.format("server.version", host.version, "");
-        }else if(host.version > Version.build && Version.build != -1){
-            versionString = Core.bundle.get("server.outdated.client") + "\n" +
-            Core.bundle.format("server.version", host.version, "");
-        }else if(host.version == Version.build && Version.type.equals(host.versionType)){
-            //not important
-            versionString = "";
-        }else{
-            versionString = Core.bundle.format("server.version", host.version, host.versionType);
-        }
+        String versionString = getVersionString(host);
 
         float twidth = targetWidth() - 40f;
 
@@ -277,12 +260,14 @@ public class JoinDialog extends BaseDialog{
 
         Color color = Pal.gray;
 
-        content.table(Tex.whiteui, t -> {
-            t.left();
-            t.setColor(color);
+        if(inner){
+            content.table(Tex.whiteui, t -> {
+                t.left();
+                t.setColor(color);
 
-            t.add(host.name + "   " + versionString).style(Styles.outlineLabel).padLeft(10f).width(twidth).left().ellipsis(true);
-        }).growX().height(36f).row();
+                t.add(host.name + "   " + versionString).style(Styles.outlineLabel).padLeft(10f).width(twidth).left().ellipsis(true);
+            }).growX().height(36f).row();
+        }
 
         content.table(Tex.whitePane, t -> {
             t.top().left();
@@ -485,11 +470,16 @@ public class JoinDialog extends BaseDialog{
 
     void addCommunityHost(Host host, Table container){
         global.background(null);
+        String versionString = getVersionString(host);
         float w = targetWidth();
 
         container.left().top();
 
-        container.button(b -> buildServer(host, b), style, () -> {
+        Button[] button = {null};
+
+        button[0] = container.button(b -> {}, style, () -> {
+            if(button[0].childrenPressed()) return;
+
             Events.fire(new ClientPreConnectEvent(host));
             if(!Core.settings.getBool("server-disclaimer", false)){
                 ui.showCustomConfirm("@warning", "@servers.disclaimer", "@ok", "@back", () -> {
@@ -501,7 +491,28 @@ public class JoinDialog extends BaseDialog{
             }else{
                 safeConnect(host.address, host.port, host.version);
             }
-        }).width(w).padBottom(7).padRight(4f).top().left().growY().uniformY();
+        }).width(w).padBottom(7).padRight(4f).top().left().growY().uniformY().get();
+
+        Table inner = new Table(Tex.whiteui);
+        inner.setColor(Pal.gray);
+
+        button[0].clearChildren();
+        button[0].add(inner).growX();
+
+        inner.add(host.name + "   " + versionString).left().padLeft(10f).wrap().style(Styles.outlineLabel).growX();
+
+        inner.button(Icon.add, Styles.emptyi, () -> {
+            Server server = new Server();
+            server.setIP(host.address + ":" + host.port);
+            servers.add(server);
+            saveServers();
+            setupRemote();
+            refreshRemote();
+        }).margin(3f).pad(8f).padRight(4f).top().right();
+
+        button[0].row();
+
+        buildServer(host, button[0].table(t -> {}).grow().get(), false);
 
         if((container.getChildren().size) % columns() == 0){
             container.row();
@@ -532,7 +543,7 @@ public class JoinDialog extends BaseDialog{
             local.row();
         }
 
-        local.button(b -> buildServer(host, b), style, () -> {
+        local.button(b -> buildServer(host, b, true), style, () -> {
             Events.fire(new ClientPreConnectEvent(host));
             safeConnect(host.address, host.port, host.version);
         }).width(w).top().left().growY();
@@ -639,6 +650,25 @@ public class JoinDialog extends BaseDialog{
 
     private void saveServers(){
         Core.settings.putJson("servers", Server.class, servers);
+    }
+
+    private String getVersionString(Host host){
+        if(host.version == -1){
+            return Core.bundle.format("server.version", Core.bundle.get("server.custombuild"), "");
+        }else if(host.version == 0){
+            return Core.bundle.get("server.outdated");
+        }else if(host.version < Version.build && Version.build != -1){
+            return Core.bundle.get("server.outdated") + "\n" +
+            Core.bundle.format("server.version", host.version, "");
+        }else if(host.version > Version.build && Version.build != -1){
+            return Core.bundle.get("server.outdated.client") + "\n" +
+            Core.bundle.format("server.version", host.version, "");
+        }else if(host.version == Version.build && Version.type.equals(host.versionType)){
+            //not important
+            return "";
+        }else{
+            return Core.bundle.format("server.version", host.version, host.versionType);
+        }
     }
 
     public static class Server{

--- a/core/src/mindustry/ui/fragments/PlacementFragment.java
+++ b/core/src/mindustry/ui/fragments/PlacementFragment.java
@@ -113,7 +113,7 @@ public class PlacementFragment{
         return hover;
     }
 
-    void rebuild(){
+    public void rebuild(){
         //category does not change on rebuild anymore, only on new world load
         Group group = toggler.parent;
         int index = toggler.getZIndex();


### PR DESCRIPTION
1. World processor's `ban`/`unban` instructions now update `PlacementFragment` (only if needed). Earlier you couldn't access build category if all its blocks are banned and `Hide Banned Blocks` is turned on, because the category button won't appear.
2. Now there's small buttons in `JoinDialog` that add a server from community server list to your remote servers (useful to track your favorite servers without checking servers_v7.json for their ip)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
