### PR TITLE
randomise same-playercount team assignment

### DIFF
--- a/core/src/mindustry/core/NetServer.java
+++ b/core/src/mindustry/core/NetServer.java
@@ -59,7 +59,7 @@ public class NetServer implements ApplicationListener{
                         count++;
                     }
                 }
-                return count;
+                return (float)count + Mathf.random(-0.1f, 0.1f); //if several have the same playercount pick random
             });
             return re == null ? null : re.team;
         }


### PR DESCRIPTION
if several teams in pvp have the same amount of players, choose out of those randomly instead of choosing the same team every time, so e.g. if you have a pvp map with 4 teams it will assign the first player to a random team and not sharded every time

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
