### PR TITLE
World Sensors

### DIFF
--- a/core/src/mindustry/entities/comp/UnitComp.java
+++ b/core/src/mindustry/entities/comp/UnitComp.java
@@ -214,6 +214,8 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
             case ammoCapacity -> type.ammoCapacity;
             case x -> World.conv(x);
             case y -> World.conv(y);
+            case velocityX -> vel.x;
+            case velocityY -> vel.y;
             case dead -> dead || !isAdded() ? 1 : 0;
             case team -> team.id;
             case shooting -> isShooting() ? 1 : 0;

--- a/core/src/mindustry/logic/LAccess.java
+++ b/core/src/mindustry/logic/LAccess.java
@@ -17,6 +17,7 @@ public enum LAccess{
     powerNetOut,
     ammo,
     ammoCapacity,
+    currentAmmoType(true),
     health,
     maxHealth,
     heat,
@@ -28,6 +29,8 @@ public enum LAccess{
     rotation,
     x,
     y,
+    velocityX(true),
+    velocityY(true),
     shootX,
     shootY,
     cameraX,
@@ -61,22 +64,30 @@ public enum LAccess{
     color("to");
 
     public final String[] params;
-    public final boolean isObj;
+    public final boolean isObj, privileged;
 
     public static final LAccess[]
         all = values(),
-        senseable = Seq.select(all, t -> t.params.length <= 1).toArray(LAccess.class),
+        senseable = Seq.select(all, t -> t.params.length <= 1 && !t.privileged).toArray(LAccess.class),
+        privilegeSenseable = Seq.select(all, t -> t.params.length <= 1 && t.privileged).toArray(LAccess.class),
         controls = Seq.select(all, t -> t.params.length > 0).toArray(LAccess.class),
         settable = {x, y, rotation, speed, armor, health, shield, team, flag, totalPower, payloadType};
 
     LAccess(String... params){
         this.params = params;
         isObj = false;
+        this.privileged = false;
     }
 
     LAccess(boolean obj, String... params){
         this.params = params;
         isObj = obj;
+        this.privileged = false;
     }
 
+    LAccess(boolean privileged){
+        this.params = new String[0];
+        isObj = false;
+        this.privileged = privileged;
+    }
 }

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -2243,4 +2243,76 @@ public class LStatements{
             return LCategory.world;
         }
     }
+
+    @RegisterStatement("worldsensor")
+    public static class WorldSensorStatement extends LStatement{
+        public String to = "result";
+        public String from = "block1", type = "@currentAmmoType";
+
+        private transient TextField tfield;
+
+        @Override
+        public void build(Table table){
+            field(table, to, str -> to = str);
+
+            table.add(" = ");
+
+            row(table);
+
+            tfield = field(table, type, str -> type = str).padRight(0f).get();
+
+            table.button(b -> {
+                b.image(Icon.pencilSmall);
+                //240
+                b.clicked(() -> showSelectTable(b, (t, hide) -> {
+                    Table tab = new Table(i -> {
+                        for(LAccess sensor : LAccess.privilegeSenseable){
+                            i.button(sensor.name(), Styles.flatt, () -> {
+                                stype("@" + sensor.name());
+                                hide.run();
+                            }).size(240f, 40f).self(c -> tooltip(c, sensor)).row();
+                        }
+                    }); //sensors section only
+
+                    Stack stack = new Stack(tab);
+                    ButtonGroup<Button> group = new ButtonGroup<>();
+
+                    t.button(Icon.tree, Styles.squareTogglei, () -> {
+                        stack.clearChildren();
+                        stack.addChild(tab);
+
+                        t.parent.parent.pack();
+                        t.parent.parent.invalidateHierarchy();
+                    }).height(50f).growX().group(group);
+
+                    t.row();
+                    t.add(stack).colspan(3).width(240f).left();
+                }));
+            }, Styles.logict, () -> {}).size(40f).padLeft(-1).color(table.color);
+
+            table.add(" in ").self(this::param);
+
+            field(table, from, str -> from = str);
+        }
+
+        private void stype(String text){
+            tfield.setText(text);
+            this.type = text;
+        }
+
+        @Override
+        public boolean privileged() {
+            return true;
+        }
+
+        @Override
+        public LInstruction build(LAssembler builder) {
+            return new SenseI(builder.var(from), builder.var(to), builder.var(type));
+        }
+
+        @Override
+        public LCategory category() {
+            return LCategory.world;
+        }
+    }
 }

