### PR TITLE
Team Color refactor for modding

### DIFF
--- a/core/src/mindustry/game/Team.java
+++ b/core/src/mindustry/game/Team.java
@@ -15,9 +15,9 @@ import static mindustry.Vars.*;
 
 public class Team implements Comparable<Team>{
     public final int id;
-    public Color color;
-    public Color[] palette;
-    public int[] palettei = new int[3];
+    public final Color color;
+    public final Color[] palette;
+    public final int[] palettei = new int[3];
     public String emoji = "";
     public boolean hasPalette;
     public String name;
@@ -64,6 +64,9 @@ public class Team implements Comparable<Team>{
         all[id] = this;
 
         palette = new Color[3];
+        palette[0] = color.cpy();
+        palette[1] = color.cpy().mul(0.75f);
+        palette[2] = color.cpy().mul(0.5f);
         
         setPalette(color);
     }
@@ -138,10 +141,10 @@ public class Team implements Comparable<Team>{
     }
     
     public void setPalette(Color pal1, Color pal2, Color pal3){
-        color = pal1;
-        palette[0] = pal1;
-        palette[1] = pal2;
-        palette[2] = pal3;
+        color.set(pal1);
+        palette[0].set(pal1);
+        palette[1].set(pal2);
+        palette[2].set(pal3);
         for(int i = 0; i < 3; i++){
             palettei[i] = palette[i].rgba();
         }

--- a/core/src/mindustry/game/Team.java
+++ b/core/src/mindustry/game/Team.java
@@ -65,7 +65,7 @@ public class Team implements Comparable<Team>{
 
         palette = new Color[3];
         
-		setPalette(color);
+        setPalette(color);
     }
 
     /** Specifies a 3-color team palette. */
@@ -131,22 +131,22 @@ public class Team implements Comparable<Team>{
     public String coloredName(){
         return emoji + "[#" + color + "]" + localized() + "[]";
     }
-	
-	public void setPalette(Color color){
-		setPalette(color, color.cpy().mul(0.75f), color.cpy().mul(0.5f)); 
-		hasPalette = false;
-	}
-	
-	public void setPalette(Color pal1, Color pal2, Color pal3){
-		color = pal1;
-		palette[0] = pal1;
+    
+    public void setPalette(Color color){
+        setPalette(color, color.cpy().mul(0.75f), color.cpy().mul(0.5f)); 
+        hasPalette = false;
+    }
+    
+    public void setPalette(Color pal1, Color pal2, Color pal3){
+        color = pal1;
+        palette[0] = pal1;
         palette[1] = pal2;
         palette[2] = pal3;
-		for(int i = 0; i < 3; i++){
+        for(int i = 0; i < 3; i++){
             palettei[i] = palette[i].rgba();
         }
-		hasPalette = true;
-	}
+        hasPalette = true;
+    }
 
     @Override
     public int compareTo(Team team){

--- a/core/src/mindustry/game/Team.java
+++ b/core/src/mindustry/game/Team.java
@@ -16,7 +16,7 @@ import static mindustry.Vars.*;
 public class Team implements Comparable<Team>{
     public final int id;
     public final Color color;
-    public final Color[] palette;
+    public final Color[] palette = new Color[3];;
     public final int[] palettei = new int[3];
     public String emoji = "";
     public boolean hasPalette;
@@ -63,7 +63,6 @@ public class Team implements Comparable<Team>{
         if(id < 6) baseTeams[id] = this;
         all[id] = this;
 
-        palette = new Color[3];
         palette[0] = color.cpy();
         palette[1] = color.cpy().mul(0.75f);
         palette[2] = color.cpy().mul(0.5f);

--- a/core/src/mindustry/game/Team.java
+++ b/core/src/mindustry/game/Team.java
@@ -15,9 +15,9 @@ import static mindustry.Vars.*;
 
 public class Team implements Comparable<Team>{
     public final int id;
-    public final Color color;
-    public final Color[] palette;
-    public final int[] palettei = new int[3];
+    public Color color;
+    public Color[] palette;
+    public int[] palettei = new int[3];
     public String emoji = "";
     public boolean hasPalette;
     public String name;
@@ -64,26 +64,15 @@ public class Team implements Comparable<Team>{
         all[id] = this;
 
         palette = new Color[3];
-        palette[0] = color;
-        palette[1] = color.cpy().mul(0.75f);
-        palette[2] = color.cpy().mul(0.5f);
-
-        for(int i = 0; i < 3; i++){
-            palettei[i] = palette[i].rgba();
-        }
+        
+		setPalette(color);
     }
 
     /** Specifies a 3-color team palette. */
     protected Team(int id, String name, Color color, Color pal1, Color pal2, Color pal3){
         this(id, name, color);
 
-        palette[0] = pal1;
-        palette[1] = pal2;
-        palette[2] = pal3;
-        for(int i = 0; i < 3; i++){
-            palettei[i] = palette[i].rgba();
-        }
-        hasPalette = true;
+        setPalette(pal1, pal2, pal3);
     }
 
     /** @return the core items for this team, or an empty item module.
@@ -142,6 +131,22 @@ public class Team implements Comparable<Team>{
     public String coloredName(){
         return emoji + "[#" + color + "]" + localized() + "[]";
     }
+	
+	public void setPalette(Color color){
+		setPalette(color, color.cpy().mul(0.75f), color.cpy().mul(0.5f)); 
+		hasPalette = false;
+	}
+	
+	public void setPalette(Color pal1, Color pal2, Color pal3){
+		color = pal1;
+		palette[0] = pal1;
+        palette[1] = pal2;
+        palette[2] = pal3;
+		for(int i = 0; i < 3; i++){
+            palettei[i] = palette[i].rgba();
+        }
+		hasPalette = true;
+	}
 
     @Override
     public int compareTo(Team team){

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -208,8 +208,7 @@ public class Mods implements Loadable{
             regionName = baseName.contains(".") ? baseName.substring(0, baseName.indexOf(".")) : baseName;
 
             if(!prefix && !Core.atlas.has(regionName)){
-                Log.warn("Sprite '@' in mod '@' attempts to override a non-existent sprite. Ignoring.", regionName, mod.name);
-                continue;
+                Log.warn("Sprite '@' in mod '@' attempts to override a non-existent sprite.", regionName, mod.name);
 
                 //(horrible code below)
             }


### PR DESCRIPTION
Implements setPalette() with two variants; either generating a palette from a single color (as the green & blue teams do), or filling one out from three manually provided colors.  This doesn't de-Finalize ``color``, ``palette``, or ``palettei`` as the setters still work.  This refactors the Team constructors to use setPalette as well to avoid code bloat.

This also allows overriding sprites that aren't in the atlas using sprite-overrides, though the warning has been left in to alert people to potential out-of-date mods.

This is realistically only going to matter to a small number of uber-nerds in the community by allowing team color editing in mods.  If there's a performant way to alter colors at runtime, that could be cool for scripted maps or similar, but I otherwise expect this to mostly be used for some simple recoloring mods/use in full conversions to freshen things up.

- [ X ] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ X ] I have ensured that my code compiles, if applicable.
- [ X ] I have ensured that any new features in this PR function correctly in-game, if applicable.

## Proof of testing (and basic mod source code)
```js
Team.all[0].setPalette(Color.valueOf("99aa77")); //derilect
Team.all[1].setPalette(Color.valueOf("aaff00")); //sharded
Team.all[2].setPalette(Color.valueOf("ffaa00")); //crux
Team.all[3].setPalette(Color.valueOf("aa00ff")); //malis
Team.all[4].setPalette(Color.valueOf("00ffaa")); //green
Team.all[5].setPalette(Color.valueOf("00aaff")); //blue
Team.all[6].setPalette(Color.valueOf("ff00aa")); //neoplastic
```
![image](https://github.com/user-attachments/assets/c61c9e0e-36db-4e2a-8bc6-bd3b58f4f33d)
![image](https://github.com/user-attachments/assets/35bd9b11-06c0-4b0b-9b8a-53f666f8b2db)

## TODO
Considering mods can auto-pack team regions using the same palette-based system that the base-game sprite packer can, I'm wondering about applying it to base-game sprites, but that goes a bit beyond the scope of this PR.