### PR TITLE
Improve ArmorPlateAbility draw

### DIFF
--- a/core/assets/shaders/unitarmor.frag
+++ b/core/assets/shaders/unitarmor.frag
@@ -13,10 +13,9 @@ void main(){
     vec2 coords = (v_texCoords - u_uv) / (u_uv2 - u_uv);
     vec2 v = vec2(1.0/u_texsize.x, 1.0/u_texsize.y);
 
-    vec4 c = v_color;
-    c.a *= texture2D(u_texture, v_texCoords).a;
+    vec4 c = texture2D(u_texture, v_texCoords);
     c.a *= u_progress;
     c.a *= step(abs(sin(coords.y*3.0 + u_time)), 0.9);
 
-    gl_FragColor = c;
+    gl_FragColor = c * v_color;
 }

--- a/core/assets/shaders/unitarmor.frag
+++ b/core/assets/shaders/unitarmor.frag
@@ -2,7 +2,6 @@ uniform sampler2D u_texture;
 
 uniform float u_time;
 uniform float u_progress;
-uniform vec4 u_color;
 uniform vec2 u_uv;
 uniform vec2 u_uv2;
 uniform vec2 u_texsize;
@@ -14,10 +13,10 @@ void main(){
     vec2 coords = (v_texCoords - u_uv) / (u_uv2 - u_uv);
     vec2 v = vec2(1.0/u_texsize.x, 1.0/u_texsize.y);
 
-	vec4 c = texture2D(u_texture, v_texCoords);
-
+    vec4 c = v_color;
+    c.a *= texture2D(u_texture, v_texCoords).a;
     c.a *= u_progress;
     c.a *= step(abs(sin(coords.y*3.0 + u_time)), 0.9);
 
-    gl_FragColor = c * v_color;
+    gl_FragColor = c;
 }

