### PR TITLE
Added offset fields to DrawFlame

### DIFF
--- a/core/src/mindustry/world/draw/DrawFlame.java
+++ b/core/src/mindustry/world/draw/DrawFlame.java
@@ -14,6 +14,7 @@ public class DrawFlame extends DrawBlock{
     public TextureRegion top;
     public float lightRadius = 60f, lightAlpha = 0.65f, lightSinScl = 10f, lightSinMag = 5;
     public float flameRadius = 3f, flameRadiusIn = 1.9f, flameRadiusScl = 5f, flameRadiusMag = 2f, flameRadiusInMag = 1f;
+    public float flameX = 0, flameY = 0;
 
     public DrawFlame(){
     }
@@ -43,9 +44,9 @@ public class DrawFlame extends DrawBlock{
             Draw.alpha(((1f - g) + Mathf.absin(Time.time, 8f, g) + Mathf.random(r) - r) * build.warmup());
 
             Draw.tint(flameColor);
-            Fill.circle(build.x, build.y, flameRadius + Mathf.absin(Time.time, flameRadiusScl, flameRadiusMag) + cr);
+            Fill.circle(build.x + flameX, build.y + flameY, flameRadius + Mathf.absin(Time.time, flameRadiusScl, flameRadiusMag) + cr);
             Draw.color(1f, 1f, 1f, build.warmup());
-            Fill.circle(build.x, build.y, flameRadiusIn + Mathf.absin(Time.time, flameRadiusScl, flameRadiusInMag) + cr);
+            Fill.circle(build.x + flameX, build.y + flameY, flameRadiusIn + Mathf.absin(Time.time, flameRadiusScl, flameRadiusInMag) + cr);
 
             Draw.color();
         }
@@ -53,6 +54,6 @@ public class DrawFlame extends DrawBlock{
 
     @Override
     public void drawLight(Building build){
-        Drawf.light(build.x, build.y, (lightRadius + Mathf.absin(lightSinScl, lightSinMag)) * build.warmup() * build.block.size, flameColor, lightAlpha);
+        Drawf.light(build.x + flameX, build.y + flameY, (lightRadius + Mathf.absin(lightSinScl, lightSinMag)) * build.warmup() * build.block.size, flameColor, lightAlpha);
     }
 }


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

This simple change could really help modders (especially hjson) with custom factories if the flame isn't locked in the center and could be offsetted (like turrets have shootX and shootY) though flameX and flameY.


Example of a hjson modded building that uses flameX = 6f and flameY = 6f:

https://github.com/Anuken/Mindustry/assets/86385005/57b712ab-2cd9-4625-a1cb-45489b651968

