### PR TITLE
fix release link in bug_report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -68,7 +68,7 @@ body:
       label: Submission
       description: Check the boxes to confirm that you have read the lines below.
       options:
-        - label: I have updated to the latest release (https://github.com/Anuken/Mindustry/releases) to make sure my issue has not been fixed.
+        - label: I have updated to the latest release (https://github.com/Anuken/MindustryBuilds/releases) to make sure my issue has not been fixed.
           required: true
         - label: I have searched the closed and open issues to make sure that this problem has not already been reported.
           required: true


### PR DESCRIPTION
why is pointing to the stable release and not the BE one?

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
