### PR TITLE
Fix generation of drills' booster stats

### DIFF
--- a/core/src/mindustry/world/blocks/production/BeamDrill.java
+++ b/core/src/mindustry/world/blocks/production/BeamDrill.java
@@ -121,7 +121,7 @@ public class BeamDrill extends Block{
                 "{0}" + StatUnit.timesSpeed.localized(),
                 consBase.amount, optionalBoostIntensity, false,
                 l -> (consumesLiquid(l) && 
-                    findConsumer(f -> f instanceof ConsumeLiquid cl && cl.booster && cl.liquid == l) != null
+                    findConsumer(f -> f instanceof ConsumeLiquid cl && cl.liquid == l && cl.booster) != null
                 )
             ));
         }

--- a/core/src/mindustry/world/blocks/production/BeamDrill.java
+++ b/core/src/mindustry/world/blocks/production/BeamDrill.java
@@ -117,11 +117,13 @@ public class BeamDrill extends Block{
 
         if(optionalBoostIntensity != 1 && findConsumer(f -> f instanceof ConsumeLiquidBase && f.booster) instanceof ConsumeLiquidBase consBase){
             stats.remove(Stat.booster);
-            stats.add(Stat.booster,
-                StatValues.speedBoosters("{0}" + StatUnit.timesSpeed.localized(),
+            stats.add(Stat.booster, StatValues.speedBoosters(
+                "{0}" + StatUnit.timesSpeed.localized(),
                 consBase.amount, optionalBoostIntensity, false,
-                l -> (consumesLiquid(l) && (findConsumer(f -> f instanceof ConsumeLiquid).booster || ((ConsumeLiquid)findConsumer(f -> f instanceof ConsumeLiquid)).liquid != l)))
-            );
+                l -> (consumesLiquid(l) && 
+                    findConsumer(f -> f instanceof ConsumeLiquid cl && cl.booster && cl.liquid == l) != null
+                )
+            ));
         }
     }
 

--- a/core/src/mindustry/world/blocks/production/Drill.java
+++ b/core/src/mindustry/world/blocks/production/Drill.java
@@ -178,11 +178,13 @@ public class Drill extends Block{
 
         if(liquidBoostIntensity != 1 && findConsumer(f -> f instanceof ConsumeLiquidBase) instanceof ConsumeLiquidBase consBase){
             stats.remove(Stat.booster);
-            stats.add(Stat.booster,
-                StatValues.speedBoosters("{0}" + StatUnit.timesSpeed.localized(),
-                consBase.amount,
-                liquidBoostIntensity * liquidBoostIntensity, false, this::consumesLiquid)
-            );
+            stats.add(Stat.booster, StatValues.speedBoosters(
+                "{0}" + StatUnit.timesSpeed.localized(),
+                consBase.amount, liquidBoostIntensity * liquidBoostIntensity, false,
+                l -> consumesLiquid(l) && findConsumer(f ->
+                    f instanceof ConsumeLiquid cl && cl.liquid == l && cl.booster
+                ) != null
+            ));
         }
     }
 


### PR DESCRIPTION
If you have a beam drill (or regular drill) with multiple boosters or multiple required liquids, like this:
![image](https://github.com/Anuken/Mindustry/assets/71201189/0f28bc18-32e5-4d88-9065-c035be0201b0)
Before:
![before](https://github.com/Anuken/Mindustry/assets/71201189/ea2dcd74-3898-41dd-90b6-1fb461d5dd50)
the boosters are determined incorrectly
After:
![image](https://github.com/Anuken/Mindustry/assets/71201189/4c6f821c-9505-4c1e-9668-093f26f067c5)
fixed

code was strange, I think it assumed there would only be one or two liquids

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
