### PR TITLE
Move Surge Alloy in ErekirTechTree to the correct position

### DIFF
--- a/core/src/mindustry/content/ErekirTechTree.java
+++ b/core/src/mindustry/content/ErekirTechTree.java
@@ -447,11 +447,11 @@ public class ErekirTechTree{
 
                                 //nodeProduce(Liquids.gallium, () -> {});
                             });
+                        });
 
-                            nodeProduce(Items.surgeAlloy, () -> {
-                                nodeProduce(Items.phaseFabric, () -> {
+                        nodeProduce(Items.surgeAlloy, () -> {
+                            nodeProduce(Items.phaseFabric, () -> {
 
-                                });
                             });
                         });
                     });


### PR DESCRIPTION
Surge Alloy can be first obtained on the "Ravine" map.
Thorium can be first obtained on the "Caldera" map.
The "Ravine" map must be unlocked and completed before the "Caldera" map can be accessed.
Since Surge Alloy isn't required to produce Thorium (and vice versa), they should appear at the same level of the tech tree, under Tungsten.


- [+] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [+] I have ensured that my code compiles, if applicable.
- [+] I have ensured that any new features in this PR function correctly in-game, if applicable.
