### PR TITLE
Allow fetching unitCount by type, and buildCount without type

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -1360,13 +1360,20 @@ public class LExecutor{
                         exec.setobj(result, i < 0 || i >= builds.size ? null : builds.get(i));
                     }
                 }
-                case unitCount -> exec.setnum(result, data.units.size);
+                case unitCount -> {
+                    UnitType type = exec.obj(extra) instanceof UnitType u ? u : null;
+                    if(type == null){
+                        exec.setnum(result, data.units.size);
+                    }else{
+                        exec.setnum(result, data.unitsByType[type.id].size);
+                    }
+                }
                 case coreCount -> exec.setnum(result, data.cores.size);
                 case playerCount -> exec.setnum(result, data.players.size);
                 case buildCount -> {
                     Block block = exec.obj(extra) instanceof Block b ? b : null;
                     if(block == null){
-                        exec.setobj(result, null);
+                        exec.setnum(result, data.buildings.size);
                     }else{
                         exec.setnum(result, data.getBuildings(block).size);
                     }

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -1748,7 +1748,7 @@ public class LStatements{
                 fields(table, index, i -> index = i);
             }
 
-            if(type == FetchType.buildCount || type == FetchType.build){
+            if(type == FetchType.buildCount || type == FetchType.build || type == FetchType.unitCount){
                 row(table);
 
                 fields(table, "block", extra, i -> extra = i);


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

Allows specifying the type of unit for `fetch unitCount`. If type is null, returns the total number of units, as before.

Allows *not* specifying the type of build for `fetch buildCount`. If type is null, it now returns the total number of builds.

Will only break logic if it relied on `fetch buildCount x @sharded null` being null which is very unlikely

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
