### PR TITLE
Trail, pierce and weave delaying

### DIFF
--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -428,15 +428,13 @@ public class BulletType extends Content implements Cloneable{
     }
 
     public void handlePierce(Bullet b, float initialHealth, float x, float y){
-        if(b.time >= pierceDelay){
-            float sub = Mathf.zero(pierceDamageFactor) ? 0f : Math.max(initialHealth * pierceDamageFactor, 0);
-            //subtract health from each consecutive pierce
-            b.damage -= Float.isNaN(sub) ? b.damage : Math.min(b.damage, sub);
+        float sub = Mathf.zero(pierceDamageFactor) ? 0f : Math.max(initialHealth * pierceDamageFactor, 0);
+        //subtract health from each consecutive pierce
+        b.damage -= Float.isNaN(sub) ? b.damage : Math.min(b.damage, sub);
 
-            if(removeAfterPierce && b.damage <= 0){
-                b.hit = true;
-                b.remove();
-            }
+        if(removeAfterPierce && b.damage <= 0 || b.time <= pierceDelay){
+            b.hit = true;
+            b.remove();
         }
     }
 
@@ -677,7 +675,7 @@ public class BulletType extends Content implements Cloneable{
     }
     
     public void updateTrail(Bullet b){
-        if(!headless && trailLength > 0 && b.time >= trailDelay)){
+        if(!headless && trailLength > 0 && b.time >= trailDelay){
             if(b.trail == null){
                 b.trail = new Trail(trailLength);
             }


### PR DESCRIPTION
Adds three new fields to BulletType:

- trailDelay - When specified, the bullet trail will not appear for a set time
- weaveDelay - When specified, the bullet will not start weaving for a set time
- pierceDelay - When specified, the bullet will be incapable of piercing targets for a set time

Use Cases:

trailDelay could be used in tandem with homingDelay and a missile bullet, simulating a missile that doesn't start up immediately after being fired from a weapon, akin to that one rocket launcher weapon in the game [Worms.](https://en.wikipedia.org/wiki/Worms_(series))

weaveDelay, I can't see a use case for. I just added it for no reason.

pierceDelay could be used to simulate a bullet that needs to build up speed (with negative drag, for example) in order to pierce targets.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
