### PR TITLE
make planet params accessible outside the renderer

### DIFF
--- a/core/src/mindustry/ClientLauncher.java
+++ b/core/src/mindustry/ClientLauncher.java
@@ -218,6 +218,7 @@ public abstract class ClientLauncher extends ApplicationCore implements Platform
         if(!finished){
             if(loader != null){
                 loader.draw();
+                Events.fire(Trigger.loaderDraw);
             }
             if(assets.update(1000 / loadingFPS)){
                 loader.dispose();

--- a/core/src/mindustry/game/EventType.java
+++ b/core/src/mindustry/game/EventType.java
@@ -53,7 +53,8 @@ public class EventType{
         //skybox drawn and bloom is enabled - use Vars.renderer.planets
         universeDraw,
         //planets drawn and bloom disabled
-        universeDrawEnd
+        universeDrawEnd,
+        loaderDraw
     }
 
     public static class WinEvent{}

--- a/core/src/mindustry/graphics/g3d/PlanetRenderer.java
+++ b/core/src/mindustry/graphics/g3d/PlanetRenderer.java
@@ -36,6 +36,8 @@ public class PlanetRenderer implements Disposable{
     //seed: 8kmfuix03fw
     public final CubemapMesh skybox = new CubemapMesh(new Cubemap("cubemaps/stars/"));
 
+    public @Nullable PlanetParams mainParams;
+
     public PlanetRenderer(){
         projector.setScaling(1f / 150f);
         cam.fov = 60f;
@@ -44,6 +46,7 @@ public class PlanetRenderer implements Disposable{
 
     /** Render the entire planet scene to the screen. */
     public void render(PlanetParams params){
+        mainParams = params;
         Draw.flush();
         Gl.clear(Gl.depthBufferBit);
         Gl.enable(Gl.depthTest);

--- a/core/src/mindustry/mod/Mod.java
+++ b/core/src/mindustry/mod/Mod.java
@@ -26,6 +26,11 @@ public abstract class Mod{
 
     }
 
+    /** Called on clientside mods after loadContent(). Load content here. */
+    public void afterLoadContent(){
+
+    }
+
     /** Register any commands to be used on the server side, e.g. from the console. */
     public void registerServerCommands(CommandHandler handler){
 

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -704,6 +704,14 @@ public class Mods implements Loadable{
             }
         }
 
+        for(LoadedMod mod : orderedMods()){
+            //hidden mods can't load content
+            if(mod.main != null && !mod.meta.hidden){
+                content.setCurrentMod(mod);
+                mod.main.afterLoadContent();
+            }
+        }
+
         content.setCurrentMod(null);
 
         class LoadRun implements Comparable<LoadRun>{


### PR DESCRIPTION
if something draws when Trigger.universeDraw that requires planet params(like drawing an line between two planets needs drawUI) it can read the params in render()

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [√] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [√] I have ensured that my code compiles, if applicable.
- [√] I have ensured that any new features in this PR function correctly in-game, if applicable.
