### PR TITLE
Fix wait instruction inconsistency

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -1230,7 +1230,6 @@ public class LExecutor{
         public int value;
 
         public float curTime;
-        public long frameId;
 
         public WaitI(int value){
             this.value = value;
@@ -1247,11 +1246,7 @@ public class LExecutor{
                 //skip back to self.
                 exec.var(varCounter).numval --;
                 exec.yield = true;
-            }
-
-            if(state.updateId != frameId){
                 curTime += Time.delta / 60f;
-                frameId = state.updateId;
             }
         }
     }


### PR DESCRIPTION
`curTime` was incremented on the same update after being set to zero causing the wait instruction to be skipped once every two frame when the wait delay is less than the time between frames. It also removes the `frameId` comparison as it became obsolete thanks to yield.

The bug was introduced in https://github.com/Anuken/Mindustry/pull/9086

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
