### PR TITLE
Logic jump UI enhancement

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -1226,6 +1226,7 @@ setting.playerchat.name = Display Player Bubble Chat
 setting.showweather.name = Show Weather Graphics
 setting.hidedisplays.name = Hide Logic Displays
 setting.dynamicjumpheights.name = Dynamic Jump Heights
+setting.coloredjumps.name = Colored Jumps
 setting.macnotch.name = Adapt interface to display notch
 setting.macnotch.description = Restart required to apply changes
 steam.friendsonly = Friends Only

--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -1225,6 +1225,7 @@ setting.bridgeopacity.name = Bridge Opacity
 setting.playerchat.name = Display Player Bubble Chat
 setting.showweather.name = Show Weather Graphics
 setting.hidedisplays.name = Hide Logic Displays
+setting.dynamicjumpheights.name = Dynamic Jump Heights
 setting.macnotch.name = Adapt interface to display notch
 setting.macnotch.description = Restart required to apply changes
 steam.friendsonly = Friends Only

--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -1227,6 +1227,7 @@ setting.showweather.name = Show Weather Graphics
 setting.hidedisplays.name = Hide Logic Displays
 setting.dynamicjumpheights.name = Dynamic Jump Heights
 setting.coloredjumps.name = Colored Jumps
+setting.trapezoidaljumps.name = Trapezoidal Jumps
 setting.macnotch.name = Adapt interface to display notch
 setting.macnotch.description = Restart required to apply changes
 steam.friendsonly = Friends Only

