### PR TITLE
Switch order of literals to prevent NullPointerException

### DIFF
--- a/android/src/mindustry/android/AndroidLauncher.java
+++ b/android/src/mindustry/android/AndroidLauncher.java
@@ -246,10 +246,10 @@ public class AndroidLauncher extends AndroidApplication{
             if(uri != null){
                 File myFile = null;
                 String scheme = uri.getScheme();
-                if(scheme.equals("file")){
+                if("file".equals(scheme)){
                     String fileName = uri.getEncodedPath();
                     myFile = new File(fileName);
-                }else if(!scheme.equals("content")){
+                }else if(!"content".equals(scheme)){
                     //error
                     return;
                 }

--- a/annotations/src/main/java/mindustry/annotations/BaseProcessor.java
+++ b/annotations/src/main/java/mindustry/annotations/BaseProcessor.java
@@ -40,8 +40,8 @@ public abstract class BaseProcessor extends AbstractProcessor{
     }
 
     public static boolean isPrimitive(String type){
-        return type.equals("boolean") || type.equals("byte") || type.equals("short") || type.equals("int")
-        || type.equals("long") || type.equals("float") || type.equals("double") || type.equals("char");
+        return "boolean".equals(type) || "byte".equals(type) || "short".equals(type) || "int".equals(type)
+        || "long".equals(type) || "float".equals(type) || "double".equals(type) || "char".equals(type);
     }
 
     public static boolean instanceOf(String type, String other){

--- a/annotations/src/main/java/mindustry/annotations/entity/EntityIO.java
+++ b/annotations/src/main/java/mindustry/annotations/entity/EntityIO.java
@@ -226,8 +226,8 @@ public class EntityIO{
         type = replacements.get(type, type);
 
         if(BaseProcessor.isPrimitive(type)){
-            s(type.equals("boolean") ? "bool" : type.charAt(0) + "", field);
-        }else if(instanceOf(type, "mindustry.ctype.Content") && !type.equals("mindustry.ai.UnitStance") && !type.equals("mindustry.ai.UnitCommand")){
+            s("boolean".equals(type) ? "bool" : type.charAt(0) + "", field);
+        }else if(instanceOf(type, "mindustry.ctype.Content") && !"mindustry.ai.UnitStance".equals(type) && !"mindustry.ai.UnitCommand".equals(type)){
             if(write){
                 s("s", field + ".id");
             }else{
@@ -262,7 +262,7 @@ public class EntityIO{
             String struct = type.substring(0, type.indexOf("<"));
             String generic = type.substring(type.indexOf("<") + 1, type.indexOf(">"));
 
-            if(struct.equals("arc.struct.Queue") || struct.equals("arc.struct.Seq")){
+            if("arc.struct.Queue".equals(struct) || "arc.struct.Seq".equals(struct)){
                 if(write){
                     s("i", field + ".size");
                     cont("for(int INDEX = 0; INDEX < $L.size; INDEX ++)", field);

--- a/annotations/src/main/java/mindustry/annotations/entity/EntityProcess.java
+++ b/annotations/src/main/java/mindustry/annotations/entity/EntityProcess.java
@@ -130,7 +130,7 @@ public class EntityProcess extends BaseProcessor{
                     .addJavadoc(method.doc() == null ? "" : method.doc())
                     .addExceptions(method.thrownt())
                     .addTypeVariables(method.typeVariables().map(TypeVariableName::get))
-                    .returns(method.ret().toString().equals("void") ? TypeName.VOID : method.retn())
+                    .returns("void".equals(method.ret().toString()) ? TypeName.VOID : method.retn())
                     .addParameters(method.params().map(v -> ParameterSpec.builder(v.tname(), v.name())
                     .build())).addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT).build());
                 }
@@ -455,18 +455,18 @@ public class EntityProcess extends BaseProcessor{
                     }
 
                     //only write the block if it's a void method with several entries
-                    boolean writeBlock = first.ret().toString().equals("void") && entry.value.size > 1;
+                    boolean writeBlock = "void".equals(first.ret().toString()) && entry.value.size > 1;
 
                     if((entry.value.first().is(Modifier.ABSTRACT) || entry.value.first().is(Modifier.NATIVE)) && entry.value.size == 1 && !entry.value.first().has(InternalImpl.class)){
                         err(entry.value.first().up().getSimpleName() + "#" + entry.value.first() + " is an abstract method and must be implemented in some component", type);
                     }
 
                     //SPECIAL CASE: inject group add/remove code
-                    if(first.name().equals("add") || first.name().equals("remove")){
-                        mbuilder.addStatement("if(added == $L) return", first.name().equals("add"));
+                    if("add".equals(first.name()) || "remove".equals(first.name())){
+                        mbuilder.addStatement("if(added == $L) return", "add".equals(first.name()));
 
                         for(GroupDefinition def : groups){
-                            if(first.name().equals("add")){
+                            if("add".equals(first.name())){
                                 //remove/add from each group, assume imported
                                 mbuilder.addStatement("index__$L = Groups.$L.addIndex(this)", def.name, def.name);
                             }else{
@@ -483,28 +483,28 @@ public class EntityProcess extends BaseProcessor{
                     if(hasIO){
                         //SPECIAL CASE: I/O code
                         //note that serialization is generated even for non-serializing entities for manual usage
-                        if((first.name().equals("read") || first.name().equals("write"))){
-                            io.write(mbuilder, first.name().equals("write"));
+                        if(("read".equals(first.name()) || "write".equals(first.name()))){
+                            io.write(mbuilder, "write".equals(first.name()));
                             specialIO = true;
                         }
 
                         //SPECIAL CASE: sync I/O code
-                        if((first.name().equals("readSync") || first.name().equals("writeSync"))){
-                            io.writeSync(mbuilder, first.name().equals("writeSync"), allFields);
+                        if(("readSync".equals(first.name()) || "writeSync".equals(first.name()))){
+                            io.writeSync(mbuilder, "writeSync".equals(first.name()), allFields);
                         }
 
                         //SPECIAL CASE: sync I/O code for writing to/from a manual buffer
-                        if((first.name().equals("readSyncManual") || first.name().equals("writeSyncManual"))){
-                            io.writeSyncManual(mbuilder, first.name().equals("writeSyncManual"), syncedFields);
+                        if(("readSyncManual".equals(first.name()) || "writeSyncManual".equals(first.name()))){
+                            io.writeSyncManual(mbuilder, "writeSyncManual".equals(first.name()), syncedFields);
                         }
 
                         //SPECIAL CASE: interpolate method implementation
-                        if(first.name().equals("interpolate")){
+                        if("interpolate".equals(first.name())){
                             io.writeInterpolate(mbuilder, syncedFields);
                         }
 
                         //SPECIAL CASE: method to snap to target position after being read for the first time
-                        if(first.name().equals("snapSync")){
+                        if("snapSync".equals(first.name())){
                             mbuilder.addStatement("updateSpacing = 16");
                             mbuilder.addStatement("lastUpdated = $T.millis()", Time.class);
                             for(Svar field : syncedFields){
@@ -515,7 +515,7 @@ public class EntityProcess extends BaseProcessor{
                         }
 
                         //SPECIAL CASE: method to snap to current position so interpolation doesn't go wild
-                        if(first.name().equals("snapInterpolation")){
+                        if("snapInterpolation".equals(first.name())){
                             mbuilder.addStatement("updateSpacing = 16");
                             mbuilder.addStatement("lastUpdated = $T.millis()", Time.class);
                             for(Svar field : syncedFields){
@@ -560,7 +560,7 @@ public class EntityProcess extends BaseProcessor{
 
                     //add free code to remove methods - always at the end
                     //this only gets called next frame.
-                    if(first.name().equals("remove") && ann.pooled()){
+                    if("remove".equals(first.name()) && ann.pooled()){
                         mbuilder.addStatement("mindustry.gen.Groups.queueFree(($T)this)", Poolable.class);
                     }
 
@@ -921,7 +921,7 @@ public class EntityProcess extends BaseProcessor{
                                     builder.addStatement("return " + getDefault(method.ret().toString()));
                                 }else{
                                     String init = varInitializers.get(desc);
-                                    builder.addStatement("return " + (init.equals("{}") ? "new " + variable.mirror().toString() : "") + init);
+                                    builder.addStatement("return " + ("{}".equals(init) ? "new " + variable.mirror().toString() : "") + init);
                                 }
                         }
                     }

--- a/annotations/src/main/java/mindustry/annotations/impl/AssetsProcess.java
+++ b/annotations/src/main/java/mindustry/annotations/impl/AssetsProcess.java
@@ -46,7 +46,7 @@ public class AssetsProcess extends BaseProcessor{
         texIcons.each((key, val) -> {
             String[] split = val.split("\\|");
             String name = Strings.kebabToCamel(split[1]).replace("Medium", "").replace("Icon", "").replace("Ui", "");
-            if(SourceVersion.isKeyword(name) || name.equals("char")) name += "i";
+            if(SourceVersion.isKeyword(name) || "char".equals(name)) name += "i";
 
             ichtype.addField(FieldSpec.builder(char.class, name, Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL).addJavadoc(String.format("\\u%04x", Integer.parseInt(key))).initializer("'" + ((char)Integer.parseInt(key)) + "'").build());
         });
@@ -177,7 +177,7 @@ public class AssetsProcess extends BaseProcessor{
             type.addStaticBlock(staticb.build());
         }
 
-        if(classname.equals("Sounds")){
+        if("Sounds".equals(classname)){
             type.addField(FieldSpec.builder(ClassName.bestGuess(rtype), "none", Modifier.STATIC, Modifier.PUBLIC).initializer("new " + rtype + "()").build());
         }
 

--- a/annotations/src/main/java/mindustry/annotations/misc/LogicStatementProcessor.java
+++ b/annotations/src/main/java/mindustry/annotations/misc/LogicStatementProcessor.java
@@ -80,7 +80,7 @@ public class LogicStatementProcessor extends BaseProcessor{
                 reader.addStatement("if(length > $L) result.$L = $L(tokens[$L])",
                 index + 1,
                 field.name(),
-                field.mirror().toString().equals("java.lang.String") ?
+                "java.lang.String".equals(field.mirror().toString()) ?
                 "" : (field.tname().isPrimitive() ? field.tname().box().toString() :
                 field.mirror().toString()) + ".valueOf", //if it's not a string, it must have a valueOf method
                 index + 1

--- a/annotations/src/main/java/mindustry/annotations/remote/CallGenerator.java
+++ b/annotations/src/main/java/mindustry/annotations/remote/CallGenerator.java
@@ -123,7 +123,7 @@ public class CallGenerator{
             }
 
             if(BaseProcessor.isPrimitive(typeName)){ //check if it's a primitive, and if so write it
-                builder.addStatement("WRITE.$L($L)", typeName.equals("boolean") ? "bool" : typeName.charAt(0) + "", varName);
+                builder.addStatement("WRITE.$L($L)", "boolean".equals(typeName) ? "bool" : typeName.charAt(0) + "", varName);
             }else{
                 //else, try and find a serializer
                 String ser = serializer.getNetWriter(typeName.replace("mindustry.gen.", ""), SerializerResolver.locate(ent.element.e, var.mirror(), true));
@@ -186,7 +186,7 @@ public class CallGenerator{
             //name of parameter
             String varName = var.name();
             //capitalized version of type name for reading primitives
-            String pname = typeName.equals("boolean") ? "bool" : typeName.charAt(0) + "";
+            String pname = "boolean".equals(typeName) ? "bool" : typeName.charAt(0) + "";
 
             //write primitives automatically
             if(BaseProcessor.isPrimitive(typeName)){

--- a/annotations/src/main/java/mindustry/annotations/remote/SerializerResolver.java
+++ b/annotations/src/main/java/mindustry/annotations/remote/SerializerResolver.java
@@ -9,7 +9,7 @@ public class SerializerResolver{
 
     public static String locate(ExecutableElement elem, TypeMirror mirror, boolean write){
         //generic type
-        if((mirror.toString().equals("T") && Seq.with(elem.getTypeParameters().get(0).getBounds()).contains(SerializerResolver::isEntity)) ||
+        if(("T".equals(mirror.toString()) && Seq.with(elem.getTypeParameters().get(0).getBounds()).contains(SerializerResolver::isEntity)) ||
             isEntity(mirror)){
             return write ? "mindustry.io.TypeIO.writeEntity" : "mindustry.io.TypeIO.readEntity";
         }

--- a/annotations/src/main/java/mindustry/annotations/util/Smethod.java
+++ b/annotations/src/main/java/mindustry/annotations/util/Smethod.java
@@ -50,7 +50,7 @@ public class Smethod extends Selement<ExecutableElement>{
     }
 
     public boolean isVoid(){
-        return ret().toString().equals("void");
+        return "void".equals(ret().toString());
     }
 
     public TypeMirror ret(){

--- a/core/src/mindustry/Vars.java
+++ b/core/src/mindustry/Vars.java
@@ -460,7 +460,7 @@ public class Vars implements Loadable{
             Fi handle = Core.files.internal("bundles/bundle");
             Locale locale;
             String loc = settings.getString("locale");
-            if(loc.equals("default")){
+            if("default".equals(loc)){
                 locale = Locale.getDefault();
             }else{
                 Locale lastLocale;
@@ -478,7 +478,7 @@ public class Vars implements Loadable{
             Core.bundle = I18NBundle.createBundle(handle, locale);
 
             //router
-            if(locale.toString().equals("router")){
+            if("router".equals(locale.toString())){
                 bundle.debug("router");
             }
         }

--- a/core/src/mindustry/core/Control.java
+++ b/core/src/mindustry/core/Control.java
@@ -334,7 +334,7 @@ public class Control implements ApplicationListener, Loadable{
         player.name = Core.settings.getString("name");
 
         String locale = Core.settings.getString("locale");
-        if(locale.equals("default")){
+        if("default".equals(locale)){
             locale = Locale.getDefault().toString();
         }
         player.locale = locale;

--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -83,7 +83,7 @@ public class NetClient implements ApplicationListener{
             });
 
             String locale = Core.settings.getString("locale");
-            if(locale.equals("default")){
+            if("default".equals(locale)){
                 locale = Locale.getDefault().toString();
             }
 

--- a/core/src/mindustry/core/NetServer.java
+++ b/core/src/mindustry/core/NetServer.java
@@ -973,7 +973,7 @@ public class NetServer implements ApplicationListener{
 
     public String fixName(String name){
         name = name.trim().replace("\n", "").replace("\t", "");
-        if(name.equals("[") || name.equals("]")){
+        if("[".equals(name) || "]".equals(name)){
             return "";
         }
 

--- a/core/src/mindustry/core/Platform.java
+++ b/core/src/mindustry/core/Platform.java
@@ -178,7 +178,7 @@ public interface Platform{
                 }
 
                 //cancelled selection, ignore result
-                if(result.isEmpty() || result.equals("\n")) return;
+                if(result.isEmpty() || "\n".equals(result)) return;
 
                 if(result.endsWith("\n")) result = result.substring(0, result.length() - 1);
                 if(result.contains("\n")) throw new IOException("invalid input: \"" + result + "\"");

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -102,7 +102,7 @@ public class LExecutor{
         builder.vars.each((name, var) -> {
             Var dest = new Var(name);
             vars[var.id] = dest;
-            if(dest.name.equals("@ipt")){
+            if("@ipt".equals(dest.name)){
                 iptIndex = var.id;
             }
 

--- a/core/src/mindustry/logic/LParser.java
+++ b/core/src/mindustry/logic/LParser.java
@@ -66,7 +66,7 @@ public class LParser{
 
     /** Apply changes after reading a list of tokens. */
     void checkRead(){
-        if(tokens[0].equals("op")){
+        if("op".equals(tokens[0])){
             //legacy name change
             tokens[1] = opNameChanges.get(tokens[1], tokens[1]);
         }
@@ -118,14 +118,14 @@ public class LParser{
                 boolean wasJump;
                 String jumpLoc = null;
                 //clean up jump position before parsing
-                if(wasJump = (tokens[0].equals("jump") && tok > 1 && !Strings.canParseInt(tokens[1]))){
+                if(wasJump = ("jump".equals(tokens[0]) && tok > 1 && !Strings.canParseInt(tokens[1]))){
                     jumpLoc = tokens[1];
                     tokens[1] = "-1";
                 }
 
                 for(int i = 1; i < tok; i++){
-                    if(tokens[i].equals("@configure")) tokens[i] = "@config";
-                    if(tokens[i].equals("configure")) tokens[i] = "config";
+                    if("@configure".equals(tokens[i])) tokens[i] = "@config";
+                    if("configure".equals(tokens[i])) tokens[i] = "config";
                 }
 
                 LStatement st;

--- a/core/src/mindustry/maps/Maps.java
+++ b/core/src/mindustry/maps/Maps.java
@@ -363,7 +363,7 @@ public class Maps{
     }
 
     public Seq<SpawnGroup> readWaves(String str){
-        return str == null ? null : str.equals("[]") ? new Seq<>() : Seq.with(JsonIO.json.fromJson(SpawnGroup[].class, str));
+        return str == null ? null : "[]".equals(str) ? new Seq<>() : Seq.with(JsonIO.json.fromJson(SpawnGroup[].class, str));
     }
 
     public void loadPreviews(){

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -961,7 +961,7 @@ public class Mods implements Loadable{
                 Class<?> main = Class.forName(mainClass, true, loader);
 
                 //detect mods that incorrectly package mindustry in the jar
-                if((main.getSuperclass().getName().equals("mindustry.mod.Plugin") || main.getSuperclass().getName().equals("mindustry.mod.Mod")) &&
+                if(("mindustry.mod.Plugin".equals(main.getSuperclass().getName()) || "mindustry.mod.Mod".equals(main.getSuperclass().getName())) &&
                     main.getSuperclass().getClassLoader() != Mod.class.getClassLoader()){
                     throw new ModLoadException(
                         "This mod/plugin has loaded Mindustry dependencies from its own class loader. " +

--- a/core/src/mindustry/type/MapLocales.java
+++ b/core/src/mindustry/type/MapLocales.java
@@ -89,7 +89,7 @@ public class MapLocales extends ObjectMap<String, StringMap> implements JsonSeri
     // To handle default locale properly
     public static String currentLocale(){
         String locale = settings.getString("locale");
-        if(locale.equals("default")){
+        if("default".equals(locale)){
             locale = Locale.getDefault().getLanguage();
         }
         return locale;

--- a/core/src/mindustry/ui/dialogs/LanguageDialog.java
+++ b/core/src/mindustry/ui/dialogs/LanguageDialog.java
@@ -91,7 +91,7 @@ public class LanguageDialog extends BaseDialog{
     public Locale getLocale(){
         String loc = Core.settings.getString("locale");
 
-        if(loc.equals("default")){
+        if("default".equals(loc)){
             findClosestLocale();
         }
 

--- a/core/src/mindustry/ui/dialogs/ModsDialog.java
+++ b/core/src/mindustry/ui/dialogs/ModsDialog.java
@@ -664,7 +664,7 @@ public class ModsDialog extends BaseDialog{
 
                 //this is a crude heuristic for class mods; only required for direct github import
                 //TODO make a more reliable way to distinguish java mod repos
-                if(language.equals("Java") || language.equals("Kotlin")){
+                if("Java".equals(language) || "Kotlin".equals(language)){
                     githubImportJavaMod(repo, release);
                 }else{
                     githubImportBranch(mainBranch, repo, release);

--- a/core/src/mindustry/ui/fragments/ConsoleFragment.java
+++ b/core/src/mindustry/ui/fragments/ConsoleFragment.java
@@ -165,7 +165,7 @@ public class ConsoleFragment extends Table{
         if(message.replace(" ", "").isEmpty()) return;
 
         //special case for 'clear' command
-        if(message.equals("clear")){
+        if("clear".equals(message)){
             clearMessages();
             return;
         }

--- a/core/src/mindustry/world/blocks/logic/LogicBlock.java
+++ b/core/src/mindustry/world/blocks/logic/LogicBlock.java
@@ -106,7 +106,7 @@ public class LogicBlock extends Block{
         if(name.contains("-")){
             String[] split = name.split("-");
             //filter out 'large' at the end of block names
-            if(split.length >= 2 && (split[split.length - 1].equals("large") || Strings.canParseFloat(split[split.length - 1]))){
+            if(split.length >= 2 && ("large".equals(split[split.length - 1]) || Strings.canParseFloat(split[split.length - 1]))){
                 name = split[split.length - 2];
             }else{
                 name = split[split.length - 1];

--- a/desktop/src/mindustry/desktop/DesktopLauncher.java
+++ b/desktop/src/mindustry/desktop/DesktopLauncher.java
@@ -193,7 +193,7 @@ public class DesktopLauncher extends ClientLauncher{
             });
 
             Core.app.post(() -> {
-                if(args.length >= 2 && args[0].equals("+connect_lobby")){
+                if(args.length >= 2 && "+connect_lobby".equals(args[0])){
                     try{
                         long id = Long.parseLong(args[1]);
                         ui.join.connect("steam:" + id, port);

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -1196,7 +1196,7 @@ public class ServerControl implements ApplicationListener{
                 }catch(BindException b){
                     err("Command input socket already in use. Is another instance of the server running?");
                 }catch(IOException e){
-                    if(!e.getMessage().equals("Socket closed") && !e.getMessage().equals("Connection reset")){
+                    if(!"Socket closed".equals(e.getMessage()) && !"Connection reset".equals(e.getMessage())){
                         err("Terminating socket server.");
                         err(e);
                     }


### PR DESCRIPTION
This change defensively switches the order of literals in comparison expressions to ensure that no null pointer exceptions are unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior. 

Both simple vulnerabilities (like information disclosure) and complex vulnerabilities (like business logic flaws) can take advantage of these unexpected code paths.

Our changes look something like this:

```diff
  String fieldName = header.getFieldName();
  String fieldValue = header.getFieldValue();
- if(fieldName.equals("requestId")) {
+ if("requestId".equals(fieldName)) {
    logRequest(fieldValue);
  }
```

<details>
  <summary>More reading</summary>

  * [https://cwe.mitre.org/data/definitions/476.html](https://cwe.mitre.org/data/definitions/476.html)
  * [https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException](https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException)
  * [https://rules.sonarsource.com/java/RSPEC-1132/](https://rules.sonarsource.com/java/RSPEC-1132/)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:java/switch-literal-first](https://docs.pixee.ai/codemods/java/pixee_java_switch-literal-first)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Java%2FMindustry-2%7Cef24e19f39ce4353e92df73b1466e203f89e8d58)

<!--{"type":"DRIP","codemod":"pixee:java/switch-literal-first"}-->
----------------------------------------------
- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
