### PR TITLE
Ability to disable fetching a list of community servers

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -1227,6 +1227,7 @@ setting.mutemusic.name = Mute Music
 setting.sfxvol.name = SFX Volume
 setting.mutesound.name = Mute Sound
 setting.crashreport.name = Send Anonymous Crash Reports
+setting.communityservers.name = Fetch Community Server List
 setting.savecreate.name = Auto-Create Saves
 setting.steampublichost.name = Public Game Visibility
 setting.playerlimit.name = Player Limit

--- a/core/assets/contributors
+++ b/core/assets/contributors
@@ -170,3 +170,4 @@ Mythril
 hexagon-recursion
 JasonP01
 BlueTheCube
+sasha0552

--- a/core/src/mindustry/ui/dialogs/JoinDialog.java
+++ b/core/src/mindustry/ui/dialogs/JoinDialog.java
@@ -635,6 +635,10 @@ public class JoinDialog extends BaseDialog{
             Core.settings.remove("server-list");
         }
 
+        fetchServers();
+    }
+
+    public static void fetchServers(){
         var urls = Version.type.equals("bleeding-edge") || Vars.forceBeServers ? serverJsonBeURLs : serverJsonURLs;
 
         if(Core.settings.getBool("communityservers", true)){
@@ -642,7 +646,7 @@ public class JoinDialog extends BaseDialog{
         }
     }
 
-    public static void fetchServers(String[] urls, int index){
+    private static void fetchServers(String[] urls, int index){
         if(index >= urls.length) return;
 
         //get servers

--- a/core/src/mindustry/ui/dialogs/JoinDialog.java
+++ b/core/src/mindustry/ui/dialogs/JoinDialog.java
@@ -138,7 +138,9 @@ public class JoinDialog extends BaseDialog{
 
         refreshLocal();
         refreshRemote();
-        refreshCommunity();
+        if(Core.settings.getBool("communityservers", true)){
+            refreshCommunity();
+        }
     }
 
     void setupRemote(){
@@ -317,7 +319,9 @@ public class JoinDialog extends BaseDialog{
 
         section(steam ? "@servers.local.steam" : "@servers.local", local, false);
         section("@servers.remote", remote, false);
-        section("@servers.global", global, true);
+        if(Core.settings.getBool("communityservers", true)){
+            section("@servers.global", global, true);
+        }
 
         ScrollPane pane = new ScrollPane(hosts);
         pane.setFadeScrollBars(false);
@@ -633,10 +637,12 @@ public class JoinDialog extends BaseDialog{
 
         var urls = Version.type.equals("bleeding-edge") || Vars.forceBeServers ? serverJsonBeURLs : serverJsonURLs;
 
-        fetchServers(urls, 0);
+        if(Core.settings.getBool("communityservers", true)){
+            fetchServers(urls, 0);
+        }
     }
 
-    private void fetchServers(String[] urls, int index){
+    public static void fetchServers(String[] urls, int index){
         if(index >= urls.length) return;
 
         //get servers

--- a/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
+++ b/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
@@ -336,8 +336,7 @@ public class SettingsMenuDialog extends BaseDialog{
         game.checkPref("communityservers", true, val -> {
             defaultServers.clear();
             if(val){
-                var urls = Version.type.equals("bleeding-edge") || forceBeServers ? serverJsonBeURLs : serverJsonURLs;
-                JoinDialog.fetchServers(urls, 0);
+                JoinDialog.fetchServers();
             }
         });
 

--- a/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
+++ b/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
@@ -333,6 +333,14 @@ public class SettingsMenuDialog extends BaseDialog{
             game.checkPref("crashreport", true);
         }
 
+        game.checkPref("communityservers", true, val -> {
+            defaultServers.clear();
+            if(val){
+                var urls = Version.type.equals("bleeding-edge") || forceBeServers ? serverJsonBeURLs : serverJsonURLs;
+                JoinDialog.fetchServers(urls, 0);
+            }
+        });
+
         game.checkPref("savecreate", true);
         game.checkPref("blockreplace", true);
         game.checkPref("conveyorpathfinding", true);


### PR DESCRIPTION
This PR adds a setting to disable fetching a list of community servers, due to the privacy issue of this feature (it sends a ping to third-party servers to get a description/etc, which reveals the user's ip to the server admin).

---

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
