### PR TITLE
Truncate ping response packets

### DIFF
--- a/core/src/mindustry/net/ArcNetProvider.java
+++ b/core/src/mindustry/net/ArcNetProvider.java
@@ -94,7 +94,9 @@ public class ArcNetProvider implements NetProvider{
         server.setMulticast(multicastGroup, multicastPort);
         server.setDiscoveryHandler((address, handler) -> {
             ByteBuffer buffer = NetworkIO.writeServerData();
+            int length = buffer.position();
             buffer.position(0);
+            buffer.limit(length);
             handler.respond(buffer);
         });
 


### PR DESCRIPTION
Previously all ping response packets were 0-padded to 500 bytes. By truncating we only send the bytes that are actually needed.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
