### PR TITLE
Add destination tile to block `rotatedOutput`

### DIFF
--- a/core/src/mindustry/world/Block.java
+++ b/core/src/mindustry/world/Block.java
@@ -519,6 +519,10 @@ public class Block extends UnlockableContent implements Senseable{
         return rotate;
     }
 
+    public boolean rotatedOutput(int fromX, int fromY, Tile destination){
+        return rotatedOutput(fromX, fromY);
+    }
+
     public boolean synthetic(){
         return update || destructible;
     }

--- a/core/src/mindustry/world/blocks/Autotiler.java
+++ b/core/src/mindustry/world/blocks/Autotiler.java
@@ -206,7 +206,7 @@ public interface Autotiler{
             //block is facing the other
             Point2.equals(tile.x + Geometry.d4(rotation).x, tile.y + Geometry.d4(rotation).y, otherx, othery) ||
             //does not output to rotated direction
-            !otherblock.rotatedOutput(otherx, othery) ||
+            !otherblock.rotatedOutput(otherx, othery, tile) ||
             //other block is facing this one
             Point2.equals(otherx + Geometry.d4(otherrot).x, othery + Geometry.d4(otherrot).y, tile.x, tile.y);
     }

--- a/core/src/mindustry/world/blocks/production/GenericCrafter.java
+++ b/core/src/mindustry/world/blocks/production/GenericCrafter.java
@@ -13,6 +13,7 @@ import mindustry.gen.*;
 import mindustry.logic.*;
 import mindustry.type.*;
 import mindustry.world.*;
+import mindustry.world.blocks.liquid.Conduit.*;
 import mindustry.world.draw.*;
 import mindustry.world.meta.*;
 
@@ -91,8 +92,19 @@ public class GenericCrafter extends Block{
     }
 
     @Override
-    public boolean rotatedOutput(int x, int y){
-        return false;
+    public boolean rotatedOutput(int fromX, int fromY, Tile destination){
+        if(!(destination.build instanceof ConduitBuild)) return false;
+
+        Building crafter = world.build(fromX, fromY);
+        Log.info(crafter);
+        if(crafter == null) return false;
+        int relative = Mathf.mod(crafter.relativeTo(destination) - crafter.rotation, 4);
+        Log.info(relative);
+        for(int dir : liquidOutputDirections){
+            if(dir == -1 || dir == relative) return false;
+        }
+
+        return true;
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/production/GenericCrafter.java
+++ b/core/src/mindustry/world/blocks/production/GenericCrafter.java
@@ -96,10 +96,8 @@ public class GenericCrafter extends Block{
         if(!(destination.build instanceof ConduitBuild)) return false;
 
         Building crafter = world.build(fromX, fromY);
-        Log.info(crafter);
         if(crafter == null) return false;
         int relative = Mathf.mod(crafter.relativeTo(destination) - crafter.rotation, 4);
-        Log.info(relative);
         for(int dir : liquidOutputDirections){
             if(dir == -1 || dir == relative) return false;
         }


### PR DESCRIPTION
Output directions affecting conduit blending:

![image](https://github.com/Anuken/Mindustry/assets/54301439/0180f509-e1ee-4510-a493-a2348c254d66)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
