### PR TITLE
Effect spawn rectangle part + fix ArmorPlateAbility stat display

### DIFF
--- a/core/src/mindustry/entities/abilities/ArmorPlateAbility.java
+++ b/core/src/mindustry/entities/abilities/ArmorPlateAbility.java
@@ -29,7 +29,7 @@ public class ArmorPlateAbility extends Ability{
 
     @Override
     public void addStats(Table t){
-        t.add("[lightgray]" + Stat.healthMultiplier.localized() + ": [white]" + Math.round(healthMultiplier * 100f) + 100 + "%");
+        t.add("[lightgray]" + Stat.healthMultiplier.localized() + ": [white]" + (Math.round(healthMultiplier * 100f) + 100) + "%");
     }
 
     @Override

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -567,14 +567,8 @@ public class BulletType extends Content implements Cloneable{
     }
 
     public void drawParts(Bullet b){
-        if(parts.size > 0){
-            DrawPart.params.set(b.fin(), 0f, 0f, 0f, 0f, 0f, b.x, b.y, b.rotation());
-            DrawPart.params.life = b.fin();
-
-            for(int i = 0; i < parts.size; i++){
-                parts.get(i).draw(DrawPart.params);
-            }
-        }
+        DrawPart.params.life = b.fin();
+        DrawPart.params.draw(parts, null, b.fin(), 0f, 0f, 0f, 0f, 0f, b.x, b.y, b.rotation());
     }
 
     public void drawLight(Bullet b){
@@ -605,6 +599,9 @@ public class BulletType extends Content implements Cloneable{
         updateWeaving(b);
         updateTrailEffects(b);
         updateBulletInterval(b);
+
+        DrawPart.params.life = b.fin();
+        DrawPart.params.update(parts, null, b.fin(), 0f, 0f, 0f, 0f, 0f, b.x, b.y, b.rotation());
     }
 
     public void updateBulletInterval(Bullet b){

--- a/core/src/mindustry/entities/part/DrawPart.java
+++ b/core/src/mindustry/entities/part/DrawPart.java
@@ -19,6 +19,7 @@ public abstract class DrawPart{
 
     public abstract void draw(PartParams params);
     public abstract void load(String name);
+    public void update(PartParams params){}
     public void getOutlines(Seq<TextureRegion> out){}
 
     /** Parameters for drawing a part in draw(). */
@@ -27,6 +28,26 @@ public abstract class DrawPart{
         public float warmup, reload, smoothReload, heat, recoil, life, charge;
         public float x, y, rotation;
         public int sideOverride = -1, sideMultiplier = 1;
+
+        public void draw(Seq<DrawPart> parts, float[] recoils, float warmup, float reload, float smoothReload, float heat, float recoil, float charge, float x, float y, float rotation){
+            if(parts == null || parts.size == 0) return;
+
+            set(warmup, reload, smoothReload, heat, recoil, charge, x, y, rotation);
+            for(var part : parts){
+                setRecoil(part.recoilIndex >= 0 && recoils != null ? recoils[part.recoilIndex] : recoil);
+                part.update(this);
+            }
+        }
+
+        public void update(Seq<DrawPart> parts, float[] recoils, float warmup, float reload, float smoothReload, float heat, float recoil, float charge, float x, float y, float rotation){
+            if(parts == null || parts.size == 0) return;
+
+            set(warmup, reload, smoothReload, heat, recoil, charge, x, y, rotation);
+            for(var part : parts){
+                setRecoil(part.recoilIndex >= 0 && recoils != null ? recoils[part.recoilIndex] : recoil);
+                part.update(this);
+            }
+        }
 
         public PartParams set(float warmup, float reload, float smoothReload, float heat, float recoil, float charge, float x, float y, float rotation){
             this.warmup = warmup;

--- a/core/src/mindustry/entities/part/DrawPart.java
+++ b/core/src/mindustry/entities/part/DrawPart.java
@@ -35,7 +35,7 @@ public abstract class DrawPart{
             set(warmup, reload, smoothReload, heat, recoil, charge, x, y, rotation);
             for(var part : parts){
                 setRecoil(part.recoilIndex >= 0 && recoils != null ? recoils[part.recoilIndex] : recoil);
-                part.update(this);
+                part.draw(this);
             }
         }
 

--- a/core/src/mindustry/entities/part/EffectSpawnerPart.java
+++ b/core/src/mindustry/entities/part/EffectSpawnerPart.java
@@ -14,7 +14,7 @@ import static arc.util.Tmp.*;
 /**Spawns effects in a rectangle centered on x and y.*/
 public class EffectSpawnerPart extends DrawPart{
     public float x, y, width, height, rotation;
-    public boolean mirror = true;
+    public boolean mirror = false;
 
     public float effectChance = 0.1f, effectRot, effectRandRot;
     public Effect effect = Fx.sparkShoot;

--- a/core/src/mindustry/entities/part/EffectSpawnerPart.java
+++ b/core/src/mindustry/entities/part/EffectSpawnerPart.java
@@ -1,0 +1,55 @@
+package mindustry.entities.part;
+
+import arc.graphics.*;
+import arc.graphics.g2d.*;
+import arc.math.*;
+import mindustry.*;
+import mindustry.content.*;
+import mindustry.entities.*;
+import mindustry.graphics.*;
+
+import static arc.math.Mathf.random;
+import static arc.util.Tmp.*;
+
+/**Spawns effects in a rectangle centered on x and y.*/
+public class EffectSpawnerPart extends DrawPart{
+    public float x, y, width, height, rotation;
+    public boolean mirror = true;
+
+    public float effectChance = 0.1f, effectRot, effectRandRot = -1f;
+    public Effect effect = Fx.sparkShoot;
+    public Color effectColor = Color.white;
+
+    public boolean useProgress = true;
+    public PartProgress progress = PartProgress.warmup;
+
+    /**Shows the spawn rectangles in red.*/
+    public boolean debugDraw = false;
+
+    @Override
+    public void draw(PartParams params){
+        for(int i = 0; i < (mirror ? 2 : 1); i++){
+            float sign = (i == 0 ? 1f : -1f), rot = params.rotation + (rotation * sign);
+
+            v1.set(x * sign, y).rotate(params.rotation - 90).add(params.x, params.y);
+
+            if(debugDraw){
+                float z = Draw.z();
+                Draw.z(Layer.buildBeam);
+                Draw.color(Color.red);
+                Draw.rect("error", v1.x, v1.y, width, height, rot - 90f);
+                Draw.color();
+                Draw.z(z);
+            }
+
+            if(!Vars.state.isPaused() && Mathf.chanceDelta(effectChance * (useProgress ? progress.getClamp(params) : 1f))){
+                v1.add(v2.set(random(-height * 0.5f, height * 0.5f), random(-width * 0.5f, width * 0.5f)).rotate(rot));
+
+                effect.at(v1.x, v1.y, rot + (effectRot * sign) + random(-effectRandRot, effectRandRot), effectColor);
+            }
+        }
+    }
+
+    @Override
+    public void load(String name){}
+}

--- a/core/src/mindustry/entities/part/EffectSpawnerPart.java
+++ b/core/src/mindustry/entities/part/EffectSpawnerPart.java
@@ -16,7 +16,7 @@ public class EffectSpawnerPart extends DrawPart{
     public float x, y, width, height, rotation;
     public boolean mirror = true;
 
-    public float effectChance = 0.1f, effectRot, effectRandRot = -1f;
+    public float effectChance = 0.1f, effectRot, effectRandRot;
     public Effect effect = Fx.sparkShoot;
     public Color effectColor = Color.white;
 

--- a/core/src/mindustry/entities/part/EffectSpawnerPart.java
+++ b/core/src/mindustry/entities/part/EffectSpawnerPart.java
@@ -27,26 +27,32 @@ public class EffectSpawnerPart extends DrawPart{
     public boolean debugDraw = false;
 
     @Override
-    public void draw(PartParams params){
+    public void update(PartParams params){
         for(int i = 0; i < (mirror ? 2 : 1); i++){
-            float sign = (i == 0 ? 1f : -1f), rot = params.rotation + (rotation * sign);
-
-            v1.set(x * sign, y).rotate(params.rotation - 90).add(params.x, params.y);
-
-            if(debugDraw){
-                float z = Draw.z();
-                Draw.z(Layer.buildBeam);
-                Draw.color(Color.red);
-                Draw.rect("error", v1.x, v1.y, width, height, rot - 90f);
-                Draw.color();
-                Draw.z(z);
-            }
-
             if(!Vars.state.isPaused() && Mathf.chanceDelta(effectChance * (useProgress ? progress.getClamp(params) : 1f))){
+                float sign = (i == 0 ? 1f : -1f), rot = params.rotation + (rotation * sign);
+                v1.set(x * sign, y).rotate(params.rotation - 90).add(params.x, params.y);
                 v1.add(v2.set(random(-height * 0.5f, height * 0.5f), random(-width * 0.5f, width * 0.5f)).rotate(rot));
 
                 effect.at(v1.x, v1.y, rot + (effectRot * sign) + random(-effectRandRot, effectRandRot), effectColor);
             }
+        }
+    }
+
+    @Override
+    public void draw(PartParams params){
+        if(!debugDraw) return;
+
+        for(int i = 0; i < (mirror ? 2 : 1); i++){
+            float sign = (i == 0 ? 1f : -1f), rot = params.rotation + (rotation * sign);
+            v1.set(x * sign, y).rotate(params.rotation - 90).add(params.x, params.y);
+
+            float z = Draw.z();
+            Draw.z(Layer.buildBeam);
+            Draw.color(Color.red);
+            Draw.rect("error", v1.x, v1.y, width, height, rot - 90f);
+            Draw.color();
+            Draw.z(z);
         }
     }
 

--- a/core/src/mindustry/entities/part/RegionPart.java
+++ b/core/src/mindustry/entities/part/RegionPart.java
@@ -146,7 +146,7 @@ public class RegionPart extends DrawPart{
                 childParam.sideMultiplier = params.sideMultiplier;
                 childParam.life = params.life;
                 childParam.sideOverride = i;
-                params.draw(children, null, params.warmup, params.reload, params.smoothReload, params.heat, params.recoil, params.charge, params.x + v1.x, params.y + v1.y, v31.z * sign + params.rotation);
+                DrawPart.params.draw(children, null, params.warmup, params.reload, params.smoothReload, params.heat, params.recoil, params.charge, params.x + v1.x, params.y + v1.y, v31.z * sign + params.rotation);
             }
         }
 
@@ -168,7 +168,7 @@ public class RegionPart extends DrawPart{
             childParam.sideOverride = i;
 
             v1.set(v31.x * sign, v31.y).rotateRadExact((params.rotation - 90) * Mathf.degRad);
-            params.update(children, null, params.warmup, params.reload, params.smoothReload, params.heat, params.recoil, params.charge, params.x + v1.x, params.y + v1.y, v31.z * sign + params.rotation);
+            DrawPart.params.update(children, null, params.warmup, params.reload, params.smoothReload, params.heat, params.recoil, params.charge, params.x + v1.x, params.y + v1.y, v31.z * sign + params.rotation);
         }
     }
 

--- a/core/src/mindustry/type/UnitType.java
+++ b/core/src/mindustry/type/UnitType.java
@@ -492,7 +492,24 @@ public class UnitType extends UnlockableContent implements Senseable{
     }
 
     public void update(Unit unit){
+        if(parts.size > 0){
+            for(int i = 0; i < parts.size; i++){
+                var part = parts.get(i);
 
+                WeaponMount first = unit.mounts.length > part.weaponIndex ? unit.mounts[part.weaponIndex] : null;
+                if(first != null){
+                    DrawPart.params.set(first.warmup, first.reload / weapons.first().reload, first.smoothReload, first.heat, first.recoil, first.charge, unit.x, unit.y, unit.rotation);
+                }else{
+                    DrawPart.params.set(0f, 0f, 0f, 0f, 0f, 0f, unit.x, unit.y, unit.rotation);
+                }
+
+                if(unit instanceof Scaled s){
+                    DrawPart.params.life = s.fin();
+                }
+
+                part.update(DrawPart.params);
+            }
+        }
     }
 
     public void updatePayload(Unit unit, @Nullable Unit unitHolder, @Nullable Building buildingHolder){

--- a/core/src/mindustry/type/Weapon.java
+++ b/core/src/mindustry/type/Weapon.java
@@ -224,8 +224,7 @@ public class Weapon implements Cloneable{
             DrawPart.params.set(mount.warmup, mount.reload / reload, mount.smoothReload, mount.heat, mount.recoil, mount.charge, wx, wy, weaponRotation + 90);
             DrawPart.params.sideMultiplier = flipSprite ? -1 : 1;
 
-            for(int i = 0; i < parts.size; i++){
-                var part = parts.get(i);
+            for(DrawPart part : parts){
                 DrawPart.params.setRecoil(part.recoilIndex >= 0 && mount.recoils != null ? mount.recoils[part.recoilIndex] : mount.recoil);
                 if(part.under){
                     part.draw(DrawPart.params);
@@ -258,8 +257,7 @@ public class Weapon implements Cloneable{
 
         if(parts.size > 0){
             //TODO does it need an outline?
-            for(int i = 0; i < parts.size; i++){
-                var part = parts.get(i);
+            for(DrawPart part : parts){
                 DrawPart.params.setRecoil(part.recoilIndex >= 0 && mount.recoils != null ? mount.recoils[part.recoilIndex] : mount.recoil);
                 if(!part.under){
                     part.draw(DrawPart.params);
@@ -426,6 +424,15 @@ public class Weapon implements Cloneable{
                 unit.ammo--;
                 if(unit.ammo < 0) unit.ammo = 0;
             }
+        }
+
+        if(parts.size > 0){
+            float
+            realRecoil = Mathf.pow(mount.recoil, recoilPow) * recoil,
+            wx = mountX + Angles.trnsx(weaponRotation, 0, -realRecoil),
+            wy = mountY + Angles.trnsy(weaponRotation, 0, -realRecoil);
+
+            DrawPart.params.update(parts, mount.recoils, mount.warmup, mount.reload / reload, mount.smoothReload, mount.heat, mount.recoil, mount.charge, wx, wy, weaponRotation + 90);
         }
     }
 

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -448,6 +448,8 @@ public class Turret extends ReloadTurret{
             if(coolant != null){
                 updateCooling();
             }
+
+            drawer.update(this);
         }
 
         @Override

--- a/core/src/mindustry/world/draw/DrawBlock.java
+++ b/core/src/mindustry/world/draw/DrawBlock.java
@@ -32,6 +32,11 @@ public abstract class DrawBlock{
 
     }
 
+    /** Use to do something not directly related to drawing.*/
+    public void update(Building build){
+
+    }
+
     /** Draws the planned version of this block. */
     public void drawPlan(Block block, BuildPlan plan, Eachable<BuildPlan> list){
 

--- a/core/src/mindustry/world/draw/DrawTurret.java
+++ b/core/src/mindustry/world/draw/DrawTurret.java
@@ -45,6 +45,12 @@ public class DrawTurret extends DrawBlock{
     }
 
     @Override
+    public void update(Building build){
+        TurretBuild tb = (TurretBuild)build;
+        DrawPart.params.update(parts, tb.curRecoils, build.warmup(), 1f - build.progress(), 1f - build.progress(), tb.heat, tb.curRecoil, tb.charge, tb.x + tb.recoilOffset.x, tb.y + tb.recoilOffset.y, tb.rotation);
+    }
+
+    @Override
     public void draw(Building build){
         Turret turret = (Turret)build.block;
         TurretBuild tb = (TurretBuild)build;
@@ -69,15 +75,8 @@ public class DrawTurret extends DrawBlock{
                 Draw.z(Layer.turret);
             }
 
-            float progress = tb.progress();
-
             //TODO no smooth reload
-            var params = DrawPart.params.set(build.warmup(), 1f - progress, 1f - progress, tb.heat, tb.curRecoil, tb.charge, tb.x + tb.recoilOffset.x, tb.y + tb.recoilOffset.y, tb.rotation);
-
-            for(var part : parts){
-                params.setRecoil(part.recoilIndex >= 0 && tb.curRecoils != null ? tb.curRecoils[part.recoilIndex] : tb.curRecoil);
-                part.draw(params);
-            }
+            DrawPart.params.draw(parts, tb.curRecoils, build.warmup(), 1f - build.progress(), 1f - build.progress(), tb.heat, tb.curRecoil, tb.charge, tb.x + tb.recoilOffset.x, tb.y + tb.recoilOffset.y, tb.rotation);
         }
     }
 


### PR DESCRIPTION
Useful for exhausts, thrusters, sparks, etc.
Should also fix ArmorPlateAbility's multiplier formatting as 60100% instead of 160%. 

https://github.com/Anuken/Mindustry/assets/89076920/7710f5ca-f620-4434-9411-c34ad2c68b21

_Debug area drawing + absurd values_

https://github.com/Anuken/Mindustry/assets/89076920/ca1dc498-46e0-40c0-aa0a-b34fd5db95ad

_Potential usecase_

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