--- a/core/src/mindustry/logic/LCanvas.java
+++ b/core/src/mindustry/logic/LCanvas.java
@@ -26,6 +26,7 @@ public class LCanvas extends Table{
     //ew static variables
     static LCanvas canvas;
     private static boolean dynamicJumpHeights = false;
+    private static boolean coloredJumps = false;
 
     public DragLayout statements;
     public ScrollPane pane;
@@ -112,6 +113,7 @@ public class LCanvas extends Table{
         jumps = statements.jumps;
 
         dynamicJumpHeights = Core.settings.getBool("dynamicjumpheights", false);
+        coloredJumps = Core.settings.getBool("coloredjumps", false);
 
         pane = pane(t -> {
             t.center();
@@ -204,6 +206,7 @@ public class LCanvas extends Table{
         public Group jumps = new WidgetGroup();
         private Seq<JumpCurve> processedJumps = new Seq<JumpCurve>();
         public boolean updateJumpHeights = true;
+        private Rand rand = new Rand();
 
         {
             setTransform(true);
@@ -262,6 +265,16 @@ public class LCanvas extends Table{
             if(dynamicJumpHeights){
                 if(updateJumpHeights) setJumpHeights();
                 updateJumpHeights = false;
+            }
+
+            if(coloredJumps){
+                jumps.getChildren().each(e -> {
+                    if(!(e instanceof JumpCurve e2) || e2.button.to.get() == null) return;
+                    int idx = e2.button.to.get().index;
+                    if(dragging != null && idx >= dragging.index) idx += 1;
+                    rand.setSeed((long) idx);
+                    Color.HSVtoRGB(rand.random(0.0f, 360.0f), rand.random(80.0f, 90.0f), 100.0f, e2.button.defaultColor);
+                });
             }
 
             if(parent != null) parent.invalidateHierarchy();//don't invalid self
@@ -533,7 +546,7 @@ public class LCanvas extends Table{
 
     public static class JumpButton extends ImageButton{
         Color hoverColor = Pal.place;
-        Color defaultColor = Color.white;
+        Color defaultColor = new Color(Color.white);
         Prov<StatementElem> to;
         boolean selecting;
         float mx, my;
@@ -673,6 +686,7 @@ public class LCanvas extends Table{
         public void drawCurve(float x, float y, float x2, float y2){
             Lines.stroke(4f, button.color);
             Draw.alpha(parentAlpha);
+            Draw.color(button.color);
 
             // exponential smoothing
             uiHeight = Mathf.lerp(100f + 100f * (float) predHeight, uiHeight, dynamicJumpHeights ? Mathf.pow(0.9f, Time.delta) : 0);
@@ -698,6 +712,7 @@ public class LCanvas extends Table{
             x2 + uiHeight, y2,
             x2, y2,
             Math.max(18, (int)(Mathf.dst(x, y, x2, y2) / 6)));
+            Draw.reset();
         }
 
         public void prepareHeight(){

--- a/core/src/mindustry/logic/LCanvas.java
+++ b/core/src/mindustry/logic/LCanvas.java
@@ -26,7 +26,7 @@ public class LCanvas extends Table{
 
     public DragLayout statements;
     public ScrollPane pane;
-    public Group jumps;
+    public Group jumps; // compatibility
 
     StatementElem dragging;
     StatementElem hovered;
@@ -106,14 +106,14 @@ public class LCanvas extends Table{
         clear();
 
         statements = new DragLayout();
-        jumps = new WidgetGroup();
+        jumps = statements.jumps;
 
         pane = pane(t -> {
             t.center();
             t.add(statements).pad(2f).center().width(targetWidth);
-            t.addChild(jumps);
+            t.addChild(statements.jumps);
 
-            jumps.cullable = false;
+            statements.jumps.cullable = false;
         }).grow().get();
         pane.setFlickScroll(false);
         pane.setScrollYForce(s);
@@ -141,7 +141,7 @@ public class LCanvas extends Table{
     }
 
     public void load(String asm){
-        jumps.clear();
+        statements.jumps.clear();
 
         Seq<LStatement> statements = LAssembler.read(asm, privileged);
         statements.truncate(LExecutor.maxInstructions);
@@ -158,7 +158,7 @@ public class LCanvas extends Table{
     }
 
     public void clearStatements(){
-        jumps.clear();
+        statements.jumps.clear();
         statements.clearChildren();
         statements.layout();
     }
@@ -195,6 +195,7 @@ public class LCanvas extends Table{
         Seq<Element> seq = new Seq<>();
         int insertPosition = 0;
         boolean invalidated;
+        public Group jumps = new WidgetGroup();
 
         {
             setTransform(true);

--- a/core/src/mindustry/logic/LCanvas.java
+++ b/core/src/mindustry/logic/LCanvas.java
@@ -615,6 +615,8 @@ public class LCanvas extends Table{
         public boolean markedDone = false;
         public int jumpUIBegin = 0, jumpUIEnd = 0;
 
+        private float uiHeight = 100f;
+
         public JumpCurve(JumpButton button){
             this.button = button;
         }
@@ -672,7 +674,8 @@ public class LCanvas extends Table{
             Lines.stroke(4f, button.color);
             Draw.alpha(parentAlpha);
 
-            float dist = 100f + 100f * (float) predHeight;
+            // exponential smoothing
+            uiHeight = Mathf.lerp(100f + 100f * (float) predHeight, uiHeight, dynamicJumpHeights ? Mathf.pow(0.9f, Time.delta) : 0);
 
             //square jumps
             if(false){
@@ -691,8 +694,8 @@ public class LCanvas extends Table{
 
             Lines.curve(
             x, y,
-            x + dist, y,
-            x2 + dist, y2,
+            x + uiHeight, y,
+            x2 + uiHeight, y2,
             x2, y2,
             Math.max(18, (int)(Mathf.dst(x, y, x2, y2) / 6)));
         }

--- a/core/src/mindustry/logic/LCanvas.java
+++ b/core/src/mindustry/logic/LCanvas.java
@@ -159,6 +159,7 @@ public class LCanvas extends Table{
             st.setupUI();
         }
 
+        this.statements.updateJumpHeights = true;
         this.statements.layout();
     }
 
@@ -202,6 +203,7 @@ public class LCanvas extends Table{
         boolean invalidated;
         public Group jumps = new WidgetGroup();
         private Seq<JumpCurve> processedJumps = new Seq<JumpCurve>();
+        public boolean updateJumpHeights = true;
 
         {
             setTransform(true);
@@ -257,7 +259,10 @@ public class LCanvas extends Table{
                 }
             }
 
-            if(dynamicJumpHeights) setJumpHeights();
+            if(dynamicJumpHeights){
+                if(updateJumpHeights) setJumpHeights();
+                updateJumpHeights = false;
+            }
 
             if(parent != null) parent.invalidateHierarchy();//don't invalid self
 
@@ -394,6 +399,7 @@ public class LCanvas extends Table{
                 dragging = null;
             }
 
+            updateJumpHeights = true;
             layout();
         }
     }
@@ -430,6 +436,7 @@ public class LCanvas extends Table{
                 t.button(Icon.cancel, Styles.logici, () -> {
                     remove();
                     dragging = null;
+                    statements.updateJumpHeights = true;
                     statements.layout();
                 }).size(24f);
 
@@ -449,6 +456,7 @@ public class LCanvas extends Table{
                         lasty = v.y;
                         dragging = StatementElem.this;
                         toFront();
+                        statements.updateJumpHeights = true;
                         statements.layout();
                         return true;
                     }
@@ -506,6 +514,7 @@ public class LCanvas extends Table{
                 statements.layout();
                 copy.elem = s;
                 copy.setupUI();
+                statements.updateJumpHeights = true;
             }
         }
 
@@ -549,6 +558,7 @@ public class LCanvas extends Table{
                     setter.get(null);
                     mx = x;
                     my = y;
+                    canvas.statements.updateJumpHeights = true;
                     return true;
                 }
 
@@ -569,6 +579,7 @@ public class LCanvas extends Table{
                         setter.get(null);
                     }
                     selecting = false;
+                    canvas.statements.updateJumpHeights = true;
                 }
             });
 

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -870,7 +870,7 @@ public class LStatements{
             table.table(this::rebuild);
 
             table.add().growX();
-            table.add(new JumpButton(() -> dest, s -> dest = s)).size(30).right().padLeft(-8);
+            table.add(new JumpButton(() -> dest, s -> dest = s, this.elem)).size(30).right().padLeft(-8);
 
             String name = name();
 

--- a/core/src/mindustry/logic/LogicDialog.java
+++ b/core/src/mindustry/logic/LogicDialog.java
@@ -256,6 +256,8 @@ public class LogicDialog extends BaseDialog{
             dialog.addCloseButton();
             dialog.show();
         }).disabled(t -> canvas.statements.getChildren().size >= LExecutor.maxInstructions);
+        
+        Core.app.post(canvas::rebuild);
     }
 
     public void show(String code, LExecutor executor, boolean privileged, Cons<String> modified){

--- a/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
+++ b/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
@@ -505,6 +505,7 @@ public class SettingsMenuDialog extends BaseDialog{
 
         graphics.checkPref("dynamicjumpheights", true);
         graphics.checkPref("coloredjumps", true);
+        graphics.checkPref("trapezoidaljumps", true);
     }
 
     public void exportData(Fi file) throws IOException{

--- a/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
+++ b/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
@@ -504,6 +504,7 @@ public class SettingsMenuDialog extends BaseDialog{
         }
 
         graphics.checkPref("dynamicjumpheights", true);
+        graphics.checkPref("coloredjumps", true);
     }
 
     public void exportData(Fi file) throws IOException{

--- a/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
+++ b/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
@@ -502,6 +502,8 @@ public class SettingsMenuDialog extends BaseDialog{
         if(!mobile){
             Core.settings.put("swapdiagonal", false);
         }
+
+        graphics.checkPref("dynamicjumpheights", true);
     }
 
     public void exportData(Fi file) throws IOException{


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
    - [ ] I have formally proven that the methods used are valid.
    - [ ] I have ensured that this is a good enough implementation.

> [!WARNING]
> I often **reorder my commits** and **force push** to this branch, so be careful while pulling from it!

> [!NOTE]
> I am not that good in computer science.
> If anyone has a better method[^1], I'd recommend discussing it here, in [general-programming](https://discord.com/channels/391020510269669376/663854113418641429), or make a competing PR.
> I got the `not-in-#development` treatment, so I can't really access the #pulls channel right now.
> I'd love to hear your ideas!

[^1]: With both Dynamic Jump Heights and Trapezoidal Jumps, I'd estimate the complexity determining jump heights is about `O(k^2 + n)` where `k` is the number of unique end destinations and `n` the number of jump curves. 

# Overview

The goal of this PR is to [improve jump UI](https://github.com/Anuken/Mindustry-Suggestions/issues/5000).
As such, this competes with @MEEPofFaith's #9925 and Foo's Client's [implementation](https://github.com/mindustry-antigrief/mindustry-client/blob/v7/core/src/mindustry/logic/LCanvas.java#L173).

This PR adds in three features[^2]:
- **Dynamic Jump Heights**: Jump curves now adjust themselves to be more legible.
- **Colored Jumps**: Jump curves are colored based on their destination. (Contributed by @Ilya246)
- **Trapezoidal Jumps**: Jump curves now look trapezoidal to improve performance[^3] (Suggested by @Arkanic)

![image](https://github.com/user-attachments/assets/b9e1e31a-a536-41a1-a0a6-5c5aa2e395d6)

[^2]: I've decided that these three features belong in one PR because they complement each other.
    Still, I've made them configurable in separate settings anyway.

[^3]: It improves both graphical rendering of the jumps *and* the implementation of Dynamic Jump Heights.

# Tested feature combinations

| Dynamic Jump Heights | Colored Jumps      | Trapezoidal Jumps  | Result |
| -------------------- | ------------------ | ------------------ | ------ |
| :x:                  | :x:                | :x:                | :heavy_check_mark: Works as intended.[^4] |
| :x:                  | :x:                | :heavy_check_mark: | :x: Jumps merge. |
| :x:                  | :heavy_check_mark: | :x:                | :heavy_check_mark: Works as intended.[^4] |
| :x:                  | :heavy_check_mark: | :heavy_check_mark: | :x: Jumps merge. |
| :heavy_check_mark:   | :x:                | :x:                | :heavy_check_mark: Works as intended.[^4] |
| :heavy_check_mark:   | :x:                | :heavy_check_mark: | :heavy_check_mark: Works as intended. |
| :heavy_check_mark:   | :heavy_check_mark: | :x:                | :heavy_check_mark: Works as intended.[^4] |
| :heavy_check_mark:   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: Works as intended. |

I think fixing Trapezoidal Jumps and Colored + Trapezoidal Jumps implies reimplementing Dynamic Jump Heights in some form or another.
I don't think there's an alternative, but I could make Trapezoidal Jumps require Dynamic Jump Heights.

[^4]: Runs slower on logic with a lot of jumps.
    (I removed `maxJumpsDrawn`)