### PR TITLE
PartProgress.time & PartProgress.mod added

### DIFF
--- a/core/src/mindustry/entities/part/DrawPart.java
+++ b/core/src/mindustry/entities/part/DrawPart.java
@@ -170,8 +170,12 @@ public abstract class DrawPart{
             return p -> get(p) + Mathf.absin(scl, mag);
         }
         
-        default PartProgress mod(float time){
-            return p -> Mathf.mod(get(p), time);
+        default PartProgress mod(float amount){
+            return p -> Mathf.mod(get(p), amount);
+        }
+        
+        default PartProgress loop(float time){
+            return p -> Mathf.mod(get(p)/time, 1);
         }
 
         default PartProgress apply(PartProgress other, PartFunc func){

--- a/core/src/mindustry/entities/part/DrawPart.java
+++ b/core/src/mindustry/entities/part/DrawPart.java
@@ -85,8 +85,10 @@ public abstract class DrawPart{
         /** Weapon heat, 1 when just fired, 0, when it has cooled down (duration depends on weapon) */
         heat = p -> p.heat,
         /** Lifetime fraction, 0 to 1. Only for missiles. */
-        life = p -> p.life;
-
+        life = p -> p.life,
+        /** Current unscaled value of Time.time. */
+        time = p -> Time.time;
+        
         float get(PartParams p);
 
         static PartProgress constant(float value){
@@ -166,6 +168,10 @@ public abstract class DrawPart{
 
         default PartProgress absin(float scl, float mag){
             return p -> get(p) + Mathf.absin(scl, mag);
+        }
+        
+        default PartProgress mod(float time){
+            return p -> Mathf.mod(get(p), time);
         }
 
         default PartProgress apply(PartProgress other, PartFunc func){


### PR DESCRIPTION
Just some simple additions to allow shenanigans like spinning parts and looping movements to be made with ease.

https://github.com/Anuken/Mindustry/assets/73347888/7d4a4035-50c0-4873-918b-255e5fc1fce0

Uses
moves.add(new PartMove(p -> Mathf.mod(Time.time/45,1), 0, 0, 360));

Which (if the PR is merged) be the equivalent of theese
moves.add(new PartMove(PartMove.time.mul(1/45).mod(1), 0, 0, 360);
moves.add(new PartMove(PartMove.time.loop(45), 0, 0, 360);

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