--- a/core/src/mindustry/entities/abilities/ArmorPlateAbility.java
+++ b/core/src/mindustry/entities/abilities/ArmorPlateAbility.java
@@ -12,10 +12,20 @@ import mindustry.world.meta.*;
 
 public class ArmorPlateAbility extends Ability{
     public TextureRegion plateRegion;
-    public Color color = Color.valueOf("d1efff");
+    public TextureRegion shineRegion;
+    public String plateSuffix = "-armor";
+    public String shineSuffix = "-armor";
+    /** Color of the shine. If null, uses team color. */
+    public @Nullable Color color = null;
+    public float shineSpeed = 1f;
+    public float z = -1;
+
+    /** Whether to draw the plate region. */
+    public boolean drawPlate = true;
+    /** Whether to draw the shine over the plate region. */
+    public boolean drawShine = true;
 
     public float healthMultiplier = 0.2f;
-    public float z = Layer.effect;
 
     protected float warmup;
 
@@ -34,24 +44,38 @@ public class ArmorPlateAbility extends Ability{
 
     @Override
     public void draw(Unit unit){
+        if(!drawPlate && !drawShine) return;
+
         if(warmup > 0.001f){
             if(plateRegion == null){
-                plateRegion = Core.atlas.find(unit.type.name + "-armor", unit.type.region);
+                plateRegion = Core.atlas.find(unit.type.name + plateSuffix, unit.type.region);
+                shineRegion = Core.atlas.find(unit.type.name + shineSuffix, unit.type.region);
             }
 
-            Draw.draw(z <= 0 ? Draw.z() : z, () -> {
-                Shaders.armor.region = plateRegion;
-                Shaders.armor.progress = warmup;
-                Shaders.armor.time = -Time.time / 20f;
+            if(drawShine){
+                Draw.draw(z <= 0 ? Draw.z() : z, () -> {
+                    Shaders.armor.region = shineRegion;
+                    Shaders.armor.progress = warmup;
+                    Shaders.armor.time = -Time.time / 20f * shineSpeed;
 
-                Draw.rect(Shaders.armor.region, unit.x, unit.y, unit.rotation - 90f);
-                Draw.color(color);
-                Draw.shader(Shaders.armor);
-                Draw.rect(Shaders.armor.region, unit.x, unit.y, unit.rotation - 90f);
-                Draw.shader();
+                    if(drawPlate){
+                        Draw.alpha(warmup);
+                        Draw.rect(plateRegion, unit.x, unit.y, unit.rotation - 90f);
+                        Draw.alpha(1f);
+                    }
 
-                Draw.reset();
-            });
+                    Draw.color(color == null ? unit.team.color : color);
+                    Draw.shader(Shaders.armor);
+                    Draw.rect(shineRegion, unit.x, unit.y, unit.rotation - 90f);
+                    Draw.shader();
+
+                    Draw.reset();
+                });
+            }else{
+                Draw.alpha(warmup);
+                Draw.rect(plateRegion, unit.x, unit.y, unit.rotation - 90f);
+                Draw.alpha(1f);
+            }
         }
     }
 }

--- a/core/src/mindustry/entities/abilities/ArmorPlateAbility.java
+++ b/core/src/mindustry/entities/abilities/ArmorPlateAbility.java
@@ -14,7 +14,7 @@ public class ArmorPlateAbility extends Ability{
     public TextureRegion plateRegion;
     public TextureRegion shineRegion;
     public String plateSuffix = "-armor";
-    public String shineSuffix = "-armor";
+    public String shineSuffix = "-shine";
     /** Color of the shine. If null, uses team color. */
     public @Nullable Color color = null;
     public float shineSpeed = 1f;
@@ -49,7 +49,7 @@ public class ArmorPlateAbility extends Ability{
         if(warmup > 0.001f){
             if(plateRegion == null){
                 plateRegion = Core.atlas.find(unit.type.name + plateSuffix, unit.type.region);
-                shineRegion = Core.atlas.find(unit.type.name + shineSuffix, unit.type.region);
+                shineRegion = Core.atlas.find(unit.type.name + shineSuffix, plateRegion);
             }
 
             if(drawShine){

--- a/core/src/mindustry/entities/abilities/ArmorPlateAbility.java
+++ b/core/src/mindustry/entities/abilities/ArmorPlateAbility.java
@@ -52,17 +52,20 @@ public class ArmorPlateAbility extends Ability{
                 shineRegion = Core.atlas.find(unit.type.name + shineSuffix, plateRegion);
             }
 
+            float pz = Draw.z();
+            if(z > 0) Draw.z(z);
+
+            if(drawPlate){
+                Draw.alpha(warmup);
+                Draw.rect(plateRegion, unit.x, unit.y, unit.rotation - 90f);
+                Draw.alpha(1f);
+            }
+
             if(drawShine){
-                Draw.draw(z <= 0 ? Draw.z() : z, () -> {
+                Draw.draw(Draw.z(), () -> {
                     Shaders.armor.region = shineRegion;
                     Shaders.armor.progress = warmup;
                     Shaders.armor.time = -Time.time / 20f * shineSpeed;
-
-                    if(drawPlate){
-                        Draw.alpha(warmup);
-                        Draw.rect(plateRegion, unit.x, unit.y, unit.rotation - 90f);
-                        Draw.alpha(1f);
-                    }
 
                     Draw.color(color == null ? unit.team.color : color);
                     Draw.shader(Shaders.armor);
@@ -71,11 +74,9 @@ public class ArmorPlateAbility extends Ability{
 
                     Draw.reset();
                 });
-            }else{
-                Draw.alpha(warmup);
-                Draw.rect(plateRegion, unit.x, unit.y, unit.rotation - 90f);
-                Draw.alpha(1f);
             }
+
+            Draw.z(pz);
         }
     }
 }


### PR DESCRIPTION
Fixes:
- Alpha with warmup before drawing the plate region. Currently, it doesn't so it just appears when you shoot.
  - ...Wow it's my own mistake again. Apparently I did that. (#7751)

Additions/Changes:
- z is now default to -1
  - Why was it defaulted to effect anyway?
- Color now defaults to null. If null, uses team color.
- Can selectively decide whether to draw the plate and the shine.
- Plate and shine can now have different sprites.
  - `plateSuffix` and `shineSuffix`
    - ...Is customizable suffix even necessary?

[test-mod.zip](https://github.com/Anuken/Mindustry/files/14367723/test-mod.zip)

---

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.