### PR TITLE
Allow Chained Doors To Spawn Effects When Opened (Or Closed)

### DIFF
--- a/core/src/mindustry/world/blocks/defense/Door.java
+++ b/core/src/mindustry/world/blocks/defense/Door.java
@@ -26,6 +26,7 @@ public class Door extends Wall{
     public Effect openfx = Fx.dooropen;
     public Effect closefx = Fx.doorclose;
     public Sound doorSound = Sounds.door;
+    public boolean chainEffect = false;
     public @Load("@-open") TextureRegion openRegion;
 
     public Door(String name){
@@ -44,6 +45,7 @@ public class Door extends Wall{
                     continue;
                 }
 
+                if(chainEffect) entity.effect();
                 entity.open = open;
                 pathfinder.updateTile(entity.tile());
             }


### PR DESCRIPTION
Doors opened through chains don't spawn effects, probably for the reason of lag, but I wanted to PR this because mods.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
