### PR TITLE
Add direct reference (via singleton) to UI.java

### DIFF
--- a/core/src/mindustry/core/UI.java
+++ b/core/src/mindustry/core/UI.java
@@ -36,6 +36,7 @@ public class UI implements ApplicationListener, Loadable{
     public static String billions, millions, thousands;
 
     public static PixmapPacker packer;
+    protected static UI instance;
 
     public MenuFragment menufrag;
     public HudFragment hudfrag;
@@ -84,6 +85,7 @@ public class UI implements ApplicationListener, Loadable{
 
     public UI(){
         Fonts.loadFonts();
+        instance = this;
     }
 
     public static void loadColors(){
@@ -93,6 +95,10 @@ public class UI implements ApplicationListener, Loadable{
         Colors.put("stat", Pal.stat);
         Colors.put("negstat", Pal.negativeStat);
     }
+
+    public static UI getInstance(){
+        return instance;
+    }   
 
     @Override
     public void loadAsync(){


### PR DESCRIPTION
It's hard (afaik, impossible) to access UI from the mod-side.
I personally would like to get access to UI.hudfrag.coreItems to play with how items are represented, and I guess there will be a lot of peoples who will gladly explore this whole UI class.

Right now even with a usage of java.lang.instrument.Instrumentation I wasn't able to access any of the classes - I guess game doesn't supports this right now.

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
Compiles with ".\gradew jar" on Windows 10 just fine.

- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
