### PR TITLE
Shader getShaderFi check for mod files

### DIFF
--- a/core/src/mindustry/graphics/Shaders.java
+++ b/core/src/mindustry/graphics/Shaders.java
@@ -474,6 +474,8 @@ public class Shaders{
     }
 
     public static Fi getShaderFi(String file){
-        return Core.files.internal("shaders/" + file);
+        Fi sh = Core.files.internal("shaders/" + file);
+        if(sh == null) sh = tree.get("shaders/" + file);
+        return sh;
     }
 }

--- a/core/src/mindustry/graphics/Shaders.java
+++ b/core/src/mindustry/graphics/Shaders.java
@@ -474,8 +474,6 @@ public class Shaders{
     }
 
     public static Fi getShaderFi(String file){
-        Fi sh = Core.files.internal("shaders/" + file);
-        if(sh == null) sh = tree.get("shaders/" + file);
-        return sh;
+        return tree.get("shaders/" + file);
     }
 }


### PR DESCRIPTION
~~If the initial `Core.files.internal` doesn't find a file, try finding with `tree.get`.~~
Use `tree.get` instead of `file.internal` in `getShaderFi`. Makes custom shaders with js/java slightly less annoying as modders wouldn't need to make their own version of `LoadShader` just to load their shader files and reduces copy/paste for things like surface shaders, as a copy of the `SurfaceShader` that extends off the copied version of `LoadShader` wouldn't be needed anymore, and also allows mods with a frag with an identical name to override vanilla shaders.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
