### PR TITLE
Fix snow weather name not match with bundle

### DIFF
--- a/core/src/mindustry/content/Weathers.java
+++ b/core/src/mindustry/content/Weathers.java
@@ -17,7 +17,7 @@ public class Weathers{
     suspendParticles;
 
     public static void load(){
-        snow = new ParticleWeather("snowing"){{
+        snow = new ParticleWeather("snow"){{
             particleRegion = "particle";
             sizeMax = 13f;
             sizeMin = 2.6f;


### PR DESCRIPTION
Snow weather do not match it's name in bundle.
Define:
https://github.com/Anuken/Mindustry/blob/45bdceb7fba0425f41a386f88b5afa5a0403785e/core/src/mindustry/content/Weathers.java#L20
Name in bundle:
https://github.com/Anuken/Mindustry/blob/45bdceb7fba0425f41a386f88b5afa5a0403785e/core/assets/bundles/bundle.properties#L741

![Screenshot_20240331_164936_Mindustry BE](https://github.com/Anuken/Mindustry/assets/44901211/4f406851-c649-4210-be44-a2eedd323af2)
![Screenshot_20240331_164857_Mindustry BE](https://github.com/Anuken/Mindustry/assets/44901211/7015d04c-36b8-4887-bce7-d757c3bb23d5)

Maybe this is not good way to fix this. Change name in bundle?

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
