### PR TITLE
Para buffs

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -3369,7 +3369,7 @@ public class Blocks{
             size = 2;
             force = 16f;
             scaledForce = 9f;
-            range = 360f;
+            range = 300f;
             damage = 0.5f;
             scaledHealth = 160;
             rotateSpeed = 12;

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -3363,18 +3363,18 @@ public class Blocks{
         }};
 
         parallax = new TractorBeamTurret("parallax"){{
-            requirements(Category.turret, with(Items.silicon, 120, Items.titanium, 90, Items.graphite, 30));
+            requirements(Category.turret, with(Items.silicon, 160, Items.titanium, 110, Items.graphite, 50));
 
             hasPower = true;
             size = 2;
-            force = 12f;
-            scaledForce = 6f;
-            range = 240f;
-            damage = 0.3f;
+            force = 16f;
+            scaledForce = 9f;
+            range = 360f;
+            damage = 0.5f;
             scaledHealth = 160;
-            rotateSpeed = 10;
+            rotateSpeed = 12;
 
-            consumePower(3f);
+            consumePower(3.3f);
         }};
 
         swarmer = new ItemTurret("swarmer"){{


### PR DESCRIPTION
Parallax is severely underpowered right now, it takes 4 to stop a flare and 17 to stop an eclipse. As well as it just generally being underused due to how bad it is. It has come to an agreement on the buffs.

Further changes to mechanics such as debuff status effects or multiple beams still need to be decided on to make it more viable, but this general stats buff is good.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
