### PR TITLE
Allied teams, for real

### DIFF
--- a/core/src/mindustry/ai/BlockIndexer.java
+++ b/core/src/mindustry/ai/BlockIndexer.java
@@ -287,7 +287,7 @@ public class BlockIndexer{
         //when team data is not initialized, scan through every team. this is terrible
         if(data.isEmpty()){
             for(Team enemy : Team.all){
-                if(enemy == team || (enemy == Team.derelict && !state.rules.coreCapture)) continue;
+                if(!team.isEnemy(enemy) || (enemy == Team.derelict && !state.rules.coreCapture)) continue;
                 var set = getFlagged(enemy)[type.ordinal()];
                 if(set != null){
                     breturnArray.addAll(set);
@@ -296,7 +296,7 @@ public class BlockIndexer{
         }else{
             for(int i = 0; i < data.size; i++){
                 Team enemy = data.items[i].team;
-                if(enemy == team || (enemy == Team.derelict && !state.rules.coreCapture)) continue;
+                if(!team.isEnemy(enemy) || (enemy == Team.derelict && !state.rules.coreCapture)) continue;
                 var set = getFlagged(enemy)[type.ordinal()];
                 if(set != null){
                     breturnArray.addAll(set);
@@ -354,7 +354,7 @@ public class BlockIndexer{
 
         for(int i = 0; i < activeTeams.size; i++){
             Team enemy = activeTeams.items[i];
-            if(enemy == team || (enemy == Team.derelict && !state.rules.coreCapture)) continue;
+            if((team == null || !team.isEnemy(enemy)) || (enemy == Team.derelict && !state.rules.coreCapture)) continue;
 
             Building candidate = indexer.findTile(enemy, x, y, range, b -> pred.get(b) && b.isDiscovered(team), true);
             if(candidate == null) continue;

--- a/core/src/mindustry/ai/types/CommandAI.java
+++ b/core/src/mindustry/ai/types/CommandAI.java
@@ -133,7 +133,7 @@ public class CommandAI extends AIController{
             if(command == UnitCommand.loadBlocksCommand && (targetPos == null || unit.within(targetPos, 1f))){
                 Building build = world.buildWorld(unit.x, unit.y);
 
-                if(build != null && state.teams.canInteract(unit.team, build.team)){
+                if(build != null && unit.team.canTakeItems(build.team)){
                     //pick up block's payload
                     Payload current = build.getPayload();
                     if(current != null && pay.canPickupPayload(current)){
@@ -149,7 +149,7 @@ public class CommandAI extends AIController{
         if(!net.client() && command == UnitCommand.enterPayloadCommand && unit.buildOn() != null && (targetPos == null || (world.buildWorld(targetPos.x, targetPos.y) != null && world.buildWorld(targetPos.x, targetPos.y) == unit.buildOn()))){
             var build = unit.buildOn();
             tmpPayload.unit = unit;
-            if(build.team == unit.team && build.acceptPayload(build, tmpPayload)){
+            if(unit.team.canGiveItems(build.team) && build.acceptPayload(build, tmpPayload)){
                 Call.unitEnteredPayload(unit, build);
                 return; //no use updating after this, the unit is gone!
             }
@@ -361,7 +361,7 @@ public class CommandAI extends AIController{
 
     @Override
     public void hit(Bullet bullet){
-        if(unit.team.isAI() && bullet.owner instanceof Teamc teamc && teamc.team() != unit.team && attackTarget == null &&
+        if(unit.team.isAI() && bullet.owner instanceof Teamc teamc && unit.team.canDamage(teamc.team()) && attackTarget == null &&
             //can only counter-attack every few seconds to prevent rapidly changing targets
             !(teamc instanceof Unit u && !u.checkTarget(unit.type.targetAir, unit.type.targetGround)) && timer.get(timerTarget4, 60f * 10f)){
             commandTarget(teamc, true);

--- a/core/src/mindustry/ai/types/MissileAI.java
+++ b/core/src/mindustry/ai/types/MissileAI.java
@@ -24,7 +24,7 @@ public class MissileAI extends AIController{
         var build = unit.buildOn();
 
         //kill instantly on enemy building contact
-        if(build != null && build.team != unit.team && (build == target || !build.block.underBullets)){
+        if(build != null && unit.team.canDamage(build.team) && (build == target || !build.block.underBullets)){
             unit.kill();
         }
     }

--- a/core/src/mindustry/ai/types/RepairAI.java
+++ b/core/src/mindustry/ai/types/RepairAI.java
@@ -28,7 +28,7 @@ public class RepairAI extends AIController{
             unit.controlWeapons(false);
         }
 
-        if(target != null && target instanceof Building b && b.team == unit.team){
+        if(target != null && target instanceof Building b && unit.team.isAlly(b.team)){
             if(unit.type.circleTarget){
                 circleAttack(120f);
             }else if(!target.within(unit, unit.type.range * 0.65f)){

--- a/core/src/mindustry/ai/types/SuicideAI.java
+++ b/core/src/mindustry/ai/types/SuicideAI.java
@@ -53,7 +53,7 @@ public class SuicideAI extends GroundAI{
                     for(Point2 p : Geometry.d4c){
                         Tile tile = Vars.world.tile(x + p.x, y + p.y);
                         if(tile != null && tile.build == target) return false;
-                        if(tile != null && tile.build != null && tile.build.team != unit.team()){
+                        if(tile != null && tile.build != null && unit.team().isEnemy(tile.build.team)){
                             blockedByBlock = true;
                             return true;
                         }else{

--- a/core/src/mindustry/core/Control.java
+++ b/core/src/mindustry/core/Control.java
@@ -62,7 +62,7 @@ public class Control implements ApplicationListener, Loadable{
         indicators = new AttackIndicators();
 
         Events.on(BuildDamageEvent.class, e -> {
-            if(e.build.team == Vars.player.team()){
+            if(Vars.player.team().isAlly(e.build.team)){
                 indicators.add(e.build.tileX(), e.build.tileY());
             }
         });

--- a/core/src/mindustry/entities/Lightning.java
+++ b/core/src/mindustry/entities/Lightning.java
@@ -53,7 +53,7 @@ public class Lightning{
                 World.raycastEach(World.toTile(from.getX()), World.toTile(from.getY()), World.toTile(to.getX()), World.toTile(to.getY()), (wx, wy) -> {
 
                     Tile tile = world.tile(wx, wy);
-                    if(tile != null && (tile.build != null && tile.build.isInsulated()) && tile.team() != team){
+                    if(tile != null && (tile.build != null && tile.build.isInsulated()) && team.canDamage(tile.team())){
                         bhit = true;
                         //snap it instead of removing
                         lines.get(lines.size - 1).set(wx * tilesize, wy * tilesize);

--- a/core/src/mindustry/entities/abilities/EnergyFieldAbility.java
+++ b/core/src/mindustry/entities/abilities/EnergyFieldAbility.java
@@ -122,7 +122,7 @@ public class EnergyFieldAbility extends Ability{
 
             if(hitUnits){
                 Units.nearby(null, rx, ry, range, other -> {
-                    if(other != unit && other.checkTarget(targetAir, targetGround) && other.targetable(unit.team) && (other.team != unit.team || other.damaged())){
+                    if(other != unit && other.checkTarget(targetAir, targetGround) && other.targetable(unit.team) && (unit.team.canDamage(other.team) || other.damaged())){
                         all.add(other);
                     }
                 });
@@ -130,7 +130,7 @@ public class EnergyFieldAbility extends Ability{
 
             if(hitBuildings && targetGround){
                 Units.nearbyBuildings(rx, ry, range, b -> {
-                    if((b.team != Team.derelict || state.rules.coreCapture) && (b.team != unit.team || b.damaged())){
+                    if((b.team != Team.derelict || state.rules.coreCapture) && (unit.team.canDamage(b.team) || b.damaged())){
                         all.add(b);
                     }
                 });
@@ -147,7 +147,7 @@ public class EnergyFieldAbility extends Ability{
                     other = absorber;
                 }
 
-                if(((Teamc)other).team() == unit.team){
+                if(unit.team.isAlly(((Teamc)other).team())){
                     if(other.damaged()){
                         anyNearby = true;
                         float healMult = (other instanceof Unit u && u.type == unit.type) ? sameTypeHealMult : 1f;

--- a/core/src/mindustry/entities/abilities/ForceFieldAbility.java
+++ b/core/src/mindustry/entities/abilities/ForceFieldAbility.java
@@ -37,7 +37,7 @@ public class ForceFieldAbility extends Ability{
     private static Unit paramUnit;
     private static ForceFieldAbility paramField;
     private static final Cons<Bullet> shieldConsumer = trait -> {
-        if(trait.team != paramUnit.team && trait.type.absorbable && Intersector.isInRegularPolygon(paramField.sides, paramUnit.x, paramUnit.y, realRad, paramField.rotation, trait.x(), trait.y()) && paramUnit.shield > 0){
+        if(trait.team.canDamage(paramUnit.team) && trait.type.absorbable && Intersector.isInRegularPolygon(paramField.sides, paramUnit.x, paramUnit.y, realRad, paramField.rotation, trait.x(), trait.y()) && paramUnit.shield > 0){
             trait.absorb();
             Fx.absorb.at(trait);
 

--- a/core/src/mindustry/entities/abilities/ShieldArcAbility.java
+++ b/core/src/mindustry/entities/abilities/ShieldArcAbility.java
@@ -20,7 +20,7 @@ public class ShieldArcAbility extends Ability{
     private static ShieldArcAbility paramField;
     private static Vec2 paramPos = new Vec2();
     private static final Cons<Bullet> shieldConsumer = b -> {
-        if(b.team != paramUnit.team && b.type.absorbable && paramField.data > 0 &&
+        if(b.team.canDamage(paramUnit.team) && b.type.absorbable && paramField.data > 0 &&
             !b.within(paramPos, paramField.radius - paramField.width/2f) &&
             Tmp.v1.set(b).add(b.vel).within(paramPos, paramField.radius + paramField.width/2f) &&
             Angles.within(paramPos.angleTo(b), paramUnit.rotation + paramField.angleOffset, paramField.angle / 2f)){

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -362,7 +362,7 @@ public class BulletType extends Content implements Cloneable{
     }
 
     public boolean testCollision(Bullet bullet, Building tile){
-        return !heals() || bullet.team.canDamage(bullet.team) || tile.healthf() < 1f;
+        return !heals() || bullet.team.canDamage(tile.team) || tile.healthf() < 1f;
     }
 
     /** If direct is false, this is an indirect hit and the tile was already damaged.

--- a/core/src/mindustry/entities/bullet/EmpBulletType.java
+++ b/core/src/mindustry/entities/bullet/EmpBulletType.java
@@ -19,7 +19,7 @@ public class EmpBulletType extends BasicBulletType{
 
         if(!b.absorbed){
             Vars.indexer.allBuildings(x, y, radius, other -> {
-                if(other.team == b.team){
+                if(b.team.isAlly(other.team)){
                     if(other.block.hasPower && other.block.canOverdrive && other.timeScale() < timeIncrease){
                         other.applyBoost(timeIncrease, timeDuration);
                         chainEffect.at(x, y, 0, hitColor, other);
@@ -48,7 +48,7 @@ public class EmpBulletType extends BasicBulletType{
 
             if(hitUnits){
                 Units.nearbyEnemies(b.team, x, y, radius, other -> {
-                    if(other.team != b.team && other.hittable()){
+                    if(b.team.canDamage(other.team) && other.hittable()){
                         var absorber = Damage.findAbsorber(b.team, x, y, other.x, other.y);
                         if(absorber != null){
                             return;

--- a/core/src/mindustry/entities/bullet/PointBulletType.java
+++ b/core/src/mindustry/entities/bullet/PointBulletType.java
@@ -59,7 +59,7 @@ public class PointBulletType extends BulletType{
             b.collision(result, px, py);
         }else if(collidesTiles){
             Building build = Vars.world.buildWorld(px, py);
-            if(build != null && build.team != b.team){
+            if(build != null && b.team.canDamage(build.team)){
                 build.collision(b);
                  hit(b, px, py);
             }

--- a/core/src/mindustry/entities/bullet/RailBulletType.java
+++ b/core/src/mindustry/entities/bullet/RailBulletType.java
@@ -84,7 +84,7 @@ public class RailBulletType extends BulletType{
 
     @Override
     public boolean testCollision(Bullet bullet, Building tile){
-        return bullet.team != tile.team;
+        return bullet.team.canDamage(tile.team);
     }
 
     @Override

--- a/core/src/mindustry/entities/comp/BoundedComp.java
+++ b/core/src/mindustry/entities/comp/BoundedComp.java
@@ -20,7 +20,7 @@ abstract class BoundedComp implements Velc, Posc, Healthc, Flyingc{
     @Override
     public void update(){
         if(!type.bounded) return;
-        
+
         float bot = 0f, left = 0f, top = world.unitHeight(), right = world.unitWidth();
 
         //TODO hidden map rules only apply to player teams? should they?

--- a/core/src/mindustry/entities/comp/BuilderComp.java
+++ b/core/src/mindustry/entities/comp/BuilderComp.java
@@ -152,7 +152,7 @@ abstract class BuilderComp implements Posc, Statusc, Teamc, Rotc{
                     plans.removeFirst();
                     continue;
                 }
-            }else if((tile.team() != team && tile.team() != Team.derelict) || (!current.breaking && (cb.current != current.block || cb.tile != current.tile()))){
+            }else if(!team.canAssistBuilding(tile.team()) || (!current.breaking && (cb.current != current.block || cb.tile != current.tile()))){
                 plans.removeFirst();
                 continue;
             }

--- a/core/src/mindustry/entities/comp/BulletComp.java
+++ b/core/src/mindustry/entities/comp/BulletComp.java
@@ -50,7 +50,7 @@ abstract class BulletComp implements Timedc, Damagec, Hitboxc, Teamc, Posc, Draw
     public void getCollisions(Cons<QuadTree> consumer){
         Seq<TeamData> data = state.teams.present;
         for(int i = 0; i < data.size; i++){
-            if(data.items[i].team != team){
+            if(team.canDamage(data.items[i].team)){
                 consumer.get(data.items[i].tree());
             }
         }
@@ -103,7 +103,7 @@ abstract class BulletComp implements Timedc, Damagec, Hitboxc, Teamc, Posc, Draw
     @Replace
     @Override
     public boolean collides(Hitboxc other){
-        return type.collides && (other instanceof Teamc t && t.team() != team)
+        return type.collides && (other instanceof Teamc t && team.canDamage(t.team()))
             && !(other instanceof Flyingc f && !f.checkTarget(type.collidesAir, type.collidesGround))
             && !(type.pierce && hasCollided(other.id())); //prevent multiple collisions
     }
@@ -164,7 +164,7 @@ abstract class BulletComp implements Timedc, Damagec, Hitboxc, Teamc, Posc, Draw
             //direct hit on correct tile
             (aimTile != null && aimTile.build == build) ||
             //same team has no 'under build' mechanics
-            (build.team == team) ||
+            (team.isAlly(build.team)) ||
             //a piercing bullet overshot the aim tile, it's fine to hit things now
             (type.pierce && aimTile != null && Mathf.dst(x, y, originX, originY) > aimTile.dst(originX, originY) + 2f) ||
             //there was nothing to aim at
@@ -197,12 +197,12 @@ abstract class BulletComp implements Timedc, Damagec, Hitboxc, Teamc, Posc, Draw
             if(build != null && isAdded()
                 && checkUnderBuild(build, x * tilesize, y * tilesize)
                 && build.collide(self()) && type.testCollision(self(), build)
-                && !build.dead() && (type.collidesTeam || build.team != team) && !(type.pierceBuilding && hasCollided(build.id))){
+                && !build.dead() && (type.collidesTeam || team.canDamage(build.team)) && !(type.pierceBuilding && hasCollided(build.id))){
 
                 boolean remove = false;
                 float health = build.health;
 
-                if(build.team != team){
+                if(team.canDamage(build.team)){
                     remove = build.collision(self());
                 }
 

--- a/core/src/mindustry/entities/comp/CrawlComp.java
+++ b/core/src/mindustry/entities/comp/CrawlComp.java
@@ -87,7 +87,7 @@ abstract class CrawlComp implements Posc, Rotc, Hitboxc, Unitc{
                             }
 
                             //TODO area damage to units
-                            if(t.build != null && t.build.team != team){
+                            if(t.build != null && team.canDamage(t.build.team)){
                                 t.build.damage(team, type.crushDamage * Time.delta * state.rules.unitDamage(team));
                             }
 

--- a/core/src/mindustry/entities/comp/PayloadComp.java
+++ b/core/src/mindustry/entities/comp/PayloadComp.java
@@ -65,11 +65,11 @@ abstract class PayloadComp implements Posc, Rotc, Hitboxc, Unitc{
     }
 
     boolean canPickup(Unit unit){
-        return type.pickupUnits && payloadUsed() + unit.hitSize * unit.hitSize <= type.payloadCapacity + 0.001f && unit.team == team() && unit.isAI();
+        return type.pickupUnits && payloadUsed() + unit.hitSize * unit.hitSize <= type.payloadCapacity + 0.001f && team.canTakeItems(unit.team()) && unit.isAI();
     }
 
     boolean canPickup(Building build){
-        return payloadUsed() + build.block.size * build.block.size * Vars.tilesize * Vars.tilesize <= type.payloadCapacity + 0.001f && build.canPickup() && build.team == team;
+        return payloadUsed() + build.block.size * build.block.size * Vars.tilesize * Vars.tilesize <= type.payloadCapacity + 0.001f && build.canPickup() && team.canTakeItems(build.team);
     }
 
     boolean canPickupPayload(Payload pay){

--- a/core/src/mindustry/entities/comp/TankComp.java
+++ b/core/src/mindustry/entities/comp/TankComp.java
@@ -62,7 +62,7 @@ abstract class TankComp implements Posc, Flyingc, Hitboxc, Unitc, ElevationMovec
                 }
 
                 //TODO should this apply to the player team(s)? currently PvE due to balancing
-                if(type.crushDamage > 0 && (walked || deltaLen() >= 0.01f) && t != null && t.build != null && t.build.team != team
+                if(type.crushDamage > 0 && (walked || deltaLen() >= 0.01f) && t != null && t.build != null && team.isEnemy(t.build.team)
                     //damage radius is 1 tile smaller to prevent it from just touching walls as it passes
                     && Math.max(Math.abs(dx), Math.abs(dy)) <= r - 1){
 

--- a/core/src/mindustry/entities/units/BuildPlan.java
+++ b/core/src/mindustry/entities/units/BuildPlan.java
@@ -72,7 +72,7 @@ public class BuildPlan implements Position, QuadTreeObject{
     public boolean isRotation(Team team){
         if(breaking) return false;
         Tile tile = tile();
-        return tile != null && tile.team() == team && tile.block() == block && tile.build != null && tile.build.rotation != rotation;
+        return tile != null && team.canPlaceOver(tile.team()) && tile.block() == block && tile.build != null && tile.build.rotation != rotation;
     }
 
     public boolean samePos(BuildPlan other){

--- a/core/src/mindustry/game/FogControl.java
+++ b/core/src/mindustry/game/FogControl.java
@@ -153,11 +153,16 @@ public final class FogControl implements CustomChunk{
         synchronized(staticEvents){
             for(var build : Groups.build){
                 if(build.block.flags.contains(BlockFlag.hasFogRadius)){
-                    if(fog[build.team.id] == null){
-                        fog[build.team.id] = new FogData();
-                    }
+                    //TODO glacially slow?
+                    for(var td : state.teams.active){
+                        if(!td.team.canSeeExplored(build.team)) continue;
 
-                    pushEvent(FogEvent.get(build.tile.x, build.tile.y, Mathf.round(build.fogRadius()), build.team.id), initial);
+                        if(fog[build.team.id] == null){
+                            fog[build.team.id] = new FogData();
+                        }
+
+                        pushEvent(FogEvent.get(build.tile.x, build.tile.y, Mathf.round(build.fogRadius()), td.team.id), initial);
+                    }
                 }
             }
         }
@@ -179,7 +184,11 @@ public final class FogControl implements CustomChunk{
 
             if(state.rules.staticFog){
                 synchronized(staticEvents){
-                    pushEvent(FogEvent.get(build.tile.x, build.tile.y, Mathf.round(build.fogRadius()), build.team.id), false);
+                    for(var td : state.teams.active){
+                        if(!td.team.canSeeExplored(build.team)) continue;
+
+                        pushEvent(FogEvent.get(build.tile.x, build.tile.y, Mathf.round(build.fogRadius()), td.team.id), false);
+                    }
                 }
             }
         }

--- a/core/src/mindustry/game/Team.java
+++ b/core/src/mindustry/game/Team.java
@@ -50,6 +50,11 @@ public class Team implements Comparable<Team>{
             new Team(i, "team#" + i, Color.HSVtoRGB(360f * Mathf.random(), 100f * Mathf.random(0.4f, 1f), 100f * Mathf.random(0.6f, 1f), 1f));
         }
         Mathf.rand.setSeed(new Rand().nextLong());
+        //weakly initialize team flags
+        for(int i = 0; i < 256; i++){
+            all[i].flags[0] = TeamFlags.derelictTarget;
+            all[i].flags[i] = TeamFlags.genericSelf;
+        }
     }
 
     public static Team get(int id){
@@ -126,13 +131,23 @@ public class Team implements Comparable<Team>{
         return isAI() && !rules().rtsAi;
     }
 
-    /** flag bindings */
+    /** Reset all flags to their default values. **/
+    public void initializeFlags(){
+        for(int i = 0; i < 256; i++){
+            for(int j = 1; j < 256; j++){
+                all[i].flags[j] = TeamFlags.genericEnemy;
+            }
+            all[i].flags[0] = TeamFlags.derelictTarget;
+            all[i].flags[i] = TeamFlags.genericSelf;
+        }
+    }
+
+    /** Flag binding methods. */
     public boolean isEnemy(Team other){
         if(other == null) return false;
         return (this.flags[other.id] & TeamFlags.isNeutral) == 0;
     }
 
-    /** used for rendering */
     public boolean isAlly(Team other){
         if(other == null) return false;
         return (this.flags[other.id] & TeamFlags.allyCheck) == TeamFlags.allyCheck;

--- a/core/src/mindustry/game/Team.java
+++ b/core/src/mindustry/game/Team.java
@@ -21,6 +21,7 @@ public class Team implements Comparable<Team>{
     public String emoji = "";
     public boolean hasPalette;
     public String name;
+    public int[] flags = new int[256];
 
     /** All 256 registered teams. */
     public static final Team[] all = new Team[256];
@@ -125,10 +126,76 @@ public class Team implements Comparable<Team>{
         return isAI() && !rules().rtsAi;
     }
 
-    /** @deprecated There is absolutely no reason to use this. */
-    @Deprecated
+    /** flag bindings */
     public boolean isEnemy(Team other){
-        return this != other;
+        if(other == null) return false;
+        return (this.flags[other.id] & TeamFlags.isNeutral) == 0;
+    }
+
+    /** used for rendering */
+    public boolean isAlly(Team other){
+        if(other == null) return false;
+        return (this.flags[other.id] & TeamFlags.allyCheck) == TeamFlags.allyCheck;
+    }
+
+    public boolean canDamage(Team other){
+        if(other == null) return false;
+        return (this.flags[other.id] & TeamFlags.cannotDamage) == 0;
+    }
+
+    public boolean canPlaceOver(Team other){
+        if(other == null) return false;
+        return (this.flags[other.id] & TeamFlags.canPlaceOver) != 0;
+    }
+
+    public boolean canDeconstruct(Team other){
+        if(other == null) return false;
+        return (this.flags[other.id] & TeamFlags.canDeconstruct) != 0;
+    }
+
+    public boolean canAssistBuilding(Team other){
+        if(other == null) return false;
+        return (this.flags[other.id] & TeamFlags.canAssistBuilding) != 0;
+    }
+
+    public boolean canAttach(Team other){
+        if(other == null) return false;
+        return (this.flags[other.id] & TeamFlags.canAttach) != 0;
+    }
+
+    public boolean canInteract(Team other){
+        if(other == null) return false;
+        return (this.flags[other.id] & TeamFlags.canInteract) != 0;
+    }
+
+    public boolean ignoresBuildRadius(Team other){
+        if(other == null) return false;
+        return (this.flags[other.id] & TeamFlags.ignoresBuildRadius) != 0;
+    }
+
+    public boolean canLogicBlocks(Team other){
+        if(other == null) return false;
+        return (this.flags[other.id] & TeamFlags.canLogicBlocks) != 0;
+    }
+
+    public boolean canLogicUnits(Team other){
+        if(other == null) return false;
+        return (this.flags[other.id] & TeamFlags.canLogicUnits) != 0;
+    }
+
+    public boolean canGiveItems(Team other){
+        if(other == null) return false;
+        return (this.flags[other.id] & TeamFlags.canGiveItems) != 0;
+    }
+
+    public boolean canTakeItems(Team other){
+        if(other == null) return false;
+        return (this.flags[other.id] & TeamFlags.canTakeItems) != 0;
+    }
+
+    //TODO might be easier to just OR-bitmask in fog code?
+    public boolean canSeeExplored(Team other){
+        return (this.flags[other.id] & TeamFlags.canSeeExplored) != 0;
     }
 
     public Seq<CoreBuild> cores(){

--- a/core/src/mindustry/game/TeamFlags.java
+++ b/core/src/mindustry/game/TeamFlags.java
@@ -1,0 +1,51 @@
+package mindustry.game;
+
+/** A list of strictly-positive flags for team interactions. */
+public class TeamFlags{
+    //These flags control whether the source team:
+    public static final int
+
+    //will not default targeting the other team
+    isNeutral = 1,
+    //is unable to target and damage the other team (excluding reactors)
+    cannotDamage = 1 << 1,
+    //can replace and/or upgrade buildings
+    canPlaceOver = 1 << 2,
+    //can deconstruct the other team's buildings
+    canDeconstruct = 1 << 3,
+    //can help (de)construct unfinished buildings of the other team
+    canAssistBuilding = 1 << 4,
+    //can use the other team's buildings as targets (including connecting them in cursed cross-team power graphs)
+    canAttach = 1 << 5,
+    //can configure and see data of the other team's buildings
+    canInteract = 1 << 6,
+    //will ignore the no-build radius of the other team
+    ignoresBuildRadius = 1 << 7,
+    //can logic control the other team's blocks
+    canLogicBlocks = 1 << 8,
+    //can logic control (but not naturally bind) the other team's units
+    canLogicUnits = 1 << 9,
+    //can give items and payloads to the other team, including via blocks
+    canGiveItems = 1 << 10,
+    //can take items and payloads from the other team, primarily with units
+    canTakeItems = 1 << 11,
+    //can see through fog with the other team
+    canSeeExplored = 1 << 12,
+
+    //enemies don't get any positive attributes
+    genericEnemy = 0,
+    //derelict buildings aren't owned by anyone
+    derelictTarget = canTakeItems | canGiveItems | canLogicBlocks | ignoresBuildRadius |
+                     canInteract | canDeconstruct | isNeutral,
+    //true neutrals don't interact
+    genericNeutral = isNeutral,
+    //player-controlled neutrals usually interact differently
+    greedyNeutral = canGiveItems | isNeutral,
+    //"allies" are considered more cooperative than neutral teams
+    genericAlly = canSeeExplored | canGiveItems | canAttach | canAssistBuilding |
+                  canPlaceOver | cannotDamage | isNeutral,
+    //lenient check for if a team is considered allied or not
+    allyCheck = cannotDamage | isNeutral,
+    //normally attributed to own teams or trusted teams, full access
+    genericSelf = 0x1fff;
+}

--- a/core/src/mindustry/game/Teams.java
+++ b/core/src/mindustry/game/Teams.java
@@ -95,7 +95,7 @@ public class Teams{
 
     public void eachRadiusCore(Team team, Cons<Building> ret){
         for(TeamData data : active){
-            if(team.ignoresBuildRadius(data.team)){
+            if(!team.ignoresBuildRadius(data.team)){
                 for(Building tile : data.cores){
                     ret.get(tile);
                 }

--- a/core/src/mindustry/game/Teams.java
+++ b/core/src/mindustry/game/Teams.java
@@ -55,6 +55,7 @@ public class Teams{
         return Geometry.findClosest(x, y, get(team).cores);
     }
 
+    //possibly deprecate: formerly only used in Build
     public boolean anyEnemyCoresWithin(Team team, float x, float y, float radius){
         for(TeamData data : active){
             if(team.isEnemy(data.team)){
@@ -68,9 +69,33 @@ public class Teams{
         return false;
     }
 
+    public boolean anyRadiusCoresWithin(Team team, float x, float y, float radius){
+        for(TeamData data : active){
+            if(!team.ignoresBuildRadius(data.team)){
+                for(CoreBuild tile : data.cores){
+                    if(tile.within(x, y, radius)){
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    //possibly deprecate: formerly only used in OverlayRenderer
     public void eachEnemyCore(Team team, Cons<Building> ret){
         for(TeamData data : active){
             if(team.isEnemy(data.team)){
+                for(Building tile : data.cores){
+                    ret.get(tile);
+                }
+            }
+        }
+    }
+
+    public void eachRadiusCore(Team team, Cons<Building> ret){
+        for(TeamData data : active){
+            if(team.ignoresBuildRadius(data.team)){
                 for(Building tile : data.cores){
                     ret.get(tile);
                 }

--- a/core/src/mindustry/game/Teams.java
+++ b/core/src/mindustry/game/Teams.java
@@ -57,7 +57,7 @@ public class Teams{
 
     public boolean anyEnemyCoresWithin(Team team, float x, float y, float radius){
         for(TeamData data : active){
-            if(team != data.team){
+            if(team.isEnemy(data.team)){
                 for(CoreBuild tile : data.cores){
                     if(tile.within(x, y, radius)){
                         return true;
@@ -70,7 +70,7 @@ public class Teams{
 
     public void eachEnemyCore(Team team, Cons<Building> ret){
         for(TeamData data : active){
-            if(team != data.team){
+            if(team.isEnemy(data.team)){
                 for(Building tile : data.cores){
                     ret.get(tile);
                 }
@@ -102,8 +102,10 @@ public class Teams{
         return get(team).active();
     }
 
+    //maybe deprecate
     public boolean canInteract(Team team, Team other){
-        return team == other || other == Team.derelict;
+        return team.canInteract(other);
+        //return team == other || other == Team.derelict;
     }
 
     /** Do not modify. */
@@ -229,7 +231,7 @@ public class Teams{
             Seq<Team> enemies = new Seq<>();
 
             for(TeamData other : active){
-                if(data.team != other.team){
+                if(data.team.isEnemy(other.team)){
                     enemies.add(other.team);
                 }
             }

--- a/core/src/mindustry/graphics/BlockRenderer.java
+++ b/core/src/mindustry/graphics/BlockRenderer.java
@@ -89,7 +89,7 @@ public class BlockRenderer{
                     updateFloors.add(new UpdateRenderState(tile, tile.overlay()));
                 }
 
-                if(tile.build != null && (tile.team() == player.team() || !state.rules.fog || (tile.build.visibleFlags & (1L << player.team().id)) != 0)){
+                if(tile.build != null && (player.team().canSeeExplored(tile.team()) || !state.rules.fog || (tile.build.visibleFlags & (1L << player.team().id)) != 0)){
                     tile.build.wasVisible = true;
                 }
 

--- a/core/src/mindustry/graphics/FogRenderer.java
+++ b/core/src/mindustry/graphics/FogRenderer.java
@@ -64,13 +64,15 @@ public final class FogRenderer{
             ScissorStack.push(rect.set(1, 1, staticFog.getWidth() - 2, staticFog.getHeight() - 2));
 
             Team team = player.team();
+            for(var td : state.teams.active){
+                if(!team.canSeeExplored(td.team)) continue;
+                for(var build : indexer.getFlagged(team, BlockFlag.hasFogRadius)){
+                    poly(build.x, build.y, build.fogRadius() * tilesize);
+                }
 
-            for(var build : indexer.getFlagged(team, BlockFlag.hasFogRadius)){
-                poly(build.x, build.y, build.fogRadius() * tilesize);
-            }
-
-            for(var unit : team.data().units){
-                poly(unit.x, unit.y, unit.type.fogRadius * tilesize);
+                for(var unit : team.data().units){
+                    poly(unit.x, unit.y, unit.type.fogRadius * tilesize);
+                }
             }
 
             dynamicFog.end();

--- a/core/src/mindustry/graphics/OverlayRenderer.java
+++ b/core/src/mindustry/graphics/OverlayRenderer.java
@@ -173,7 +173,7 @@ public class OverlayRenderer{
                     float offset = (i == 0 ? -2f : 0f);
                     for(CoreEdge edge : cedges){
                         Team displayed = edge.displayed();
-                        if(displayed != null){
+                        if(displayed != null && !player.team().ignoresBuildRadius(displayed)){
                             Draw.color(i == 0 ? Color.darkGray : Tmp.c1.set(displayed.color).lerp(Pal.accent, Mathf.absin(Time.time, 10f, 0.2f)));
                             Lines.line(edge.x1, edge.y1 + offset, edge.x2, edge.y2 + offset);
                         }

--- a/core/src/mindustry/graphics/OverlayRenderer.java
+++ b/core/src/mindustry/graphics/OverlayRenderer.java
@@ -182,7 +182,7 @@ public class OverlayRenderer{
 
                 Draw.color();
             }else{
-                state.teams.eachEnemyCore(player.team(), core -> {
+                state.teams.eachRadiusCore(player.team(), core -> {
                     //it must be clear that there is a core here.
                     if(/*core.wasVisible && */Core.camera.bounds(Tmp.r1).overlaps(Tmp.r2.setCentered(core.x, core.y, state.rules.enemyCoreBuildRadius * 2f))){
                         Draw.color(Color.darkGray);

--- a/core/src/mindustry/graphics/OverlayRenderer.java
+++ b/core/src/mindustry/graphics/OverlayRenderer.java
@@ -213,7 +213,7 @@ public class OverlayRenderer{
             Vec2 vec = Core.input.mouseWorld(input.getMouseX(), input.getMouseY());
             Building build = world.buildWorld(vec.x, vec.y);
 
-            if(build != null && build.team == player.team()){
+            if(build != null && player.team().canInteract(build.team)){
                 build.drawSelect();
                 if(!build.enabled && build.block.drawDisabled){
                    build.drawDisabled();

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -451,7 +451,7 @@ public class DesktopInput extends InputHandler{
                 cursorType = cursor.build.getCursor();
             }
 
-            if(cursor.build != null && cursor.build.team == Team.derelict && Build.validPlace(cursor.block(), player.team(), cursor.build.tileX(), cursor.build.tileY(), cursor.build.rotation)){
+            if(cursor.build != null && cursor.build.team == Team.derelict && Build.validPlace(cursor.block(), player.team(), cursor.build.tileX(), cursor.build.tileY(), cursor.build.rotation) && player.team().canDeconstruct(cursor.build.team)){
                 cursorType = ui.repairCursor;
             }
 
@@ -464,7 +464,7 @@ public class DesktopInput extends InputHandler{
             }
 
             if(commandMode && selectedUnits.any()){
-                boolean canAttack = (cursor.build != null && !cursor.build.inFogTo(player.team()) && cursor.build.team != player.team());
+                boolean canAttack = (cursor.build != null && !cursor.build.inFogTo(player.team()) && player.team().canDamage(cursor.build.team));
 
                 if(!canAttack){
                     var unit = selectedEnemyUnit(input.mouseWorldX(), input.mouseWorldY());

--- a/core/src/mindustry/input/MobileInput.java
+++ b/core/src/mindustry/input/MobileInput.java
@@ -96,7 +96,7 @@ public class MobileInput extends InputHandler implements GestureListener{
         }else{
             Building tile = world.buildWorld(x, y);
 
-            if((tile != null && player.team() != tile.team && (tile.team != Team.derelict || state.rules.coreCapture)) || (tile != null && player.unit().type.canHeal && tile.team == player.team() && tile.damaged())){
+            if((tile != null && player.team().canDamage(tile.team) && (tile.team != Team.derelict || state.rules.coreCapture)) || (tile != null && player.unit().type.canHeal && !player.team().isEnemy(tile.team) && tile.damaged())){
                 player.unit().mineTile = null;
                 target = tile;
             }
@@ -613,7 +613,7 @@ public class MobileInput extends InputHandler implements GestureListener{
                     }else{
                         Building build = world.buildWorld(pos.x, pos.y);
 
-                        if(build != null && build.team == player.team() && (pay.canPickup(build) || build.getPayload() != null && pay.canPickupPayload(build.getPayload()))){
+                        if(build != null && player.team().canGiveItems(build.team) && (pay.canPickup(build) || build.getPayload() != null && pay.canPickupPayload(build.getPayload()))){
                             payloadTarget = build;
                         }else if(pay.hasPayload()){
                             //drop off at position
@@ -965,7 +965,7 @@ public class MobileInput extends InputHandler implements GestureListener{
 
         boolean omni = unit.type.omniMovement;
         boolean allowHealing = type.canHeal;
-        boolean validHealTarget = allowHealing && target instanceof Building b && b.isValid() && target.team() == unit.team && b.damaged() && target.within(unit, type.range);
+        boolean validHealTarget = allowHealing && target instanceof Building b && b.isValid() && !unit.team.canDamage(target.team()) && b.damaged() && target.within(unit, type.range);
         boolean boosted = (unit instanceof Mechc && unit.isFlying());
 
         //reset target if:
@@ -1003,7 +1003,7 @@ public class MobileInput extends InputHandler implements GestureListener{
                 if(payloadTarget instanceof Vec2 && pay.hasPayload()){
                     //vec -> dropping something
                     tryDropPayload();
-                }else if(payloadTarget instanceof Building build && build.team == unit.team){
+                }else if(payloadTarget instanceof Building build && unit.team.canTakeItems(build.team)){
                     //building -> picking building up
                     Call.requestBuildPayload(player, build);
                 }else if(payloadTarget instanceof Unit other && pay.canPickup(other)){

--- a/core/src/mindustry/logic/RadarTarget.java
+++ b/core/src/mindustry/logic/RadarTarget.java
@@ -5,8 +5,8 @@ import mindustry.gen.*;
 
 public enum RadarTarget{
     any((team, other) -> true),
-    enemy((team, other) -> team != other.team && other.team != Team.derelict),
-    ally((team, other) -> team == other.team),
+    enemy((team, other) -> team.isEnemy(other.team)),
+    ally((team, other) -> team.isAlly(other.team)),
     player((team, other) -> other.isPlayer()),
     attacker((pos, other) -> other.canShoot()),
     flying((team, other) -> other.isFlying()),

--- a/core/src/mindustry/maps/Map.java
+++ b/core/src/mindustry/maps/Map.java
@@ -123,7 +123,7 @@ public class Map implements Comparable<Map>, Publishable{
         }
         return maps.readFilters(tags.get("genfilters", ""));
     }
-    
+
     public String name(){
         return tag("name");
     }
@@ -135,7 +135,7 @@ public class Map implements Comparable<Map>, Publishable{
     public String description(){
         return tag("description");
     }
-    
+
     public String plainName() {
         return Strings.stripColors(name());
     }
@@ -165,13 +165,13 @@ public class Map implements Comparable<Map>, Publishable{
     public void addSteamID(String id){
         tags.put("steamid", id);
         editor.tags.put("steamid", id);
-        
+
         try{
             ui.editor.save();
         }catch(Exception e){
             Log.err(e);
         }
-        
+
         Events.fire(new MapPublishEvent());
     }
 
@@ -179,7 +179,7 @@ public class Map implements Comparable<Map>, Publishable{
     public void removeSteamID(){
         tags.remove("steamid");
         editor.tags.remove("steamid");
-        
+
         try{
             ui.editor.save();
         }catch(Exception e){

--- a/core/src/mindustry/type/weapons/PointDefenseWeapon.java
+++ b/core/src/mindustry/type/weapons/PointDefenseWeapon.java
@@ -40,12 +40,12 @@ public class PointDefenseWeapon extends Weapon{
 
     @Override
     protected Teamc findTarget(Unit unit, float x, float y, float range, boolean air, boolean ground){
-        return Groups.bullet.intersect(x - range, y - range, range*2, range*2).min(b -> b.team != unit.team && b.type().hittable, b -> b.dst2(x, y));
+        return Groups.bullet.intersect(x - range, y - range, range*2, range*2).min(b -> b.team.canDamage(unit.team) && b.type().hittable, b -> b.dst2(x, y));
     }
 
     @Override
     protected boolean checkTarget(Unit unit, Teamc target, float x, float y, float range){
-        return !(target.within(unit, range) && target.team() != unit.team && target instanceof Bullet bullet && bullet.type != null && bullet.type.hittable);
+        return !(target.within(unit, range) && target.team().canDamage(unit.team) && target instanceof Bullet bullet && bullet.type != null && bullet.type.hittable);
     }
 
     @Override

--- a/core/src/mindustry/type/weapons/RepairBeamWeapon.java
+++ b/core/src/mindustry/type/weapons/RepairBeamWeapon.java
@@ -93,7 +93,7 @@ public class RepairBeamWeapon extends Weapon{
 
     @Override
     protected boolean checkTarget(Unit unit, Teamc target, float x, float y, float range){
-        return !(target.within(unit, range + unit.hitSize/2f) && target.team() == unit.team && target instanceof Healthc u && u.damaged() && u.isValid());
+        return !(target.within(unit, range + unit.hitSize/2f) && !unit.team.isEnemy(target.team()) && target instanceof Healthc u && u.damaged() && u.isValid());
     }
 
     @Override
@@ -130,7 +130,7 @@ public class RepairBeamWeapon extends Weapon{
                 //snap to closest building
                 World.raycastEachWorld(wx, wy, heal.lastEnd.x, heal.lastEnd.y, (x, y) -> {
                     var build = Vars.world.build(x, y);
-                    if(build != null && build.team == unit.team && build.damaged()){
+                    if(build != null && !unit.team.isEnemy(build.team) && build.damaged()){
                         heal.target = build;
                         heal.lastEnd.set(x * tilesize, y * tilesize);
                         return true;

--- a/core/src/mindustry/ui/fragments/HudFragment.java
+++ b/core/src/mindustry/ui/fragments/HudFragment.java
@@ -814,7 +814,7 @@ public class HudFragment{
             }
 
             if(!state.rules.waves && state.rules.attackMode){
-                int sum = Math.max(state.teams.present.sum(t -> t.team != player.team() ? t.cores.size : 0), 1);
+                int sum = Math.max(state.teams.present.sum(t -> player.team().isEnemy(t.team) ? t.cores.size : 0), 1);
                 builder.append(sum > 1 ? enemycsf.get(sum) : enemycf.get(sum));
                 return builder;
             }

--- a/core/src/mindustry/world/Build.java
+++ b/core/src/mindustry/world/Build.java
@@ -78,7 +78,7 @@ public class Build{
         if(tile == null) return;
 
         //auto-rotate the block to the correct orientation and bail out
-        if(tile.team() == team && tile.block == result && tile.build != null && tile.block.quickRotate){
+        if(team.canPlaceOver(tile.team()) && tile.block == result && tile.build != null && tile.block.quickRotate){
             if(unit != null && unit.getControllerName() != null) tile.build.lastAccessed = unit.getControllerName();
             int previous = tile.build.rotation;
             tile.build.rotation = Mathf.mod(rotation, 4);
@@ -130,7 +130,7 @@ public class Build{
         tmp.clear();
 
         tile.getLinkedTilesAs(result, t -> {
-            if(t.build != null && t.build.team == team && tmp.add(t.build.id)){
+            if(t.build != null && team.canPlaceOver(t.build.team) && tmp.add(t.build.id)){
                 prevBuild.add(t.build);
             }
         });
@@ -178,7 +178,7 @@ public class Build{
                         }
                     }
                 }
-                if(closest != null && closest.team != team){
+                if(closest != null && !team.ignoresBuildRadius(closest.team)){
                     return false;
                 }
             }else if(state.teams.anyEnemyCoresWithin(team, x * tilesize + type.offset, y * tilesize + type.offset, state.rules.enemyCoreBuildRadius + tilesize)){
@@ -284,6 +284,6 @@ public class Build{
     /** Returns whether the tile at this position is breakable by this team */
     public static boolean validBreak(Team team, int x, int y){
         Tile tile = world.tile(x, y);
-        return tile != null && tile.block().canBreak(tile) && tile.breakable() && tile.interactable(team);
+        return tile != null && tile.block().canBreak(tile) && tile.breakable() && team.canDeconstruct(tile.team());
     }
 }

--- a/core/src/mindustry/world/blocks/Autotiler.java
+++ b/core/src/mindustry/world/blocks/Autotiler.java
@@ -184,7 +184,7 @@ public interface Autotiler{
     // TODO docs -- use for direction?
     default boolean blends(Tile tile, int rotation, int direction){
         Building other = tile.nearbyBuild(Mathf.mod(rotation - direction, 4));
-        return other != null && other.team == tile.team() && blends(tile, rotation, other.tileX(), other.tileY(), other.rotation, other.block);
+        return other != null && (tile.team().canAttach(other.team) || other.team.canAttach(tile.team())) && blends(tile, rotation, other.tileX(), other.tileY(), other.rotation, other.block);
     }
 
     default boolean blendsArmored(Tile tile, int rotation, int otherx, int othery, int otherrot, Block otherblock){

--- a/core/src/mindustry/world/blocks/campaign/LaunchPad.java
+++ b/core/src/mindustry/world/blocks/campaign/LaunchPad.java
@@ -147,7 +147,7 @@ public class LaunchPad extends Block{
         public void display(Table table){
             super.display(table);
 
-            if(!state.isCampaign() || net.client() || team != player.team()) return;
+            if(!state.isCampaign() || net.client() || !player.team().canInteract(team)) return;
 
             table.row();
             table.label(() -> {

--- a/core/src/mindustry/world/blocks/defense/BaseShield.java
+++ b/core/src/mindustry/world/blocks/defense/BaseShield.java
@@ -23,7 +23,7 @@ public class BaseShield extends Block{
     protected static BaseShieldBuild paramBuild;
     //protected static Effect paramEffect;
     protected static final Cons<Bullet> bulletConsumer = bullet -> {
-        if(bullet.team != paramBuild.team && bullet.type.absorbable && bullet.within(paramBuild, paramBuild.radius())){
+        if(bullet.team.canDamage(paramBuild.team) && bullet.type.absorbable && bullet.within(paramBuild, paramBuild.radius())){
             bullet.absorb();
             //paramEffect.at(bullet);
 

--- a/core/src/mindustry/world/blocks/defense/DirectionalForceProjector.java
+++ b/core/src/mindustry/world/blocks/defense/DirectionalForceProjector.java
@@ -26,7 +26,7 @@ public class DirectionalForceProjector extends Block{
     protected static DirectionalForceProjectorBuild paramEntity;
     protected static Effect paramEffect;
     protected static final Cons<Bullet> dirShieldConsumer = b -> {
-        if(b.team != paramEntity.team && b.type.absorbable){
+        if(b.team.canDamage(paramEntity.team) && b.type.absorbable){
             //just in case
             float deltaAdd = 1.1f;
 

--- a/core/src/mindustry/world/blocks/defense/ForceProjector.java
+++ b/core/src/mindustry/world/blocks/defense/ForceProjector.java
@@ -48,7 +48,7 @@ public class ForceProjector extends Block{
     protected static ForceBuild paramEntity;
     protected static Effect paramEffect;
     protected static final Cons<Bullet> shieldConsumer = bullet -> {
-        if(bullet.team != paramEntity.team && bullet.type.absorbable && Intersector.isInRegularPolygon(((ForceProjector)(paramEntity.block)).sides, paramEntity.x, paramEntity.y, paramEntity.realRadius(), ((ForceProjector)(paramEntity.block)).shieldRotation, bullet.x, bullet.y)){
+        if(bullet.team.canDamage(paramEntity.team) && bullet.type.absorbable && Intersector.isInRegularPolygon(((ForceProjector)(paramEntity.block)).sides, paramEntity.x, paramEntity.y, paramEntity.realRadius(), ((ForceProjector)(paramEntity.block)).shieldRotation, bullet.x, bullet.y)){
             bullet.absorb();
             paramEffect.at(bullet);
             paramEntity.hit = 1f;
@@ -237,7 +237,7 @@ public class ForceProjector extends Block{
                 Draw.z(Layer.block);
                 Draw.reset();
             }
-            
+
             drawShield();
         }
 

--- a/core/src/mindustry/world/blocks/defense/ShockMine.java
+++ b/core/src/mindustry/world/blocks/defense/ShockMine.java
@@ -56,7 +56,7 @@ public class ShockMine extends Block{
 
         @Override
         public void unitOn(Unit unit){
-            if(enabled && unit.team != team && timer(timerDamage, cooldown)){
+            if(enabled && team.canDamage(unit.team) && timer(timerDamage, cooldown)){
                 triggered();
                 damage(tileDamage);
             }

--- a/core/src/mindustry/world/blocks/defense/ShockwaveTower.java
+++ b/core/src/mindustry/world/blocks/defense/ShockwaveTower.java
@@ -72,7 +72,7 @@ public class ShockwaveTower extends Block{
             if(potentialEfficiency > 0 && (reloadCounter += Time.delta) >= reload && timer(timerCheck, checkInterval)){
                 targets.clear();
                 Groups.bullet.intersect(x - range, y - range, range * 2, range * 2, b -> {
-                    if(b.team != team && b.type.hittable){
+                    if(team.isEnemy(b.team) && b.type.hittable){
                         targets.add(b);
                     }
                 });

--- a/core/src/mindustry/world/blocks/defense/turrets/LiquidTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/LiquidTurret.java
@@ -85,7 +85,7 @@ public class LiquidTurret extends Turret{
                         var fire = Fires.get(x + tx, y + ty);
                         float dst = fire == null ? 0 : dst2(fire);
                         //do not extinguish fires on other team blocks
-                        if(other != null && fire != null && Fires.has(other.x, other.y) && dst <= range * range && (result == null || dst < mindst) && (other.build == null || other.team() == team)){
+                        if(other != null && fire != null && Fires.has(other.x, other.y) && dst <= range * range && (result == null || dst < mindst) && (other.build == null || team.isAlly(other.team()))){
                             result = fire;
                             mindst = dst;
                         }

--- a/core/src/mindustry/world/blocks/defense/turrets/PointDefenseTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/PointDefenseTurret.java
@@ -62,7 +62,7 @@ public class PointDefenseTurret extends ReloadTurret{
 
             //retarget
             if(timer(timerTarget, retargetTime)){
-                target = Groups.bullet.intersect(x - range, y - range, range*2, range*2).min(b -> b.team != team && b.type().hittable, b -> b.dst2(this));
+                target = Groups.bullet.intersect(x - range, y - range, range*2, range*2).min(b -> b.team.canDamage(team) && b.type().hittable, b -> b.dst2(this));
             }
 
             //pooled bullets
@@ -75,7 +75,7 @@ public class PointDefenseTurret extends ReloadTurret{
             }
 
             //look at target
-            if(target != null && target.within(this, range) && target.team != team && target.type() != null && target.type().hittable){
+            if(target != null && target.within(this, range) && target.team.canDamage(team) && target.type() != null && target.type().hittable){
                 float dest = angleTo(target);
                 rotation = Angles.moveToward(rotation, dest, rotateSpeed * edelta());
                 reloadCounter += edelta();

--- a/core/src/mindustry/world/blocks/defense/turrets/TractorBeamTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/TractorBeamTurret.java
@@ -103,7 +103,7 @@ public class TractorBeamTurret extends BaseTurret{
             any = false;
 
             //look at target
-            if(target != null && target.within(this, range + target.hitSize/2f) && target.team() != team && target.checkTarget(targetAir, targetGround) && efficiency > 0.02f){
+            if(target != null && target.within(this, range + target.hitSize/2f) && team.isEnemy(target.team()) && target.checkTarget(targetAir, targetGround) && efficiency > 0.02f){
                 if(!headless){
                     control.sound.loop(shootSound, this, shootSoundVolume);
                 }

--- a/core/src/mindustry/world/blocks/distribution/Conveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/Conveyor.java
@@ -216,7 +216,7 @@ public class Conveyor extends Block implements Autotiler{
             blending = bits[4];
 
             next = front();
-            nextc = next instanceof ConveyorBuild && next.team == team ? (ConveyorBuild)next : null;
+            nextc = next instanceof ConveyorBuild && team.canGiveItems(next.team) ? (ConveyorBuild)next : null;
             aligned = nextc != null && rotation == next.rotation;
         }
 
@@ -295,7 +295,7 @@ public class Conveyor extends Block implements Autotiler{
         }
 
         public boolean pass(Item item){
-            if(item != null && next != null && next.team == team && next.acceptItem(this, item)){
+            if(item != null && next != null && team.canGiveItems(next.team) && next.acceptItem(this, item)){
                 next.handleItem(this, item);
                 return true;
             }

--- a/core/src/mindustry/world/blocks/distribution/DirectionBridge.java
+++ b/core/src/mindustry/world/blocks/distribution/DirectionBridge.java
@@ -94,7 +94,7 @@ public class DirectionBridge extends Block{
         for(int i = 1; i <= range; i++){
             Tile other = world.tile(x + dx * i, y + dy * i);
 
-            if(other != null && other.build instanceof DirectionBridgeBuild build && build.block == this && build.team == player.team()){
+            if(other != null && other.build instanceof DirectionBridgeBuild build && build.block == this && player.team().canGiveItems(build.team)){
                 length = i;
                 found = other.build;
                 break;
@@ -208,7 +208,7 @@ public class DirectionBridge extends Block{
         public DirectionBridgeBuild findLink(){
             for(int i = 1; i <= range; i++){
                 Tile other = tile.nearby(Geometry.d4x(rotation) * i, Geometry.d4y(rotation) * i);
-                if(other != null && other.build instanceof DirectionBridgeBuild build && build.block == DirectionBridge.this && build.team == team){
+                if(other != null && other.build instanceof DirectionBridgeBuild build && build.block == DirectionBridge.this && team.canGiveItems(build.team)){
                     return build;
                 }
             }

--- a/core/src/mindustry/world/blocks/distribution/DirectionLiquidBridge.java
+++ b/core/src/mindustry/world/blocks/distribution/DirectionLiquidBridge.java
@@ -83,7 +83,7 @@ public class DirectionLiquidBridge extends DirectionBridge{
             int rel = this.relativeToEdge(source.tile);
 
             return
-                hasLiquids && team == source.team &&
+                hasLiquids && source.team.canGiveItems(team) &&
                 (liquids.current() == liquid || liquids.get(liquids.current()) < 0.2f) && rel != rotation &&
                 (occupied[(rel + 2) % 4] == null || occupied[(rel + 2) % 4] == source);
         }

--- a/core/src/mindustry/world/blocks/distribution/DirectionalUnloader.java
+++ b/core/src/mindustry/world/blocks/distribution/DirectionalUnloader.java
@@ -86,7 +86,7 @@ public class DirectionalUnloader extends Block{
             if((unloadTimer += edelta()) >= speed){
                 Building front = front(), back = back();
 
-                if(front != null && back != null && back.items != null && front.team == team && back.team == team && back.canUnload() && (allowCoreUnload || !(back instanceof CoreBuild || (back instanceof StorageBuild sb && sb.linkedCore != null)))){
+                if(front != null && back != null && back.items != null && team.canGiveItems(front.team) && team.canTakeItems(back.team) && back.canUnload() && (allowCoreUnload || !(back instanceof CoreBuild || (back instanceof StorageBuild sb && sb.linkedCore != null)))){
                     if(unloadItem == null){
                         var itemseq = content.items();
                         int itemc = itemseq.size;

--- a/core/src/mindustry/world/blocks/distribution/DuctRouter.java
+++ b/core/src/mindustry/world/blocks/distribution/DuctRouter.java
@@ -127,7 +127,7 @@ public class DuctRouter extends Block{
                 Building other = proximity.get((i + dump) % proximity.size);
                 int rel = relativeTo(other);
 
-                if(!(sortItem != null && (current == sortItem) != (rel == rotation)) && !(rel == (rotation + 2) % 4) && other.team == team && other.acceptItem(this, current)){
+                if(!(sortItem != null && (current == sortItem) != (rel == rotation)) && !(rel == (rotation + 2) % 4) && team.canGiveItems(other.team) && other.acceptItem(this, current)){
                     incrementDump(proximity.size);
                     return other;
                 }

--- a/core/src/mindustry/world/blocks/distribution/ItemBridge.java
+++ b/core/src/mindustry/world/blocks/distribution/ItemBridge.java
@@ -136,7 +136,7 @@ public class ItemBridge extends Block{
         if(other == null || tile == null || !positionsValid(tile.x, tile.y, other.x, other.y)) return false;
 
         return ((other.block() == tile.block() && tile.block() == this) || (!(tile.block() instanceof ItemBridge) && other.block() == this))
-            && (other.team() == tile.team() || tile.block() != this)
+            && ((tile.team().canAttach(other.team()) && tile.team().canGiveItems(other.team())) || tile.block() != this)
             && (!checkDouble || ((ItemBridgeBuild)other.build).link != tile.pos());
     }
 
@@ -402,7 +402,7 @@ public class ItemBridge extends Block{
 
         @Override
         public boolean acceptItem(Building source, Item item){
-            return hasItems && team == source.team && items.total() < itemCapacity && checkAccept(source, world.tile(link));
+            return hasItems && source.team.canGiveItems(team) && items.total() < itemCapacity && checkAccept(source, world.tile(link));
         }
 
         @Override
@@ -413,7 +413,7 @@ public class ItemBridge extends Block{
         @Override
         public boolean acceptLiquid(Building source, Liquid liquid){
             return
-                hasLiquids && team == source.team &&
+                hasLiquids && source.team.canGiveItems(team) &&
                 (liquids.current() == liquid || liquids.get(liquids.current()) < 0.2f) &&
                 checkAccept(source, world.tile(link));
         }

--- a/core/src/mindustry/world/blocks/distribution/Junction.java
+++ b/core/src/mindustry/world/blocks/distribution/Junction.java
@@ -52,7 +52,7 @@ public class Junction extends Block{
                         Building dest = nearby(i);
 
                         //skip blocks that don't want the item, keep waiting until they do
-                        if(item == null || dest == null || !dest.acceptItem(this, item) || dest.team != team){
+                        if(item == null || dest == null || !dest.acceptItem(this, item) || !team.canGiveItems(dest.team)){
                             continue;
                         }
 
@@ -76,7 +76,7 @@ public class Junction extends Block{
 
             if(relative == -1 || !buffer.accepts(relative)) return false;
             Building to = nearby(relative);
-            return to != null && to.team == team;
+            return to != null && team.canGiveItems(to.team);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/distribution/MassDriver.java
+++ b/core/src/mindustry/world/blocks/distribution/MassDriver.java
@@ -260,7 +260,7 @@ public class MassDriver extends Block{
             if(link == other.pos()){
                 configure(-1);
                 return false;
-            }else if(other.block == block && other.dst(tile) <= range && other.team == team){
+            }else if(other.block == block && other.dst(tile) <= range && team.canAttach(other.team)){
                 configure(other.pos());
                 return false;
             }
@@ -299,7 +299,7 @@ public class MassDriver extends Block{
             smokeEffect.at(x + Angles.trnsx(angle, translation), y + Angles.trnsy(angle, translation), angle);
 
             Effect.shake(shake, shake, this);
-            
+
             shootSound.at(tile, Mathf.random(0.9f, 1.1f));
         }
 
@@ -331,7 +331,7 @@ public class MassDriver extends Block{
 
         protected boolean linkValid(){
             if(link == -1) return false;
-            return world.build(this.link) instanceof MassDriverBuild other && other.block == block && other.team == team && within(other, range);
+            return world.build(this.link) instanceof MassDriverBuild other && other.block == block && team.canAttach(other.team) && within(other, range);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/distribution/OverflowDuct.java
+++ b/core/src/mindustry/world/blocks/distribution/OverflowDuct.java
@@ -98,8 +98,8 @@ public class OverflowDuct extends Block{
 
             if(invert){ //Lots of extra code. Make separate UnderflowDuct class?
                 Building l = left(), r = right();
-                boolean lc = l != null && l.team == team && l.acceptItem(this, current),
-                    rc = r != null && r.team == team && r.acceptItem(this, current);
+                boolean lc = l != null && team.canGiveItems(l.team) && l.acceptItem(this, current),
+                    rc = r != null && team.canGiveItems(r.team) && r.acceptItem(this, current);
 
                 if(lc && !rc){
                     return l;
@@ -111,7 +111,7 @@ public class OverflowDuct extends Block{
             }
 
             Building front = front();
-            if(front != null && front.team == team && front.acceptItem(this, current)){
+            if(front != null && team.canGiveItems(front.team) && front.acceptItem(this, current)){
                 return front;
             }
 
@@ -121,7 +121,7 @@ public class OverflowDuct extends Block{
                 int dir = Mathf.mod(rotation + (((i + cdump + 1) % 3) - 1), 4);
                 if(dir == rotation) continue;
                 Building other = nearby(dir);
-                if(other != null && other.team == team && other.acceptItem(this, current)){
+                if(other != null && team.canGiveItems(other.team) && other.acceptItem(this, current)){
                     return other;
                 }
             }

--- a/core/src/mindustry/world/blocks/distribution/OverflowGate.java
+++ b/core/src/mindustry/world/blocks/distribution/OverflowGate.java
@@ -36,7 +36,7 @@ public class OverflowGate extends Block{
         public boolean acceptItem(Building source, Item item){
             Building to = getTileTarget(item, source, false);
 
-            return to != null && to.acceptItem(this, item) && to.team == team;
+            return to != null && to.acceptItem(this, item) && team.canGiveItems(to.team);
         }
 
         @Override
@@ -52,14 +52,14 @@ public class OverflowGate extends Block{
             Building to = nearby((from + 2) % 4);
             boolean
                 fromInst = src.block.instantTransfer,
-                canForward = to != null && to.team == team && !(fromInst && to.block.instantTransfer) && to.acceptItem(this, item),
+                canForward = to != null && team.canGiveItems(to.team) && !(fromInst && to.block.instantTransfer) && to.acceptItem(this, item),
                 inv = invert == enabled;
 
             if(!canForward || inv){
                 Building a = nearby(Mathf.mod(from - 1, 4));
                 Building b = nearby(Mathf.mod(from + 1, 4));
-                boolean ac = a != null && !(fromInst && a.block.instantTransfer) && a.team == team && a.acceptItem(this, item);
-                boolean bc = b != null && !(fromInst && b.block.instantTransfer) && b.team == team && b.acceptItem(this, item);
+                boolean ac = a != null && !(fromInst && a.block.instantTransfer) && team.canGiveItems(a.team) && a.acceptItem(this, item);
+                boolean bc = b != null && !(fromInst && b.block.instantTransfer) && team.canGiveItems(b.team) && b.acceptItem(this, item);
 
                 if(!ac && !bc){
                     return inv && canForward ? to : null;

--- a/core/src/mindustry/world/blocks/distribution/Router.java
+++ b/core/src/mindustry/world/blocks/distribution/Router.java
@@ -75,7 +75,7 @@ public class Router extends Block{
 
         @Override
         public boolean acceptItem(Building source, Item item){
-            return team == source.team && lastItem == null && items.total() == 0;
+            return source.team.canGiveItems(team) && lastItem == null && items.total() == 0;
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/distribution/Sorter.java
+++ b/core/src/mindustry/world/blocks/distribution/Sorter.java
@@ -87,7 +87,7 @@ public class Sorter extends Block{
         public boolean acceptItem(Building source, Item item){
             Building to = getTileTarget(item, source, false);
 
-            return to != null && to.acceptItem(this, item) && to.team == team;
+            return to != null && to.acceptItem(this, item) && team.canGiveItems(to.team);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/distribution/StackConveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/StackConveyor.java
@@ -283,7 +283,7 @@ public class StackConveyor extends Block implements Autotiler{
                 }
             }else{ //transfer
                 if(state != stateLoad || (items.total() >= getMaximumAccepted(lastItem))){
-                    if(front() instanceof StackConveyorBuild e && e.team == team){
+                    if(front() instanceof StackConveyorBuild e && team.canGiveItems(e.team)){
                         //sleep if its occupied
                         if(e.link == -1){
                             e.items.add(items);

--- a/core/src/mindustry/world/blocks/liquid/Conduit.java
+++ b/core/src/mindustry/world/blocks/liquid/Conduit.java
@@ -215,8 +215,8 @@ public class Conduit extends LiquidBlock implements Autotiler{
             blending = bits[4];
 
             Building next = front(), prev = back();
-            capped = next == null || next.team != team || !next.block.hasLiquids;
-            backCapped = blendbits == 0 && (prev == null || prev.team != team || !prev.block.hasLiquids);
+            capped = next == null || !team.canGiveItems(next.team) || !next.block.hasLiquids;
+            backCapped = blendbits == 0 && (prev == null || !prev.team.canGiveItems(team) || !prev.block.hasLiquids);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/logic/LogicBlock.java
+++ b/core/src/mindustry/world/blocks/logic/LogicBlock.java
@@ -570,7 +570,7 @@ public class LogicBlock extends Block{
         }
 
         public boolean validLink(Building other){
-            return other != null && other.isValid() && (privileged || (!other.block.privileged && other.team == team && other.within(this, range + other.block.size*tilesize/2f))) && !(other instanceof ConstructBuild);
+            return other != null && other.isValid() && (privileged || (!other.block.privileged && team.canAttach(other.team) && other.within(this, range + other.block.size*tilesize/2f))) && !(other instanceof ConstructBuild);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/payloads/PayloadMassDriver.java
+++ b/core/src/mindustry/world/blocks/payloads/PayloadMassDriver.java
@@ -442,7 +442,7 @@ public class PayloadMassDriver extends PayloadBlock{
             if(link == other.pos()){
                 configure(-1);
                 return false;
-            }else if(other.block instanceof PayloadMassDriver && other.dst(tile) <= range && other.team == team){
+            }else if(other.block instanceof PayloadMassDriver && other.dst(tile) <= range && team.canAttach(other.team)){
                 configure(other.pos());
                 return false;
             }
@@ -456,7 +456,7 @@ public class PayloadMassDriver extends PayloadBlock{
         }
 
         protected boolean linkValid(){
-            return link != -1 && world.build(this.link) instanceof PayloadDriverBuild other && other.block == block && other.team == team && within(other, range);
+            return link != -1 && world.build(this.link) instanceof PayloadDriverBuild other && other.block == block && team.canAttach(other.team) && within(other, range);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/power/BeamNode.java
+++ b/core/src/mindustry/world/blocks/power/BeamNode.java
@@ -78,7 +78,7 @@ public class BeamNode extends PowerBlock{
                     break;
                 }
 
-                if(other != null && other.block.hasPower && other.team == Vars.player.team() && !(other.block instanceof PowerNode)){
+                if(other != null && other.block.hasPower && Vars.player.team().canAttach(other.team) && !(other.block instanceof PowerNode)){
                     maxLen = j;
                     dest = other;
                     break;
@@ -180,7 +180,7 @@ public class BeamNode extends PowerBlock{
                     }
 
                     //power nodes do NOT play nice with beam nodes, do not touch them as that forcefully modifies their links
-                    if(other != null && other.block.hasPower && other.block.connectedPower && other.team == team && !(other.block instanceof PowerNode)){
+                    if(other != null && other.block.hasPower && other.block.connectedPower && team.canAttach(other.team) && !(other.block instanceof PowerNode)){
                         links[i] = other;
                         dests[i] = world.tile(tile.x + j * dir.x, tile.y + j * dir.y);
                         break;

--- a/core/src/mindustry/world/blocks/power/PowerDiode.java
+++ b/core/src/mindustry/world/blocks/power/PowerDiode.java
@@ -56,7 +56,8 @@ public class PowerDiode extends Block{
         public void updateTile(){
             super.updateTile();
 
-            if(tile == null || front() == null || back() == null || !back().block.hasPower || !front().block.hasPower || back().team != team || front().team != team) return;
+            // maybe discard diode usage if back team doesn't match at all?
+            if(tile == null || front() == null || back() == null || !back().block.hasPower || !front().block.hasPower || !(team.canTakeItems(back().team) && team.canAttach(back().team)) || !team.canAttach(front().team)) return;
 
             PowerGraph backGraph = back().power.graph;
             PowerGraph frontGraph = front().power.graph;

--- a/core/src/mindustry/world/blocks/power/PowerNode.java
+++ b/core/src/mindustry/world/blocks/power/PowerNode.java
@@ -78,7 +78,7 @@ public class PowerNode extends PowerBlock{
 
                 power.links.addUnique(other.pos());
 
-                if(other.team == entity.team){
+                if(entity.team.canAttach(other.team)){
                     other.power.links.addUnique(entity.pos());
                 }
 
@@ -212,7 +212,7 @@ public class PowerNode extends PowerBlock{
 
         Boolf<Building> valid = other -> other != null && other.tile() != tile && other.block.connectedPower && other.power != null &&
             (other.block.outputsPower || other.block.consumesPower || other.block instanceof PowerNode) &&
-            overlaps(tile.x * tilesize + offset, tile.y * tilesize + offset, other.tile(), laserRange * tilesize) && other.team == team &&
+            overlaps(tile.x * tilesize + offset, tile.y * tilesize + offset, other.tile(), laserRange * tilesize) && team.isAlly(other.team) && team.canAttach(other.team) &&
             !graphs.contains(other.power.graph) &&
             !PowerNode.insulated(tile, other.tile) &&
             !(other instanceof PowerNodeBuild obuild && obuild.power.links.size >= ((PowerNode)obuild.block).maxNodes) &&
@@ -227,7 +227,7 @@ public class PowerNode extends PowerBlock{
         //add conducting graphs to prevent double link
         for(var p : Edges.getEdges(size)){
             Tile other = tile.nearby(p);
-            if(other != null && other.team() == team && other.build != null && other.build.power != null){
+            if(other != null && team.canAttach(other.team()) && other.build != null && other.build.power != null){
                 graphs.add(other.build.power.graph);
             }
         }
@@ -268,7 +268,7 @@ public class PowerNode extends PowerBlock{
         Boolf<Building> valid = other -> other != null && other.tile() != tile && other.block instanceof PowerNode node &&
         node.autolink &&
         other.power.links.size < node.maxNodes &&
-        node.overlaps(other.x, other.y, tile, block, node.laserRange * tilesize) && other.team == team
+        node.overlaps(other.x, other.y, tile, block, node.laserRange * tilesize) && team.canAttach(other.team)
         && !graphs.contains(other.power.graph) &&
         !PowerNode.insulated(tile, other.tile) &&
         !Structs.contains(Edges.getEdges(block.size), p -> { //do not link to adjacent buildings
@@ -282,7 +282,7 @@ public class PowerNode extends PowerBlock{
         //add conducting graphs to prevent double link
         for(var p : Edges.getEdges(block.size)){
             Tile other = tile.nearby(p);
-            if(other != null && other.team() == team && other.build != null && other.build.power != null
+            if(other != null && team.canAttach(other.team()) && other.build != null && other.build.power != null
                 && !(block.consumesPower && other.block().consumesPower && !block.outputsPower && !other.block().outputsPower)){
                 graphs.add(other.build.power.graph);
             }
@@ -342,7 +342,7 @@ public class PowerNode extends PowerBlock{
     }
 
     public boolean linkValid(Building tile, Building link, boolean checkMaxNodes){
-        if(tile == link || link == null || !link.block.hasPower || !link.block.connectedPower || tile.team != link.team) return false;
+        if(tile == link || link == null || !link.block.hasPower || !link.block.connectedPower || !(tile.team.canAttach(link.team) || link.team.canAttach(tile.team))) return false;
 
         if(overlaps(tile, link, laserRange * tilesize) || (link.block instanceof PowerNode node && overlaps(link, tile, node.laserRange * tilesize))){
             if(checkMaxNodes && link.block instanceof PowerNode node){

--- a/core/src/mindustry/world/blocks/storage/CoreBlock.java
+++ b/core/src/mindustry/world/blocks/storage/CoreBlock.java
@@ -148,6 +148,8 @@ public class CoreBlock extends StorageBlock{
         if(tile == null) return false;
         //in the editor, you can place them anywhere for convenience
         if(state.isEditor()) return true;
+        //prevent allies from wiping each others' cores out
+        if(tile.team() != team) return false;
 
         CoreBuild core = team.core();
 

--- a/core/src/mindustry/world/blocks/units/RepairTower.java
+++ b/core/src/mindustry/world/blocks/units/RepairTower.java
@@ -57,11 +57,14 @@ public class RepairTower extends Block{
             if(potentialEfficiency > 0 && (refresh += Time.delta) >= refreshInterval){
                 targets.clear();
                 refresh = 0f;
-                Units.nearby(team, x, y, range, u -> {
-                    if(u.damaged()){
-                        targets.add(u);
-                    }
-                });
+                for(var td : state.teams.active){
+                    if(!team.isAlly(td.team)) continue;
+                    Units.nearby(team, x, y, range, u -> {
+                        if(u.damaged()){
+                            targets.add(u);
+                        }
+                    });
+                }
             }
 
             boolean any = false;

--- a/core/src/mindustry/world/blocks/units/RepairTurret.java
+++ b/core/src/mindustry/world/blocks/units/RepairTurret.java
@@ -200,7 +200,11 @@ public class RepairTurret extends Block{
 
             if(timer(timerTarget, 20)){
                 rect.setSize(repairRadius * 2).setCenter(x, y);
-                target = Units.closest(team, x, y, repairRadius, Unit::damaged);
+                for(var td : state.teams.active){
+                    if(!team.isAlly(td.team)) continue;
+                    target = Units.closest(team, x, y, repairRadius, Unit::damaged);
+                    if(target != null) break;
+                }
             }
         }
 


### PR DESCRIPTION
This PR replaces EVERY SINGLE direct team comparison (that I could find by `grep -r team`) with method invocations on the teams involved, typically using `Team.isEnemy(Team)`. Teams can now have flags assigned to them, which allow granular control over what a team can or can't do.

~~A bleeding edge (bypassing commits) unversioned desktop build for this PR can be found [here](http://2.baseduser.eu.org/Mindustry.jar). I'm running these builds off of a bash script for every change I make in the code.~~

## Breaking changes
Mods will no longer be able to rely on pure `self.team != other.team` checks for enemy checks, these checks are now only useful for pure-team checks and UI. `Team#isEnemy` has been undeprecated.

## Known issues (don't comment these)
* No map serialization
* ~~No team flag initialization (run `for(i=0;i<256;i++){Team.all[i].flags[0]=TeamFlags.derelictTarget;Team.all[i].flags[i]=TeamFlags.genericSelf}` manually)~~
* Indexers and quadtrees are messed up because they use `int` internally and have no `Team` comparisons/return generic team matches intentionally
* No `null` checks in the vast majority of method invocations, causing a copious amount of `NullPointer`s (do comment where it *can* crash, though)
* ~~Build radius check is on `isNeutral`, not `ignoresBuildRadius`~~
* `Weaponc` entities can kill themselves
* Non-sharded teams, for whatever reason, cannot control all of their units
* Fog is literally unchanged

As if it wasn't clear enough, ***this PR is not finished.*** I also have no idea what effects it has on performance, but since I haven't intimately looked at indexers, quadtrees and AI yet I believe there aren't any adverse effects (until I change them to match)

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, ~~if applicable~~ to the best of my ability.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
