### PR TITLE
Shield health should also be factored in pierce factor when `maxDamageFraction` is 0

### DIFF
--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -387,14 +387,14 @@ public class BulletType extends Content implements Cloneable{
 
         if(entity instanceof Healthc h){
             float damage = b.damage;
+            float shield = entity instanceof Shieldc s ? Math.max(s.shield(), 0f) : 0f;
             if(maxDamageFraction > 0){
-                float cap = h.maxHealth() * maxDamageFraction;
-                if(entity instanceof Shieldc s){
-                    cap += Math.max(s.shield(), 0f);
-                }
+                float cap = h.maxHealth() * maxDamageFraction + shield;
                 damage = Math.min(damage, cap);
                 //cap health to effective health for handlePierce to handle it properly
                 health = Math.min(health, cap);
+            }else{
+                health += shield;
             }
             if(pierceArmor){
                 h.damagePierce(damage);


### PR DESCRIPTION
Currently, shield health is only factored into pierce factor when `maxDamageFraction > 0`

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
