### PR TITLE
Update bundle_zh_CN.properties

### DIFF
--- a/core/assets/bundles/bundle_zh_CN.properties
+++ b/core/assets/bundles/bundle_zh_CN.properties
@@ -1929,7 +1929,7 @@ onset.commandmode = 按住[accent]shift[]键进入[accent]指挥模式[]。\n按
 onset.commandmode.mobile = 点击左下角的[accent]指挥[]进入[accent]指挥模式[]。\n按住屏幕，[accent]拖动[]框选单位。\n[accent]点击[]指挥所选单位移动或攻击。
 aegis.tungsten = Tungsten can be mined using an [accent]impact drill[].\nThis structure requires [accent]water[] and [accent]power[].
 
-split.pickup = 核心单位可以拾取一些方块。\n拾取这个[accent]强化容器[]并将其放到[accent]载荷装载器[]中。\n（默认使用[拾取，]放下载荷）
+split.pickup = 核心单位可以拾取一些方块。\n拾取这个[accent]强化容器[]并将其放到[accent]载荷装载器[]中。\n（默认使用快捷键“[”拾取载荷，“]“放下载荷）
 split.pickup.mobile = 核心单位可以拾取一些方块。\n拾取这个[accent]强化容器[]并将其放到[accent]载荷装载器[]中。\n（长按以拾取或放下载荷）
 split.acquire = 你需要获取钨来生产单位。
 split.build = 单位必须被运输到墙的另一侧。\n在墙壁两侧各放置一个[accent]载荷质量驱动器[]。\n点击其中一个，然后点击另一个以连接它们。


### PR DESCRIPTION

In the description of core unit operations, the original translation used the phrase `（默认使用[拾取，]放下载荷）` which, although it implied the information about shortcut keys, might not be intuitive or easy to understand for players.

Therefore, I have modified it to a more explicit expression: `（默认使用快捷键“[”拾取载荷，“]”放下载荷）` Such a change is aimed at making the game's operational instructions clearer, especially for beginners.