### PR TITLE
Allow conveyors/ducts to use duct/conveyor bridges

### DIFF
--- a/core/src/mindustry/input/Placement.java
+++ b/core/src/mindustry/input/Placement.java
@@ -129,10 +129,10 @@ public class Placement{
     }
 
     public static void calculateBridges(Seq<BuildPlan> plans, ItemBridge bridge){
-        calculateBridges(plans, bridge, t -> false);
+        calculateBridges(plans, bridge, false, t -> false);
     }
 
-    public static void calculateBridges(Seq<BuildPlan> plans, ItemBridge bridge, Boolf<Block> avoid){
+    public static void calculateBridges(Seq<BuildPlan> plans, ItemBridge bridge, boolean hasJunction, Boolf<Block> avoid){
         if(isSidePlace(plans) || plans.size == 0) return;
 
         //check for orthogonal placement + unlocked state
@@ -170,7 +170,7 @@ public class Placement{
                         continue outer;
                     }else if(placeable.get(other)){
 
-                        if(wereSame){
+                        if(wereSame && hasJunction){
                             //the gap is fake, it's just conveyors that can be replaced with junctions
                             i ++;
                             continue outer;

--- a/core/src/mindustry/world/blocks/distribution/Conveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/Conveyor.java
@@ -64,7 +64,7 @@ public class Conveyor extends Block implements Autotiler{
         super.init();
 
         if(junctionReplacement == null) junctionReplacement = Blocks.junction;
-        if(bridgeReplacement == null || !(bridgeReplacement instanceof ItemBridge)) bridgeReplacement = Blocks.itemBridge;
+        if(bridgeReplacement == null || !(bridgeReplacement instanceof ItemBridge || bridgeReplacement instanceof DuctBridge)) bridgeReplacement = Blocks.itemBridge;
     }
 
     @Override
@@ -92,8 +92,9 @@ public class Conveyor extends Block implements Autotiler{
     @Override
     public void handlePlacementLine(Seq<BuildPlan> plans){
         if(bridgeReplacement == null) return;
-
-        Placement.calculateBridges(plans, (ItemBridge)bridgeReplacement, b -> b instanceof Conveyor);
+        boolean hasJuntionReplacement = junctionReplacement != null;
+        if(bridgeReplacement instanceof DuctBridge) Placement.calculateBridges(plans, (DuctBridge)bridgeReplacement, hasJuntionReplacement, b -> b instanceof Duct || b instanceof Conveyor);
+        if(bridgeReplacement instanceof ItemBridge) Placement.calculateBridges(plans, (ItemBridge)bridgeReplacement, hasJuntionReplacement, b -> b instanceof Conveyor);
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/distribution/Conveyor.java
+++ b/core/src/mindustry/world/blocks/distribution/Conveyor.java
@@ -93,8 +93,8 @@ public class Conveyor extends Block implements Autotiler{
     public void handlePlacementLine(Seq<BuildPlan> plans){
         if(bridgeReplacement == null) return;
         boolean hasJuntionReplacement = junctionReplacement != null;
-        if(bridgeReplacement instanceof DuctBridge) Placement.calculateBridges(plans, (DuctBridge)bridgeReplacement, hasJuntionReplacement, b -> b instanceof Duct || b instanceof Conveyor);
-        if(bridgeReplacement instanceof ItemBridge) Placement.calculateBridges(plans, (ItemBridge)bridgeReplacement, hasJuntionReplacement, b -> b instanceof Conveyor);
+        if(bridgeReplacement instanceof DuctBridge bridge) Placement.calculateBridges(plans, bridge, hasJuntionReplacement, b -> b instanceof Duct || b instanceof Conveyor);
+        if(bridgeReplacement instanceof ItemBridge bridge) Placement.calculateBridges(plans, bridge, hasJuntionReplacement, b -> b instanceof Conveyor);
     }
 
     @Override

--- a/core/src/mindustry/world/blocks/distribution/Duct.java
+++ b/core/src/mindustry/world/blocks/distribution/Duct.java
@@ -106,8 +106,8 @@ public class Duct extends Block implements Autotiler{
     @Override
     public void handlePlacementLine(Seq<BuildPlan> plans){
         if(bridgeReplacement == null) return;
-        if(bridgeReplacement instanceof ItemBridge) Placement.calculateBridges(plans, (ItemBridge)bridgeReplacement, false, b -> b instanceof Duct || b instanceof StackConveyor || b instanceof Conveyor);
-        if(bridgeReplacement instanceof DuctBridge) Placement.calculateBridges(plans, (DuctBridge)bridgeReplacement, false, b -> b instanceof Duct || b instanceof StackConveyor || b instanceof Conveyor);
+        if(bridgeReplacement instanceof ItemBridge bridge) Placement.calculateBridges(plans, bridge, false, b -> b instanceof Duct || b instanceof StackConveyor || b instanceof Conveyor);
+        if(bridgeReplacement instanceof DuctBridge bridge) Placement.calculateBridges(plans, bridge, false, b -> b instanceof Duct || b instanceof StackConveyor || b instanceof Conveyor);
     }
 
     public class DuctBuild extends Building{

--- a/core/src/mindustry/world/blocks/distribution/Duct.java
+++ b/core/src/mindustry/world/blocks/distribution/Duct.java
@@ -62,7 +62,7 @@ public class Duct extends Block implements Autotiler{
     public void init(){
         super.init();
 
-        if(bridgeReplacement == null || !(bridgeReplacement instanceof DuctBridge)) bridgeReplacement = Blocks.ductBridge;
+        if(bridgeReplacement == null || !(bridgeReplacement instanceof DuctBridge || bridgeReplacement instanceof ItemBridge)) bridgeReplacement = Blocks.ductBridge;
     }
 
     @Override
@@ -106,8 +106,8 @@ public class Duct extends Block implements Autotiler{
     @Override
     public void handlePlacementLine(Seq<BuildPlan> plans){
         if(bridgeReplacement == null) return;
-
-        Placement.calculateBridges(plans, (DuctBridge)bridgeReplacement, false, b -> b instanceof Duct || b instanceof StackConveyor || b instanceof Conveyor);
+        if(bridgeReplacement instanceof ItemBridge) Placement.calculateBridges(plans, (ItemBridge)bridgeReplacement, false, b -> b instanceof Duct || b instanceof StackConveyor || b instanceof Conveyor);
+        if(bridgeReplacement instanceof DuctBridge) Placement.calculateBridges(plans, (DuctBridge)bridgeReplacement, false, b -> b instanceof Duct || b instanceof StackConveyor || b instanceof Conveyor);
     }
 
     public class DuctBuild extends Building{

--- a/core/src/mindustry/world/blocks/liquid/Conduit.java
+++ b/core/src/mindustry/world/blocks/liquid/Conduit.java
@@ -140,7 +140,7 @@ public class Conduit extends LiquidBlock implements Autotiler{
         if(rotBridgeReplacement instanceof DirectionBridge duct){
             Placement.calculateBridges(plans, duct, true, b -> b instanceof Conduit);
         }else{
-            Placement.calculateBridges(plans, (ItemBridge)bridgeReplacement, b -> b instanceof Conduit);
+            Placement.calculateBridges(plans, (ItemBridge)bridgeReplacement, true, b -> b instanceof Conduit);
         }
     }
 


### PR DESCRIPTION
Previously, when using duct bridges on conveyors (or vice versa) and placing them, they weren't automatically replaced by the correct bridges.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
