### PR TITLE
Added elapsed time counter

### DIFF
--- a/core/src/mindustry/core/Logic.java
+++ b/core/src/mindustry/core/Logic.java
@@ -30,9 +30,11 @@ import static mindustry.Vars.*;
  * This class should <i>not</i> call any outside methods to change state of modules, but instead fire events.
  */
 public class Logic implements ApplicationListener{
-
+    private long time = Time.nanos();
+    private long totalElapsedTime = 0;
+    private int frameCount = 0;
+    private boolean debug = false;
     public Logic(){
-
         Events.on(BlockDestroyEvent.class, event -> {
             //skip if rule is off
             if(!state.rules.ghostBlocks) return;
@@ -497,6 +499,21 @@ public class Logic implements ApplicationListener{
         }else if(netServer.isWaitingForPlayers() && runStateCheck){
             checkGameState();
         }
+        
+        long elapsedTime = Time.nanos() - time;
+        totalElapsedTime += elapsedTime;
+        if((elapsedTime >= 1000000000) && debug)
+        {
+            time = Time.nanos();
+            totalElapsedTime /= Time.nanosPerMilli;
+            if(frameCount > 0)
+                totalElapsedTime /= frameCount;
+            Log.log(Log.LogLevel.warn, "Average time elapsed per frame last second: " + totalElapsedTime);
+            totalElapsedTime = 0;
+            frameCount = 0;
+        }
+
+        frameCount += 1;
     }
 
     /** @return whether the wave timer is paused due to enemies */


### PR DESCRIPTION
With this update, a simple boolean-enabled elapsed time feature is added. All this does is show how much time elapses between every frame while updating it. This counter outputs that every second via logging to console. This update can and should be ignored, as it is only being done for a pull request. In that pull request, we are to detail said elapsed time as well as frame rate measured by running 3  relatively large-scale games.

I was tasked to benchmark Mindustry on games with thousands of blocks. I found three relatively large games with hundreds of nodes, potentially thousands. Each of these games were joined twice, and played for 10 minutes for accurate data. For the first map, on the first join, I got a frame rate of 20, and an elapsed time of 31830 milliseconds averaged over a minute. For the second join, it was 30 frames, with an elapsed time per frame of 32071 milliseconds averaged over a minute.

For the second map, on first join, the frame rate was 26, and its elapsed time was 26409 milliseconds. With respect to its second join, the frame rate was 19, and the elapsed time was 32806 milliseconds.

For the third and final map, after first joining it, I calculated a frame rate of 13 per second, and an elapsed time of 32269 milliseconds between frame update, averaged over a minute. After joining it a second time, the frame rate was 18, and the elapsed time was 26956 milliseconds per minute.

Per second, all of these maps and sessions had a minimum of 500 milliseconds between frames every second, and a maximum of 700 milliseconds between frames.

Again, as stated: this update can be ignored as it was only made for this pull request. I do plan on adding a separate interface that shows this information, which will be accessed via button or key press.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
