### PR TITLE
Allow gasses to be coolants

### DIFF
--- a/core/src/mindustry/type/Liquid.java
+++ b/core/src/mindustry/type/Liquid.java
@@ -84,8 +84,6 @@ public class Liquid extends UnlockableContent implements Senseable{
         super.init();
 
         if(gas){
-            //gases can't be coolants
-            coolant = false;
             //always "boils", it's a gas
             boilPoint = -1;
             //ensure no accidental global mutation


### PR DESCRIPTION
What's the point of `allowGas` in `ConsumeCoolant` if gasses are hardcoded to always be `coolant = false`?

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
