### PR TITLE
Increase visibility of `makeRect()`

### DIFF
--- a/core/src/mindustry/type/Sector.java
+++ b/core/src/mindustry/type/Sector.java
@@ -236,7 +236,7 @@ public class Sector{
 
     /** Projects this sector onto a 4-corner square for use in map gen.
      * Allocates a new object. Do not call in the main loop. */
-    private SectorRect makeRect(){
+    protected SectorRect makeRect(){
         Vec3[] corners = new Vec3[tile.corners.length];
         for(int i = 0; i < corners.length; i++){
             corners[i] = tile.corners[i].v.cpy().setLength(planet.radius);


### PR DESCRIPTION
`PlanetGrid`'s constructor is already `protected` to allow customizations, why not this too?

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
