### PR TITLE
Add afterLoadContent() method to Mod.java that called between all Mod.loadContent() called and ContentLoader.init()

### DIFF
--- a/core/src/mindustry/mod/Mod.java
+++ b/core/src/mindustry/mod/Mod.java
@@ -26,6 +26,11 @@ public abstract class Mod{
 
     }
 
+    /** Called after all contents has been loaded and before content initialization.*/
+    public void afterLoadContent(){
+
+    }
+
     /** Register any commands to be used on the server side, e.g. from the console. */
     public void registerServerCommands(CommandHandler handler){
 

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -705,6 +705,14 @@ public class Mods implements Loadable{
             }
         }
 
+        for(LoadedMod mod : orderedMods()){
+            //hidden mods can't load content
+            if(mod.main != null && !mod.meta.hidden){
+                content.setCurrentMod(mod);
+                mod.main.afterLoadContent();
+            }
+        }
+
         content.setCurrentMod(null);
 
         class LoadRun implements Comparable<LoadRun>{


### PR DESCRIPTION
it will be useful if you want to read other unspecified mod's content before ContentLoader.init()
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
