### PR TITLE
Add UnitCommandEvent

### DIFF
--- a/core/src/mindustry/game/EventType.java
+++ b/core/src/mindustry/game/EventType.java
@@ -328,6 +328,17 @@ public class EventType{
         }
     }
 
+    /** Called when a some player send command to unit **/
+    public static class UnitCommandEvent{
+        public final Player player;
+        public final @Nullable Unit unit;
+
+        public UnitCommandEvent(Player player, @Nullable Unit unit){
+            this.player = player;
+            this.unit = unit;
+        }
+    }
+
     public static class BuildingCommandEvent{
         public final Player player;
         public final Building building;

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -287,6 +287,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
                 }
 
                 toAdd.add(unit);
+                Events.fire(new UnitCommandEvent(player, unit));
             }
         }
 


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.

## If this is added...
Players will now be able to see where they are sending their units.
example 1) Server will now be able to see where Griefers are sending units for malicious purposes.
example 2) Can be used for statistical functions such as Action Per Meter.
