### PR TITLE
Make privileged SwitchBlock(World Switch) can't pickup

### DIFF
--- a/core/src/mindustry/world/blocks/logic/SwitchBlock.java
+++ b/core/src/mindustry/world/blocks/logic/SwitchBlock.java
@@ -42,6 +42,11 @@ public class SwitchBlock extends Block{
             if(privileged) return;
             super.damage(damage);
         }
+        
+        @Override
+        public boolean canPickup(){
+            return !privileged;
+        }
 
         @Override
         public boolean collide(Bullet other){


### PR DESCRIPTION
World switch can't be picked up.

https://github.com/Anuken/Mindustry/assets/44901211/a7245768-ae55-4bbb-9958-9dfd36fc2dcd

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
