### PR TITLE
[AMENDED] Add diagonal symmetry compat

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -58,3 +58,10 @@ jobs:
         cd ../Mindustry
     - name: Run unit tests
       run: ./gradlew tests:test --rerun --stacktrace
+    - name: Build
+      run: ./gradlew deploy
+    - name: Upload
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.event.repository.name }}
+        path: build/libs/${{ github.event.repository.name }}.jar

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -58,10 +58,3 @@ jobs:
         cd ../Mindustry
     - name: Run unit tests
       run: ./gradlew tests:test --rerun --stacktrace
-    - name: Build
-      run: ./gradlew deploy
-    - name: Upload
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.event.repository.name }}
-        path: build/libs/${{ github.event.repository.name }}.jar

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,14 +13,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Trigger BE build
-      if: ${{ github.repository == 'The4codeblocks/Mindustry' }}
+      if: ${{ github.repository == 'Anuken/Mindustry' }}
       run: |
-        git clone --depth=1 --branch=master https://github.com/The4codeblocks/MindustryBuilds ../MindustryBuilds
+        git clone --depth=1 --branch=master https://github.com/Anuken/MindustryBuilds ../MindustryBuilds
         cd ../MindustryBuilds
         BNUM=$(($GITHUB_RUN_NUMBER + 20000))
         git tag ${BNUM}
         git config --global user.name "Github Actions"
-        git push https://The4codeblocks:${{ secrets.API_TOKEN_GITHUB }}@github.com/The4codeblocks/MindustryBuilds ${BNUM}
+        git push https://Anuken:${{ secrets.API_TOKEN_GITHUB }}@github.com/Anuken/MindustryBuilds ${BNUM}
     - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
@@ -58,3 +58,10 @@ jobs:
         cd ../Mindustry
     - name: Run unit tests
       run: ./gradlew tests:test --rerun --stacktrace
+    - name: Build
+      run: ./gradlew deploy
+    - name: Upload
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.event.repository.name }}
+        path: build/libs/${{ github.event.repository.name }}.jar

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,14 +13,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Trigger BE build
-      if: ${{ github.repository == 'Anuken/Mindustry' }}
+      if: ${{ github.repository == 'The4codeblocks/Mindustry' }}
       run: |
-        git clone --depth=1 --branch=master https://github.com/Anuken/MindustryBuilds ../MindustryBuilds
+        git clone --depth=1 --branch=master https://github.com/The4codeblocks/MindustryBuilds ../MindustryBuilds
         cd ../MindustryBuilds
         BNUM=$(($GITHUB_RUN_NUMBER + 20000))
         git tag ${BNUM}
         git config --global user.name "Github Actions"
-        git push https://Anuken:${{ secrets.API_TOKEN_GITHUB }}@github.com/Anuken/MindustryBuilds ${BNUM}
+        git push https://The4codeblocks:${{ secrets.API_TOKEN_GITHUB }}@github.com/The4codeblocks/MindustryBuilds ${BNUM}
     - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
@@ -58,10 +58,3 @@ jobs:
         cd ../Mindustry
     - name: Run unit tests
       run: ./gradlew tests:test --rerun --stacktrace
-    - name: Build
-      run: ./gradlew deploy
-    - name: Upload
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.event.repository.name }}
-        path: build/libs/${{ github.event.repository.name }}.jar

--- a/core/assets/ElectricGun-message-block-commands-0f8093e/commands/commands.json
+++ b/core/assets/ElectricGun-message-block-commands-0f8093e/commands/commands.json
@@ -1,0 +1,1 @@
+{"listCommands":["v2logic"]}

--- a/core/assets/contributors
+++ b/core/assets/contributors
@@ -165,3 +165,4 @@ OpalSoPL
 BalaM314
 Redstonneur1256
 ApsZoldat
