### PR TITLE
Different distances for jump arrows

### DIFF
--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -856,6 +856,7 @@ public class LStatements{
         private static Color last = new Color();
 
         public transient StatementElem dest;
+        public transient JumpButton jumpButton;
 
         public int destIndex;
 
@@ -870,7 +871,7 @@ public class LStatements{
             table.table(this::rebuild);
 
             table.add().growX();
-            table.add(new JumpButton(() -> dest, s -> dest = s)).size(30).right().padLeft(-8);
+            table.add(jumpButton = new JumpButton(() -> dest, s -> dest = s)).size(30).right().padLeft(-8);
 
             String name = name();
 


### PR DESCRIPTION
Makes jump arrows go further out depending on other jump arrows being inside. (https://github.com/Anuken/Mindustry-Suggestions/issues/5000)

https://github.com/Anuken/Mindustry/assets/54301439/426981ea-a5e2-4d0a-ac81-ba7f843b2acb

Does not work properly yet and I don't know how to make it work properly.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
