### PR TITLE
Percentage modifier stat for status effects

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -1151,6 +1151,7 @@ unit.minutes = mins
 unit.persecond = /sec
 unit.perminute = /min
 unit.timesspeed = x speed
+unit.multiplier = x
 unit.percent = %
 unit.shieldhealth = shield health
 unit.items = items

--- a/core/src/mindustry/type/StatusEffect.java
+++ b/core/src/mindustry/type/StatusEffect.java
@@ -90,11 +90,11 @@ public class StatusEffect extends UnlockableContent{
 
     @Override
     public void setStats(){
-        if(damageMultiplier != 1) stats.addPercent(Stat.damageMultiplier, damageMultiplier);
-        if(healthMultiplier != 1) stats.addPercent(Stat.healthMultiplier, healthMultiplier);
-        if(speedMultiplier != 1) stats.addPercent(Stat.speedMultiplier, speedMultiplier);
-        if(reloadMultiplier != 1) stats.addPercent(Stat.reloadMultiplier, reloadMultiplier);
-        if(buildSpeedMultiplier != 1) stats.addPercent(Stat.buildSpeedMultiplier, buildSpeedMultiplier);
+        if(damageMultiplier != 1) stats.addPercentModifier(Stat.damageMultiplier, damageMultiplier);
+        if(healthMultiplier != 1) stats.addPercentModifier(Stat.healthMultiplier, healthMultiplier);
+        if(speedMultiplier != 1) stats.addPercentModifier(Stat.speedMultiplier, speedMultiplier);
+        if(reloadMultiplier != 1) stats.addPercentModifier(Stat.reloadMultiplier, reloadMultiplier);
+        if(buildSpeedMultiplier != 1) stats.addPercentModifier(Stat.buildSpeedMultiplier, buildSpeedMultiplier);
         if(damage > 0) stats.add(Stat.damage, damage * 60f, StatUnit.perSecond);
         if(damage < 0) stats.add(Stat.healing, -damage * 60f, StatUnit.perSecond);
 

--- a/core/src/mindustry/type/StatusEffect.java
+++ b/core/src/mindustry/type/StatusEffect.java
@@ -90,11 +90,11 @@ public class StatusEffect extends UnlockableContent{
 
     @Override
     public void setStats(){
-        if(damageMultiplier != 1) stats.addPercentModifier(Stat.damageMultiplier, damageMultiplier);
-        if(healthMultiplier != 1) stats.addPercentModifier(Stat.healthMultiplier, healthMultiplier);
-        if(speedMultiplier != 1) stats.addPercentModifier(Stat.speedMultiplier, speedMultiplier);
-        if(reloadMultiplier != 1) stats.addPercentModifier(Stat.reloadMultiplier, reloadMultiplier);
-        if(buildSpeedMultiplier != 1) stats.addPercentModifier(Stat.buildSpeedMultiplier, buildSpeedMultiplier);
+        if(damageMultiplier != 1) stats.addMultModifier(Stat.damageMultiplier, damageMultiplier);
+        if(healthMultiplier != 1) stats.addMultModifier(Stat.healthMultiplier, healthMultiplier);
+        if(speedMultiplier != 1) stats.addMultModifier(Stat.speedMultiplier, speedMultiplier);
+        if(reloadMultiplier != 1) stats.addMultModifier(Stat.reloadMultiplier, reloadMultiplier);
+        if(buildSpeedMultiplier != 1) stats.addMultModifier(Stat.buildSpeedMultiplier, buildSpeedMultiplier);
         if(damage > 0) stats.add(Stat.damage, damage * 60f, StatUnit.perSecond);
         if(damage < 0) stats.add(Stat.healing, -damage * 60f, StatUnit.perSecond);
 

--- a/core/src/mindustry/world/meta/StatUnit.java
+++ b/core/src/mindustry/world/meta/StatUnit.java
@@ -29,6 +29,7 @@ public class StatUnit{
     perMinute = new StatUnit("perMinute", false),
     perShot = new StatUnit("perShot", false),
     timesSpeed = new StatUnit("timesSpeed", false),
+    multiplier = new StatUnit("multiplier", false),
     percent = new StatUnit("percent", false),
     shieldHealth = new StatUnit("shieldHealth"),
     none = new StatUnit("none"),

--- a/core/src/mindustry/world/meta/StatValues.java
+++ b/core/src/mindustry/world/meta/StatValues.java
@@ -69,6 +69,23 @@ public class StatValues{
         return number(value, unit, false);
     }
 
+    public static StatValue percentModifier(float value, StatUnit unit, boolean merge){
+        return table -> {
+            String l1 = (unit.icon == null ? "" : unit.icon + " ") + ammoStat((value - 1) * 100), l2 = (unit.space ? " " : "") + unit.localized();
+
+            if(merge){
+                table.add(l1 + l2).left();
+            }else{
+                table.add(l1).left();
+                table.add(l2).left();
+            }
+        };
+    }
+
+    public static StatValue percentModifier(float value, StatUnit unit){
+        return percentModifier(value, unit, false);
+    }
+
     public static StatValue liquid(Liquid liquid, float amount, boolean perSecond){
         return table -> table.add(displayLiquid(liquid, amount, perSecond));
     }

--- a/core/src/mindustry/world/meta/StatValues.java
+++ b/core/src/mindustry/world/meta/StatValues.java
@@ -69,6 +69,27 @@ public class StatValues{
         return number(value, unit, false);
     }
 
+    public static StatValue multiplierModifier(float value, StatUnit unit, boolean merge){
+        return table -> {
+            String l1 = (unit.icon == null ? "" : unit.icon + " ") + multStat(value), l2 = (unit.space ? " " : "") + unit.localized();
+
+            if(merge){
+                table.add(l1 + l2).left();
+            }else{
+                table.add(l1).left();
+                table.add(l2).left();
+            }
+        };
+    }
+
+    public static StatValue multiplierModifier(float value, StatUnit unit){
+        return multiplierModifier(value, unit, true);
+    }
+
+    public static StatValue multiplierModifier(float value){
+        return multiplierModifier(value, StatUnit.multiplier);
+    }
+
     public static StatValue percentModifier(float value, StatUnit unit, boolean merge){
         return table -> {
             String l1 = (unit.icon == null ? "" : unit.icon + " ") + ammoStat((value - 1) * 100), l2 = (unit.space ? " " : "") + unit.localized();
@@ -84,6 +105,10 @@ public class StatValues{
 
     public static StatValue percentModifier(float value, StatUnit unit){
         return percentModifier(value, unit, true);
+    }
+
+    public static StatValue percentModifier(float value){
+        return percentModifier(value, StatUnit.percent);
     }
 
     public static StatValue liquid(Liquid liquid, float amount, boolean perSecond){
@@ -698,6 +723,10 @@ public class StatValues{
     //for AmmoListValue
     private static String ammoStat(float val){
         return (val > 0 ? "[stat]+" : "[negstat]") + Strings.autoFixed(val, 1);
+    }
+
+    private static String multStat(float val){
+        return (val >= 1 ? "[stat]" : "[negstat]") + Strings.autoFixed(val, 2);
     }
 
     private static TextureRegion icon(UnlockableContent t){

--- a/core/src/mindustry/world/meta/StatValues.java
+++ b/core/src/mindustry/world/meta/StatValues.java
@@ -83,7 +83,7 @@ public class StatValues{
     }
 
     public static StatValue percentModifier(float value, StatUnit unit){
-        return percentModifier(value, unit, false);
+        return percentModifier(value, unit, true);
     }
 
     public static StatValue liquid(Liquid liquid, float amount, boolean perSecond){

--- a/core/src/mindustry/world/meta/Stats.java
+++ b/core/src/mindustry/world/meta/Stats.java
@@ -32,9 +32,14 @@ public class Stats{
         add(stat, StatValues.number((int)(value * 100), StatUnit.percent));
     }
 
+    /** Adds a multiplicative modifier stat value. Value is assumed to be in the 0-1 range. */
+    public void addMultModifier(Stat stat, float value){
+        add(stat, StatValues.multiplierModifier(value));
+    }
+
     /** Adds an percent modifier stat value. Value is assumed to be in the 0-1 range. */
     public void addPercentModifier(Stat stat, float value){
-        add(stat, StatValues.percentModifier(value, StatUnit.percent));
+        add(stat, StatValues.percentModifier(value));
     }
 
     /** Adds a single y/n boolean value. */

--- a/core/src/mindustry/world/meta/Stats.java
+++ b/core/src/mindustry/world/meta/Stats.java
@@ -32,6 +32,11 @@ public class Stats{
         add(stat, StatValues.number((int)(value * 100), StatUnit.percent));
     }
 
+    /** Adds an percent modifier stat value. Value is assumed to be in the 0-1 range. */
+    public void addPercentModifier(Stat stat, float value){
+        add(stat, StatValues.percentModifier(value, StatUnit.percent));
+    }
+
     /** Adds a single y/n boolean value. */
     public void add(Stat stat, boolean value){
         add(stat, StatValues.bool(value));


### PR DESCRIPTION
Before:
<img width="236" alt="20241030-201229-Mindustry" src="https://github.com/user-attachments/assets/d2098a66-b282-404d-89c3-be07a2e9ae79">

After:
<img width="155" alt="20241030-202150-java" src="https://github.com/user-attachments/assets/70497c35-6bfe-4fe7-ad13-f513cce04beb">
(Did the default UI scale change at some point? 75% scale in the custom build is much smaller than 75% scale in 146.)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
