### PR TITLE
make shield field in database more clear

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -1047,6 +1047,7 @@ ability.liquidexplode.description = Spills liquid on death
 
 ability.stat.firingrate = [stat]{0}/sec[lightgray] firing rate
 ability.stat.regen = [stat]{0}[lightgray] health/sec
+ability.stat.pulseregen = [stat]{0}[lightgray] health/pulse
 ability.stat.shield = [stat]{0}[lightgray] shield
 ability.stat.repairspeed = [stat]{0}/sec[lightgray] repair speed
 ability.stat.slurpheal = [stat]{0}[lightgray] health/liquid unit

--- a/core/src/mindustry/entities/abilities/ShieldRegenFieldAbility.java
+++ b/core/src/mindustry/entities/abilities/ShieldRegenFieldAbility.java
@@ -34,6 +34,8 @@ public class ShieldRegenFieldAbility extends Ability{
         t.row();
         t.add(abilityStat("firingrate", Strings.autoFixed(60f / reload, 2)));
         t.row();
+        t.add(abilityStat("pulseregen", Strings.autoFixed(amount, 2)));
+        t.row();
         t.add(abilityStat("shield", Strings.autoFixed(max, 2)));
     }
 


### PR DESCRIPTION
currently ShieldRegenFieldAbility in core database is very misleading so this fixes that

![image](https://github.com/user-attachments/assets/200fc8be-54f8-4e31-bf6f-19968495bcfd)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
