### PR TITLE
Adding Omega Network to Serverlist

### DIFF
--- a/servers_v7.json
+++ b/servers_v7.json
@@ -338,6 +338,6 @@
   },
   {
     "name": "Omega Network",
-    "address": ["93.115.10.226"]
+    "address": ["omegahub.my.to"]
   }
 ]

--- a/servers_v7.json
+++ b/servers_v7.json
@@ -1,5 +1,9 @@
 [
   {
+    "name": "EscoCorp",
+    "address": ["81.30.105.171:6567"]
+  },
+  {
     "name": "Redundancy Dept",
     "address": ["min7.include-once.org:8000", "min7.include-once.org:8001"]
   },
@@ -254,7 +258,7 @@
   },
   {
     "name": "Extra Utilities",
-    "address": ["p1.i9mr.com:44922", "p1.i9mr.com:44834", "p1.i9mr.com:43189", "203.135.99.189:15142", "203.135.99.189:15143", "203.135.99.190:15142", "203.135.99.190:15143"]
+    "address": ["p1.i9mr.com:44922", "p1.i9mr.com:44834", "p1.i9mr.com:43189", "203.135.99.65:15142", "203.135.99.65:15143", "203.135.99.71:15142", "203.135.99.71:15143"]
   },
   {
     "name": "Alex Multiverse",

--- a/servers_v7.json
+++ b/servers_v7.json
@@ -331,5 +331,9 @@
   {
     "name": "LibreDUSTRY",
     "address": ["46.4.114.111"]
+  },
+  {
+    "name": "Omega Network",
+    "address": ["93.115.10.226"]
   }
 ]

--- a/servers_v7.json
+++ b/servers_v7.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "EscoCorp",
-    "address": ["81.30.105.171:6567"]
+    "address": ["81.30.105.171:6567", "81.30.105.171:6568"]
   },
   {
     "name": "Redundancy Dept",
@@ -17,7 +17,7 @@
   },
   {
     "name": "gods field",
-    "address": ["n2.akiracloud.net:10225"]
+    "address": ["n2.akiracloud.net:10225","n2.akiracloud.net:10335"]
   },
   {
     "name": "STP",


### PR DESCRIPTION
Added 2r2t, this first server of OmegaHub or OmegaNetwork to the serverlist. It has been many months now since the server was removed. All of the other servers except the first ever one was scrapped in that time.

I wanted to be genuine when readding the server, so I have not changed the name or used an alt. Instead, none of the old staff or admins are assosiated with this new one, and the server is provided by "siyahpulsar", one of the Mindustry Turkey's co-owners. I want this to be a kind of fresh start and a server managed by the MindusTR community. 