+The4codeblocks

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -141,7 +141,7 @@ public class DesktopInput extends InputHandler{
         if(splan != null){
             boolean valid = validPlace(splan.x, splan.y, splan.block, splan.rotation, splan);
             if(splan.block.rotate && splan.block.drawArrow){
-                drawArrow(splan.block, splan.x, splan.y, splan.rotation + (splan.diagonalSymmtryAxis ? 0.5 : 0), valid);
+                drawArrow(splan.block, splan.x, splan.y, splan.rotation, valid);
             }
 
             splan.block.drawPlan(splan, allPlans(), valid);
@@ -180,7 +180,7 @@ public class DesktopInput extends InputHandler{
                 for(int i = 0; i < linePlans.size; i++){
                     var plan = linePlans.get(i);
                     if(i == linePlans.size - 1 && plan.block.rotate && plan.block.drawArrow){
-                        drawArrow(block, plan.x, plan.y, plan.rotation + (plan.block.diagonalSymmetryAxis ? 0.5 : 0));
+                        drawArrow(block, plan.x, plan.y, plan.rotation);
                     }
                     drawPlan(linePlans.get(i));
                 }
@@ -188,7 +188,7 @@ public class DesktopInput extends InputHandler{
             }else if(isPlacing()){
                 int rot = block == null ? rotation : block.planRotation(rotation);
                 if(block.rotate && block.drawArrow){
-                    drawArrow(block, cursorX, cursorY, rot + (block.diagonalSymmetryAxis ? 0.5 : 0));
+                    drawArrow(block, cursorX, cursorY, rot);
                 }
                 Draw.color();
                 boolean valid = validPlace(cursorX, cursorY, block, rot);

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -141,7 +141,7 @@ public class DesktopInput extends InputHandler{
         if(splan != null){
             boolean valid = validPlace(splan.x, splan.y, splan.block, splan.rotation, splan);
             if(splan.block.rotate && splan.block.drawArrow){
-                drawArrow(splan.block, splan.x, splan.y, splan.rotation, valid);
+                drawArrow(splan.block, splan.x, splan.y, splan.rotation + (splan.diagonalSymmtryAxis ? 0.5 : 0), valid);
             }
 
             splan.block.drawPlan(splan, allPlans(), valid);
@@ -180,7 +180,7 @@ public class DesktopInput extends InputHandler{
                 for(int i = 0; i < linePlans.size; i++){
                     var plan = linePlans.get(i);
                     if(i == linePlans.size - 1 && plan.block.rotate && plan.block.drawArrow){
-                        drawArrow(block, plan.x, plan.y, plan.rotation);
+                        drawArrow(block, plan.x, plan.y, plan.rotation + (plan.block.diagonalSymmetryAxis ? 0.5 : 0));
                     }
                     drawPlan(linePlans.get(i));
                 }
@@ -188,7 +188,7 @@ public class DesktopInput extends InputHandler{
             }else if(isPlacing()){
                 int rot = block == null ? rotation : block.planRotation(rotation);
                 if(block.rotate && block.drawArrow){
-                    drawArrow(block, cursorX, cursorY, rot);
+                    drawArrow(block, cursorX, cursorY, rot + (block.diagonalSymmetryAxis ? 0.5 : 0));
                 }
                 Draw.color();
                 boolean valid = validPlace(cursorX, cursorY, block, rot);

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -180,7 +180,7 @@ public class DesktopInput extends InputHandler{
                 for(int i = 0; i < linePlans.size; i++){
                     var plan = linePlans.get(i);
                     if(i == linePlans.size - 1 && plan.block.rotate && plan.block.drawArrow){
-                        drawArrow(block, plan.x, plan.y, plan.rotation, plan.block.diagonalSymmetry);
+                        drawArrow(block, plan.x, plan.y, plan.rotation, validPlace(plan.x, plan.y, block, plan.rotation), plan.block.diagonalSymmetry);
                     }
                     drawPlan(linePlans.get(i));
                 }
@@ -188,7 +188,7 @@ public class DesktopInput extends InputHandler{
             }else if(isPlacing()){
                 int rot = block == null ? rotation : block.planRotation(rotation);
                 if(block.rotate && block.drawArrow){
-                    drawArrow(block, cursorX, cursorY, rot, block.diagonalSymmetry);
+                    drawArrow(block, cursorX, cursorY, rot, validPlace(cursorX, cursorY, block, rot), block.diagonalSymmetry);
                 }
                 Draw.color();
                 boolean valid = validPlace(cursorX, cursorY, block, rot);

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -141,7 +141,7 @@ public class DesktopInput extends InputHandler{
         if(splan != null){
             boolean valid = validPlace(splan.x, splan.y, splan.block, splan.rotation, splan);
             if(splan.block.rotate && splan.block.drawArrow){
-                drawArrow(splan.block, splan.x, splan.y, splan.rotation, valid, splan.diagonalSymmetry);
+                drawArrow(splan.block, splan.x, splan.y, splan.rotation, valid, splan.block.diagonalSymmetry);
             }
 
             splan.block.drawPlan(splan, allPlans(), valid);

--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -141,7 +141,7 @@ public class DesktopInput extends InputHandler{
         if(splan != null){
             boolean valid = validPlace(splan.x, splan.y, splan.block, splan.rotation, splan);
             if(splan.block.rotate && splan.block.drawArrow){
-                drawArrow(splan.block, splan.x, splan.y, splan.rotation, valid);
+                drawArrow(splan.block, splan.x, splan.y, splan.rotation, valid, splan.diagonalSymmetry);
             }
 
             splan.block.drawPlan(splan, allPlans(), valid);
@@ -180,7 +180,7 @@ public class DesktopInput extends InputHandler{
                 for(int i = 0; i < linePlans.size; i++){
                     var plan = linePlans.get(i);
                     if(i == linePlans.size - 1 && plan.block.rotate && plan.block.drawArrow){
-                        drawArrow(block, plan.x, plan.y, plan.rotation);
+                        drawArrow(block, plan.x, plan.y, plan.rotation, plan.block.diagonalSymmetry);
                     }
                     drawPlan(linePlans.get(i));
                 }
@@ -188,7 +188,7 @@ public class DesktopInput extends InputHandler{
             }else if(isPlacing()){
                 int rot = block == null ? rotation : block.planRotation(rotation);
                 if(block.rotate && block.drawArrow){
-                    drawArrow(block, cursorX, cursorY, rot);
+                    drawArrow(block, cursorX, cursorY, rot, block.diagonalSymmetry);
                 }
                 Draw.color();
                 boolean valid = validPlace(cursorX, cursorY, block, rot);

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1933,7 +1933,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
 
     public void drawArrow(Block block, int x, int y, int rotation, boolean valid, boolean diagonalSymmetry){
         float trns = (block.size / 2) * tilesize;
-        float[] dxf = [0.707106781,0.707106781,-0.707106781,-0.707106781][rotation], dyf = [-0.707106781,0.707106781,0.707106781,-0.707106781][rotation];
+        float dxf = [0.707106781,0.707106781,-0.707106781,-0.707106781][rotation], dyf = [-0.707106781,0.707106781,0.707106781,-0.707106781][rotation];
         int dx = Geometry.d4(rotation).x, dy = Geometry.d4(rotation).y;
         float offsetx = x * tilesize + block.offset + (diagonalSymmetry ? dxf : dx)*trns;
         float offsety = y * tilesize + block.offset + (diagonalSymmetry ? dyf : dy)*trns;

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1933,9 +1933,10 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
 
     public void drawArrow(Block block, int x, int y, int rotation, boolean valid, boolean diagonalSymmetry){
         float trns = (block.size / 2) * tilesize;
+        float[] dxf = [0.707106781,0.707106781,-0.707106781,-0.707106781][rotation], dyf = [-0.707106781,0.707106781,0.707106781,-0.707106781][rotation];
         int dx = Geometry.d4(rotation).x, dy = Geometry.d4(rotation).y;
-        float offsetx = x * tilesize + block.offset + dx*trns;
-        float offsety = y * tilesize + block.offset + dy*trns;
+        float offsetx = x * tilesize + block.offset + (diagonalSymmetry ? dxf : dx)*trns;
+        float offsety = y * tilesize + block.offset + (diagonalSymmetry ? dyf : dy)*trns;
 
         Draw.color(!valid ? Pal.removeBack : Pal.accentBack);
         TextureRegion regionArrow = Core.atlas.find("place-arrow");
@@ -1945,7 +1946,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         offsety - 1,
         regionArrow.width * regionArrow.scl(),
         regionArrow.height * regionArrow.scl(),
-        rotation * 90 - (diagonalSymmetry ? 45 : 90));
+        rotation * 90 - (diagonalSymmetry ? 135 : 90));
 
         Draw.color(!valid ? Pal.remove : Pal.accent);
         Draw.rect(regionArrow,
@@ -1953,7 +1954,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         offsety,
         regionArrow.width * regionArrow.scl(),
         regionArrow.height * regionArrow.scl(),
-        rotation * 90 - 90);
+        rotation * 90 - (diagonalSymmetry ? 135 : 90));
     }
 
     void iterateLine(int startX, int startY, int endX, int endY, Cons<PlaceLine> cons){

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1933,8 +1933,8 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
 
     public void drawArrow(Block block, int x, int y, int rotation, boolean valid, boolean diagonalSymmetry){
         float trns = (block.size / 2) * tilesize;
-        float[] d4xf = {0.707106781,0.707106781,-0.707106781,-0.707106781};
-        float[] d4yf = {-0.707106781,0.707106781,0.707106781,-0.707106781};
+        float[] d4xf = {0.707106781f,0.707106781f,-0.707106781f,-0.707106781f};
+        float[] d4yf = {-0.707106781f,0.707106781f,0.707106781f,-0.707106781f};
         float dxf = d4xf[rotation];
         float dyf = d4yf[rotation];
         int dx = Geometry.d4(rotation).x, dy = Geometry.d4(rotation).y;

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1941,8 +1941,8 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
 
     public void drawArrow(Block block, int x, int y, int rotation, boolean valid, boolean diagonalSymmetry){
         float trns = (block.size / 2) * tilesize;
-        float[] d4xf = {0.707106781f,0.707106781f,-0.707106781f,-0.707106781f};
-        float[] d4yf = {-0.707106781f,0.707106781f,0.707106781f,-0.707106781f};
+        float[] d4xf = {0.707106781f,-0.707106781f,-0.707106781f,0.707106781f};
+        float[] d4yf = {0.707106781f,0.707106781f,-0.707106781f,-0.707106781f};
         float dxf = d4xf[rotation];
         float dyf = d4yf[rotation];
         int dx = Geometry.d4(rotation).x, dy = Geometry.d4(rotation).y;
@@ -1957,7 +1957,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         offsety - 1,
         regionArrow.width * regionArrow.scl(),
         regionArrow.height * regionArrow.scl(),
-        rotation * 90 - (diagonalSymmetry ? 135 : 90));
+        rotation * 90 - (diagonalSymmetry ? 45 : 90));
 
         Draw.color(!valid ? Pal.remove : Pal.accent);
         Draw.rect(regionArrow,
@@ -1965,7 +1965,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         offsety,
         regionArrow.width * regionArrow.scl(),
         regionArrow.height * regionArrow.scl(),
-        rotation * 90 - (diagonalSymmetry ? 135 : 90));
+        rotation * 90 - (diagonalSymmetry ? 45 : 90));
     }
 
     void iterateLine(int startX, int startY, int endX, int endY, Cons<PlaceLine> cons){

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1926,11 +1926,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         if(tile != null && tile.build != null) tile = tile.build.tile;
         player.unit().addBuild(new BuildPlan(tile.x, tile.y));
     }
-
-    public void drawArrow(Block block, int x, int y, int rotation, boolean diagonalSymmetry){
-        drawArrow(block, x, y, rotation, validPlace(x, y, block, rotation), diagonalSymmetry);
-    }
-
+    
     public void drawArrow(Block block, int x, int y, int rotation){
         drawArrow(block, x, y, rotation, validPlace(x, y, block, rotation), false);
     }

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1927,11 +1927,11 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         player.unit().addBuild(new BuildPlan(tile.x, tile.y));
     }
 
-    public void drawArrow(Block block, int x, int y, int rotation){
+    public void drawArrow(Block block, int x, int y, float rotation){
         drawArrow(block, x, y, rotation, validPlace(x, y, block, rotation));
     }
 
-    public void drawArrow(Block block, int x, int y, int rotation, boolean valid){
+    public void drawArrow(Block block, int x, int y, float rotation, boolean valid){
         float trns = (block.size / 2) * tilesize;
         int dx = Geometry.d4(rotation).x, dy = Geometry.d4(rotation).y;
         float offsetx = x * tilesize + block.offset + dx*trns;

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1927,11 +1927,11 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         player.unit().addBuild(new BuildPlan(tile.x, tile.y));
     }
 
-    public void drawArrow(Block block, int x, int y, float rotation){
+    public void drawArrow(Block block, int x, int y, int rotation){
         drawArrow(block, x, y, rotation, validPlace(x, y, block, rotation));
     }
 
-    public void drawArrow(Block block, int x, int y, float rotation, boolean valid){
+    public void drawArrow(Block block, int x, int y, int rotation, boolean valid){
         float trns = (block.size / 2) * tilesize;
         int dx = Geometry.d4(rotation).x, dy = Geometry.d4(rotation).y;
         float offsetx = x * tilesize + block.offset + dx*trns;

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1927,11 +1927,11 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         player.unit().addBuild(new BuildPlan(tile.x, tile.y));
     }
 
-    public void drawArrow(Block block, int x, int y, int rotation){
-        drawArrow(block, x, y, rotation, validPlace(x, y, block, rotation));
+    public void drawArrow(Block block, int x, int y, int rotation, boolean diagonalSymmetry){
+        drawArrow(block, x, y, rotation, validPlace(x, y, block, rotation), diagonalSymmetry);
     }
 
-    public void drawArrow(Block block, int x, int y, int rotation, boolean valid){
+    public void drawArrow(Block block, int x, int y, int rotation, boolean valid, boolean diagonalSymmetry){
         float trns = (block.size / 2) * tilesize;
         int dx = Geometry.d4(rotation).x, dy = Geometry.d4(rotation).y;
         float offsetx = x * tilesize + block.offset + dx*trns;
@@ -1945,7 +1945,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         offsety - 1,
         regionArrow.width * regionArrow.scl(),
         regionArrow.height * regionArrow.scl(),
-        rotation * 90 - 90);
+        rotation * 90 - (diagonalSymmetry ? 45 : 90));
 
         Draw.color(!valid ? Pal.remove : Pal.accent);
         Draw.rect(regionArrow,

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1933,7 +1933,8 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
 
     public void drawArrow(Block block, int x, int y, int rotation, boolean valid, boolean diagonalSymmetry){
         float trns = (block.size / 2) * tilesize;
-        float dxf = [0.707106781,0.707106781,-0.707106781,-0.707106781][rotation], dyf = [-0.707106781,0.707106781,0.707106781,-0.707106781][rotation];
+        float[] d4xf = [0.707106781,0.707106781,-0.707106781,-0.707106781], d4yf = [-0.707106781,0.707106781,0.707106781,-0.707106781];
+        float dxf = d4xf[rotation], float dyf = d4yf[rotation];
         int dx = Geometry.d4(rotation).x, dy = Geometry.d4(rotation).y;
         float offsetx = x * tilesize + block.offset + (diagonalSymmetry ? dxf : dx)*trns;
         float offsety = y * tilesize + block.offset + (diagonalSymmetry ? dyf : dy)*trns;

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1931,6 +1931,14 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         drawArrow(block, x, y, rotation, validPlace(x, y, block, rotation), diagonalSymmetry);
     }
 
+    public void drawArrow(Block block, int x, int y, int rotation){
+        drawArrow(block, x, y, rotation, validPlace(x, y, block, rotation), false);
+    }
+
+    public void drawArrow(Block block, int x, int y, int rotation, boolean valid){
+        drawArrow(block, x, y, rotation, valid, false)
+    }
+
     public void drawArrow(Block block, int x, int y, int rotation, boolean valid, boolean diagonalSymmetry){
         float trns = (block.size / 2) * tilesize;
         float[] d4xf = {0.707106781f,0.707106781f,-0.707106781f,-0.707106781f};

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1934,7 +1934,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
     public void drawArrow(Block block, int x, int y, int rotation, boolean valid, boolean diagonalSymmetry){
         float trns = (block.size / 2) * tilesize;
         float[] d4xf = [0.707106781,0.707106781,-0.707106781,-0.707106781], d4yf = [-0.707106781,0.707106781,0.707106781,-0.707106781];
-        float dxf = d4xf[rotation], float dyf = d4yf[rotation];
+        float dxf = d4xf[rotation], dyf = d4yf[rotation];
         int dx = Geometry.d4(rotation).x, dy = Geometry.d4(rotation).y;
         float offsetx = x * tilesize + block.offset + (diagonalSymmetry ? dxf : dx)*trns;
         float offsety = y * tilesize + block.offset + (diagonalSymmetry ? dyf : dy)*trns;

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1933,8 +1933,10 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
 
     public void drawArrow(Block block, int x, int y, int rotation, boolean valid, boolean diagonalSymmetry){
         float trns = (block.size / 2) * tilesize;
-        float[] d4xf = [0.707106781,0.707106781,-0.707106781,-0.707106781], d4yf = [-0.707106781,0.707106781,0.707106781,-0.707106781];
-        float dxf = d4xf[rotation], dyf = d4yf[rotation];
+        float[] d4xf = {0.707106781,0.707106781,-0.707106781,-0.707106781};
+        float[] d4yf = {-0.707106781,0.707106781,0.707106781,-0.707106781};
+        float dxf = d4xf[rotation];
+        float dyf = d4yf[rotation];
         int dx = Geometry.d4(rotation).x, dy = Geometry.d4(rotation).y;
         float offsetx = x * tilesize + block.offset + (diagonalSymmetry ? dxf : dx)*trns;
         float offsety = y * tilesize + block.offset + (diagonalSymmetry ? dyf : dy)*trns;

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1936,7 +1936,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
     }
 
     public void drawArrow(Block block, int x, int y, int rotation, boolean valid){
-        drawArrow(block, x, y, rotation, valid, false)
+        drawArrow(block, x, y, rotation, valid, false);
     }
 
     public void drawArrow(Block block, int x, int y, int rotation, boolean valid, boolean diagonalSymmetry){

--- a/core/src/mindustry/input/MobileInput.java
+++ b/core/src/mindustry/input/MobileInput.java
@@ -409,7 +409,7 @@ public class MobileInput extends InputHandler implements GestureListener{
 
             if(!plan.breaking && plan == lastPlaced && plan.block != null){
                 Draw.mixcol();
-                if(plan.block.rotate && plan.block.drawArrow) drawArrow(plan.block, tile.x, tile.y, plan.rotation, plan.block.diagonalSymmetry);
+                if(plan.block.rotate && plan.block.drawArrow) drawArrow(plan.block, tile.x, tile.y, plan.rotation, validPlace(plan.x, plan.y, block, plan.rotation), plan.block.diagonalSymmetry);
             }
 
             Draw.reset();

--- a/core/src/mindustry/input/MobileInput.java
+++ b/core/src/mindustry/input/MobileInput.java
@@ -365,7 +365,7 @@ public class MobileInput extends InputHandler implements GestureListener{
                 for(int i = 0; i < linePlans.size; i++){
                     BuildPlan plan = linePlans.get(i);
                     if(i == linePlans.size - 1 && plan.block.rotate && plan.block.drawArrow){
-                        drawArrow(block, plan.x, plan.y, plan.rotation);
+                        drawArrow(block, plan.x, plan.y, plan.rotation + (plan.block.diagonalSymmetryAxis ? 0.5 : 0));
                     }
                     plan.block.drawPlan(plan, allPlans(), validPlace(plan.x, plan.y, plan.block, plan.rotation) && getPlan(plan.x, plan.y, plan.block.size, null) == null);
                     drawSelected(plan.x, plan.y, plan.block, Pal.accent);
@@ -409,7 +409,7 @@ public class MobileInput extends InputHandler implements GestureListener{
 
             if(!plan.breaking && plan == lastPlaced && plan.block != null){
                 Draw.mixcol();
-                if(plan.block.rotate && plan.block.drawArrow) drawArrow(plan.block, tile.x, tile.y, plan.rotation);
+                if(plan.block.rotate && plan.block.drawArrow) drawArrow(plan.block, tile.x, tile.y, plan.rotation + (plan.block.diagonalSymmetryAxis ? 0.5 : 0));
             }
 
             Draw.reset();

--- a/core/src/mindustry/input/MobileInput.java
+++ b/core/src/mindustry/input/MobileInput.java
@@ -365,7 +365,7 @@ public class MobileInput extends InputHandler implements GestureListener{
                 for(int i = 0; i < linePlans.size; i++){
                     BuildPlan plan = linePlans.get(i);
                     if(i == linePlans.size - 1 && plan.block.rotate && plan.block.drawArrow){
-                        drawArrow(block, plan.x, plan.y, plan.rotation + (plan.block.diagonalSymmetryAxis ? 0.5 : 0));
+                        drawArrow(block, plan.x, plan.y, plan.rotation);
                     }
                     plan.block.drawPlan(plan, allPlans(), validPlace(plan.x, plan.y, plan.block, plan.rotation) && getPlan(plan.x, plan.y, plan.block.size, null) == null);
                     drawSelected(plan.x, plan.y, plan.block, Pal.accent);
@@ -409,7 +409,7 @@ public class MobileInput extends InputHandler implements GestureListener{
 
             if(!plan.breaking && plan == lastPlaced && plan.block != null){
                 Draw.mixcol();
-                if(plan.block.rotate && plan.block.drawArrow) drawArrow(plan.block, tile.x, tile.y, plan.rotation + (plan.block.diagonalSymmetryAxis ? 0.5 : 0));
+                if(plan.block.rotate && plan.block.drawArrow) drawArrow(plan.block, tile.x, tile.y, plan.rotation);
             }
 
             Draw.reset();

--- a/core/src/mindustry/input/MobileInput.java
+++ b/core/src/mindustry/input/MobileInput.java
@@ -365,7 +365,7 @@ public class MobileInput extends InputHandler implements GestureListener{
                 for(int i = 0; i < linePlans.size; i++){
                     BuildPlan plan = linePlans.get(i);
                     if(i == linePlans.size - 1 && plan.block.rotate && plan.block.drawArrow){
-                        drawArrow(block, plan.x, plan.y, plan.rotation);
+                        drawArrow(block, plan.x, plan.y, plan.rotation, plan.block.diagonalSymmetry);
                     }
                     plan.block.drawPlan(plan, allPlans(), validPlace(plan.x, plan.y, plan.block, plan.rotation) && getPlan(plan.x, plan.y, plan.block.size, null) == null);
                     drawSelected(plan.x, plan.y, plan.block, Pal.accent);
@@ -409,7 +409,7 @@ public class MobileInput extends InputHandler implements GestureListener{
 
             if(!plan.breaking && plan == lastPlaced && plan.block != null){
                 Draw.mixcol();
-                if(plan.block.rotate && plan.block.drawArrow) drawArrow(plan.block, tile.x, tile.y, plan.rotation);
+                if(plan.block.rotate && plan.block.drawArrow) drawArrow(plan.block, tile.x, tile.y, plan.rotation, plan.block.diagonalSymmetry);
             }
 
             Draw.reset();

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -114,7 +114,7 @@ public class Block extends UnlockableContent implements Senseable{
     public boolean lockRotation = true;
     /** if true, schematic flips with this block are inverted. */
     public boolean invertFlip = false;
-    /** if true, schematic flips with this block are based on diagonal symmetry instead of axial symmetry. */
+    /** if true, schematic flips with this block are based on diagonal symmetry instead of orthogonal symmetry. */
     public boolean diagonalSymmetry = false;
     /** number of different variant regions to use */
     public int variants = 0;

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -1381,10 +1381,10 @@ public class Block extends UnlockableContent implements Senseable{
         return !rotate && lockRotation ? 0 : rot;
     }
 
-    public void flipRotation(BuildPlan req, boolean x){
+    public void flipRotation(BuildPlan req, boolean flipHorizontally){
 		if (diagonalSymmetry) {
-        	req.rotation = planRotation(req.rotation ^ ((x ^ invertFlip) ? 3 : 1));
-		} else if ((x == ((req.rotation & 1) == 0)) != invertFlip) {
+        	req.rotation = planRotation(req.rotation ^ ((flipHorizontally ^ invertFlip) ? 1 : 3));
+		} else if ((flipHorizontally ^ invertFlip) == ((req.rotation & 1) == 0)) {
             req.rotation = planRotation(req.rotation ^ 2);
         }
     }

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -114,8 +114,6 @@ public class Block extends UnlockableContent implements Senseable{
     public boolean lockRotation = true;
     /** if true, schematic flips with this block are inverted. */
     public boolean invertFlip = false;
-    /** if true, schematic flips with this block are based on diagonal symmetry instead of axial symmetry. */
-	public boolean diagonalSymmetryAxis = false;
     /** number of different variant regions to use */
     public int variants = 0;
     /** whether to draw a rotation arrow - this does not apply to lines of blocks */
@@ -1382,13 +1380,11 @@ public class Block extends UnlockableContent implements Senseable{
     }
 
     public void flipRotation(BuildPlan req, boolean x){
-		if (diagonalSymmetryAxis) {
-        	req.rotation = planRotation(req.rotation ^ ((x ^ invertFlip) ? 3 : 1));
-		} else if ((x == ((req.rotation & 1) == 0)) != invertFlip) {
-            req.rotation = planRotation(req.rotation ^ 2);
+        if((x == (req.rotation % 2 == 0)) != invertFlip){
+            req.rotation = planRotation(Mathf.mod(req.rotation + 2, 4));
         }
     }
-    
+
     @Override
     public double sense(LAccess sensor){
         return switch(sensor){

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -114,6 +114,8 @@ public class Block extends UnlockableContent implements Senseable{
     public boolean lockRotation = true;
     /** if true, schematic flips with this block are inverted. */
     public boolean invertFlip = false;
+    /** if true, schematic flips with this block are based on diagonal symmetry instead of axial symmetry. */
+	public boolean diagonalSymmetryAxis = false;
     /** number of different variant regions to use */
     public int variants = 0;
     /** whether to draw a rotation arrow - this does not apply to lines of blocks */
@@ -1380,11 +1382,13 @@ public class Block extends UnlockableContent implements Senseable{
     }
 
     public void flipRotation(BuildPlan req, boolean x){
-        if((x == (req.rotation % 2 == 0)) != invertFlip){
-            req.rotation = planRotation(Mathf.mod(req.rotation + 2, 4));
+		if (diagonalSymmetryAxis) {
+        	req.rotation = planRotation(req.rotation ^ ((x ^ invertFlip) ? 3 : 1));
+		} else if ((x == ((req.rotation & 1) == 0)) != invertFlip) {
+            req.rotation = planRotation(req.rotation ^ 2);
         }
     }
-
+    
     @Override
     public double sense(LAccess sensor){
         return switch(sensor){

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -1382,7 +1382,7 @@ public class Block extends UnlockableContent implements Senseable{
     }
 
     public void flipRotation(BuildPlan req, boolean x){
-		if (diagonalSymmetryAxis) {
+		if (diagonalSymmetry) {
         	req.rotation = planRotation(req.rotation ^ ((x ^ invertFlip) ? 3 : 1));
 		} else if ((x == ((req.rotation & 1) == 0)) != invertFlip) {
             req.rotation = planRotation(req.rotation ^ 2);

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -115,7 +115,7 @@ public class Block extends UnlockableContent implements Senseable{
     /** if true, schematic flips with this block are inverted. */
     public boolean invertFlip = false;
     /** if true, schematic flips with this block are based on diagonal symmetry instead of axial symmetry. */
-    public boolean diagonalSymmetryAxis = false;
+    public boolean diagonalSymmetry = false;
     /** number of different variant regions to use */
     public int variants = 0;
     /** whether to draw a rotation arrow - this does not apply to lines of blocks */

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -115,7 +115,7 @@ public class Block extends UnlockableContent implements Senseable{
     /** if true, schematic flips with this block are inverted. */
     public boolean invertFlip = false;
     /** if true, schematic flips with this block are based on diagonal symmetry instead of axial symmetry. */
-    public boolean diagonalSymmetryAxis = false;
+	public boolean diagonalSymmetryAxis = false;
     /** number of different variant regions to use */
     public int variants = 0;
     /** whether to draw a rotation arrow - this does not apply to lines of blocks */

--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -115,7 +115,7 @@ public class Block extends UnlockableContent implements Senseable{
     /** if true, schematic flips with this block are inverted. */
     public boolean invertFlip = false;
     /** if true, schematic flips with this block are based on diagonal symmetry instead of axial symmetry. */
-	public boolean diagonalSymmetryAxis = false;
+    public boolean diagonalSymmetryAxis = false;
     /** number of different variant regions to use */
     public int variants = 0;
     /** whether to draw a rotation arrow - this does not apply to lines of blocks */


### PR DESCRIPTION
Adds functionality for blocks with a diagonal symmetry axis (defined by `Block.diagonalSymmetry`).
_`Block.rotation` = 0 means facing top-right_

Amendments: Maintained legacy method signatures

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
