### PR TITLE
Make file name orders deterministic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,12 +106,12 @@ allprojects{
         generateLocales = {
             def output = 'en\n'
             def bundles = new File(project(':core').projectDir, 'assets/bundles/')
-            bundles.listFiles().each{ other ->
-                if(other.name == "bundle.properties") return
-                output += other.name.substring("bundle".length() + 1, other.name.lastIndexOf('.')) + "\n"
+            bundles.list().sort().each{ name ->
+                if(name == "bundle.properties") return
+                output += name.substring("bundle".length() + 1, name.lastIndexOf('.')) + "\n"
             }
             new File(project(':core').projectDir, 'assets/locales').text = output
-            new File(project(':core').projectDir, 'assets/basepartnames').text = new File(project(':core').projectDir, 'assets/baseparts/').list().join("\n")
+            new File(project(':core').projectDir, 'assets/basepartnames').text = new File(project(':core').projectDir, 'assets/baseparts/').list().sort().join("\n")
         }
 
         writeVersion = {


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.

---

I was going through some java packages on Nixpkgs to see if they were completely deterministic, and if not, fix them.

This package only had a few issues with determinism: one of them I could figure out, and is fixed in this PR, the other one is probably any issue inside `Arc`.

---

The first issue was that `file.list()` or `file.listFiles()` gives back files in a non-fixed order (at least on Linux), so the generated files would differ between builds.

This PR fixes this by running `.sort()` before processing the file names.
I also refactored the code to use `list` instead of `listFiles`.


---

The other issue mentioned above is an issue, where the spritesheets inside `core/assets/sprites` are in a (maybe) random order.
[link to the relevant code](https://github.com/Anuken/Mindustry/blob/92b2fc077254dfc3dc649a3b742013e5e2e4391b/tools/build.gradle#L174C9-L186)

Sadly, as I am not really familiar with the codebase of `Arc` I couldn't figure out whether the issue was with the file iteration of the used FileProcessor or the packing algorithm

Should I open this last part as an issue on `Arc`?