### PR TITLE
Data imported exit message

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -374,6 +374,7 @@ crash.none = No crash logs found.
 crash.exported = Crash logs exported.
 data.export = Export Data
 data.import = Import Data
+data.import.exit = The game will now exit, to reload imported data.
 data.openfolder = Open Data Folder
 data.exported = Data exported.
 data.invalid = This isn't valid game data.

--- a/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
+++ b/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
@@ -182,7 +182,9 @@ public class SettingsMenuDialog extends BaseDialog{
                     importData(file);
                     control.saves.resetSave();
                     state = new GameState();
-                    Core.app.exit();
+                    ui.showInfoOnHidden("@data.import.exit", () -> {
+                        Core.app.exit();
+                    });
                 }catch(IllegalArgumentException e){
                     ui.showErrorMessage("@data.invalid");
                 }catch(Exception e){


### PR DESCRIPTION
This will make players less confusing after game's data imported and no message tell them. They will think that is a crash.

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.