### PR TITLE
Quad markers translation

### DIFF
--- a/core/src/mindustry/core/Renderer.java
+++ b/core/src/mindustry/core/Renderer.java
@@ -357,6 +357,7 @@ public class Renderer implements ApplicationListener{
         float scaleFactor = 4f / renderer.getDisplayScale();
 
         //draw objective markers
+        Tmp.m2.set(Draw.trans());
         state.rules.objectives.eachRunning(obj -> {
             for(var marker : obj.markers){
                 if(marker.world){
@@ -370,7 +371,7 @@ public class Renderer implements ApplicationListener{
                 marker.draw(marker.autoscale ? scaleFactor : 1);
             }
         }
-
+        Draw.trans(Tmp.m2);
         Draw.reset();
 
         Draw.draw(Layer.overlayUI, overlays::drawTop);


### PR DESCRIPTION
* Adds default x, y, u and v positions to quad markers
* Allows for quad markers to be translated using `setmarker pos`
* Allow for quad marker vertices to be rotated around the center position using `setmarker rotation`
* Adds `@Transform` for 2D matrices in the objectives dialog
* Replacement for #9738

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
