### PR TITLE
Make a "unitCommandPosition" event so that unit commands issued to non-attack coordinates can still be listened for

### DIFF
--- a/core/src/mindustry/game/EventType.java
+++ b/core/src/mindustry/game/EventType.java
@@ -39,6 +39,7 @@ public class EventType{
         socketConfigChanged,
         update,
         unitCommandChange,
+        unitCommandPosition,
         unitCommandAttack,
         importMod,
         draw,

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1012,6 +1012,8 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
 
                 if(attack != null){
                     Events.fire(Trigger.unitCommandAttack);
+                }else{
+                    Events.fire(Trigger.unitCommandPosition);
                 }
 
                 int maxChunkSize = 200;


### PR DESCRIPTION
I tested this; it doesn't interfere with anything else that I'm aware of (although how would it?) but I checked to make sure anyway. It compiles and runs fine.

Basically, what this does is add a single event, which is fired when the player commands a selected group of units to coordinates and *isn't* attacking. Currently, there does exist a `Trigger.unitCommandAttack`, which is fired when the player gives units an attack command (i.e. there's an an enemy building at the coordinates, or the user clicked on an enemy unit instead of terrain when giving the command). There is also `Trigger.unitCommandChange`, which is fired whenever the user changes their command group (i.e. draws a new selection box, or selects all by type), but 

`Trigger.unitCommandPosition` (the new event) makes it possible to make listeners for whenever a movement command is issued to a group of units.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.