### PR TITLE
Add DDNS experimental server to server list

### DIFF
--- a/servers_v7.json
+++ b/servers_v7.json
@@ -141,7 +141,7 @@
   },
   {
     "name": "mindustry.ddns.net",
-    "address": ["mindustry.ddns.net", "mindustry.ddns.net:1000", "mindustry.ddns.net:2000", "mindustry.ddns.net:3000", "mindustry.ddns.net:4000"]
+    "address": ["mindustry.ddns.net", "mindustry.ddns.net:1000", "mindustry.ddns.net:2000", "mindustry.ddns.net:3000", "mindustry.ddns.net:4000", "mindustry.ddns.net:5000"]
   },
   {
     "name": "EasyPlay.su",


### PR DESCRIPTION
Added DDNS experimental server (mindustry.ddns.net:5000) to the server list under "mindustry.ddns.net".

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [] I have ensured that my code compiles, if applicable.
- [] I have ensured that any new features in this PR function correctly in-game, if applicable.