--- a/core/src/mindustry/world/blocks/defense/turrets/ContinuousLiquidTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/ContinuousLiquidTurret.java
@@ -4,6 +4,7 @@ import arc.struct.*;
 import mindustry.content.*;
 import mindustry.entities.bullet.*;
 import mindustry.gen.*;
+import mindustry.logic.LAccess;
 import mindustry.type.*;
 import mindustry.world.consumers.*;
 import mindustry.world.meta.*;
@@ -75,6 +76,14 @@ public class ContinuousLiquidTurret extends ContinuousTurret{
             unit.ammo(unit.type().ammoCapacity * liquids.currentAmount() / liquidCapacity);
 
             super.updateTile();
+        }
+
+        @Override
+        public Object senseObject(LAccess sensor) {
+            return switch(sensor){
+                case currentAmmoType -> liquids.current();
+                default -> super.senseObject(sensor);
+            };
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/defense/turrets/ItemTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/ItemTurret.java
@@ -11,6 +11,7 @@ import mindustry.entities.bullet.*;
 import mindustry.game.EventType.*;
 import mindustry.gen.*;
 import mindustry.graphics.*;
+import mindustry.logic.LAccess;
 import mindustry.type.*;
 import mindustry.ui.*;
 import mindustry.world.consumers.*;
@@ -105,6 +106,14 @@ public class ItemTurret extends Turret{
             if(!hasAmmo() && cheating() && ammoTypes.size > 0){
                 handleItem(this, ammoTypes.keys().next());
             }
+        }
+
+        @Override
+        public Object senseObject(LAccess sensor) {
+            return switch(sensor){
+                case currentAmmoType -> ammo.size > 0 ? ((ItemEntry)ammo.peek()).item : null;
+                default -> super.senseObject(sensor);
+            };
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/defense/turrets/LiquidTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/LiquidTurret.java
@@ -6,6 +6,7 @@ import mindustry.core.*;
 import mindustry.entities.*;
 import mindustry.entities.bullet.*;
 import mindustry.gen.*;
+import mindustry.logic.LAccess;
 import mindustry.type.*;
 import mindustry.world.*;
 import mindustry.world.consumers.*;
@@ -70,6 +71,14 @@ public class LiquidTurret extends Turret{
             unit.ammo(unit.type().ammoCapacity * liquids.currentAmount() / liquidCapacity);
 
             super.updateTile();
+        }
+
+        @Override
+        public Object senseObject(LAccess sensor) {
+            return switch(sensor){
+                case currentAmmoType -> liquids.current();
+                default -> super.senseObject(sensor);
+            };
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -294,7 +294,7 @@ public class Turret extends ReloadTurret{
 
         @Override
         public double sense(LAccess sensor) {
-            return switch (sensor) {
+            return switch(sensor){
                 case ammo -> totalAmmo;
                 case ammoCapacity -> maxAmmo;
                 case rotation -> rotation;

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -293,8 +293,8 @@ public class Turret extends ReloadTurret{
         }
 
         @Override
-        public double sense(LAccess sensor){
-            return switch(sensor){
+        public double sense(LAccess sensor) {
+            return switch (sensor) {
                 case ammo -> totalAmmo;
                 case ammoCapacity -> maxAmmo;
                 case rotation -> rotation;


### PR DESCRIPTION
Add some sensors getters that can only access through world processor because they have high chance to become overpower in regular processor, the names are self-explanatory
``@currentAmmoType``
``@velocityX``
``@velocityY``

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x]  I have ensured that my code compiles, if applicable.
- [x]  I have ensured that any new features in this PR function correctly in-game, if applicable.