### PR TITLE
Allow markers to be deleted

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -2050,6 +2050,11 @@ public class LExecutor{
     }
 
     @Remote(called = Loc.server, variants = Variant.both, unreliable = true)
+    public static void removeMarker(int id){
+        state.markers.remove(id);
+    }
+
+    @Remote(called = Loc.server, variants = Variant.both, unreliable = true)
     public static void updateMarker(int id, LMarkerControl control, double p1, double p2, double p3){
         var marker = state.markers.get(id);
         if(marker != null){


### PR DESCRIPTION
Markers can currently be created and updated with `Call` but not deleted, this adds it.
On the same note, shouldn't marker related call methods (at least create/remove) have reliable variants/be reliable?

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
