### PR TITLE
Unit Mine Speed Game Rule Implementation and World Processor Set Rule for Unit Mine Speed

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -1393,6 +1393,7 @@ rules.unitcostmultiplier = Unit Cost Multiplier
 rules.unithealthmultiplier = Unit Health Multiplier
 rules.unitdamagemultiplier = Unit Damage Multiplier
 rules.unitcrashdamagemultiplier = Unit Crash Damage Multiplier
+rules.unitminespeedmultiplier = Unit Mine Speed Multiplier
 rules.solarmultiplier = Solar Power Multiplier
 rules.unitcapvariable = Cores Contribute To Unit Cap
 rules.unitpayloadsexplode = Carried Payloads Explode With The Unit

--- a/core/src/mindustry/entities/comp/MinerComp.java
+++ b/core/src/mindustry/entities/comp/MinerComp.java
@@ -65,7 +65,7 @@ abstract class MinerComp implements Itemsc, Posc, Teamc, Rotc, Drawc{
     }
 
     public boolean canMine(){
-        return type.mineSpeed > 0 && type.mineTier >= 0;
+        return type.mineSpeed * state.rules.unitMineSpeed(team()) > 0 && type.mineTier >= 0;
     }
 
     @Override
@@ -89,7 +89,7 @@ abstract class MinerComp implements Itemsc, Posc, Teamc, Rotc, Drawc{
             mineTile = null;
             mineTimer = 0f;
         }else if(mining() && item != null){
-            mineTimer += Time.delta * type.mineSpeed;
+            mineTimer += Time.delta * type.mineSpeed * state.rules.unitMineSpeed(team());
 
             if(Mathf.chance(0.06 * Time.delta)){
                 Fx.pulverizeSmall.at(mineTile.worldx() + Mathf.range(tilesize / 2f), mineTile.worldy() + Mathf.range(tilesize / 2f), 0f, item.color);

--- a/core/src/mindustry/game/Rules.java
+++ b/core/src/mindustry/game/Rules.java
@@ -84,6 +84,8 @@ public class Rules{
     public float unitHealthMultiplier = 1f;
     /** How much damage unit crash damage deals. (Compounds with unitDamageMultiplier) */
     public float unitCrashDamageMultiplier = 1f;
+    /** How fast units can mine. */
+    public float unitMineSpeedMultiplier = 1f;
     /** If true, ghost blocks will appear upon destruction, letting builder blocks/units rebuild them. */
     public boolean ghostBlocks = true;
     /** Whether to allow units to build with logic. */
@@ -262,6 +264,10 @@ public class Rules{
         return unitDamage(team) * unitCrashDamageMultiplier * teams.get(team).unitCrashDamageMultiplier;
     }
 
+    public float unitMineSpeed(Team team){
+        return unitMineSpeedMultiplier * teams.get(team).unitMineSpeedMultiplier;
+    }
+
     public float blockHealth(Team team){
         return blockHealthMultiplier * teams.get(team).blockHealthMultiplier;
     }
@@ -312,6 +318,8 @@ public class Rules{
         public float unitDamageMultiplier = 1f;
         /** How much damage unit crash damage deals. (Compounds with unitDamageMultiplier) */
         public float unitCrashDamageMultiplier = 1f;
+        /** How fast units can mine. */
+        public float unitMineSpeedMultiplier = 1f;
         /** Multiplier of resources that units take to build. */
         public float unitCostMultiplier = 1f;
         /** How much health units start with. */

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -1515,7 +1515,7 @@ public class LExecutor{
                         state.rules.bannedUnits.remove(u);
                     }
                 }
-                case unitHealth, unitBuildSpeed, unitMineSpeed, unitCost, unitDamage, blockHealth, blockDamage, buildSpeed, rtsMinSquad, rtsMinWeight -> {
+                case unitHealth, unitBuildSpeed, unitCrashDamage, unitMineSpeed, unitCost, unitDamage, blockHealth, blockDamage, buildSpeed, rtsMinSquad, rtsMinWeight -> {
                     Team team = p1.team();
                     if(team != null){
                         float num = value.numf();
@@ -1523,6 +1523,7 @@ public class LExecutor{
                             case buildSpeed -> team.rules().buildSpeedMultiplier = Mathf.clamp(num, 0.001f, 50f);
                             case unitHealth -> team.rules().unitHealthMultiplier = Math.max(num, 0.001f);
                             case unitBuildSpeed -> team.rules().unitBuildSpeedMultiplier = Mathf.clamp(num, 0f, 50f);
+                            case unitCrashDamage -> team.rules().unitCrashDamageMultiplier = Math.max(num, 0f);
                             case unitMineSpeed -> team.rules().unitMineSpeedMultiplier = Math.max(num, 0f);
                             case unitCost -> team.rules().unitCostMultiplier = Math.max(num, 0f);
                             case unitDamage -> team.rules().unitDamageMultiplier = Math.max(num, 0f);

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -1515,7 +1515,7 @@ public class LExecutor{
                         state.rules.bannedUnits.remove(u);
                     }
                 }
-                case unitHealth, unitBuildSpeed, unitCost, unitDamage, blockHealth, blockDamage, buildSpeed, rtsMinSquad, rtsMinWeight -> {
+                case unitHealth, unitBuildSpeed, unitMineSpeed, unitCost, unitDamage, blockHealth, blockDamage, buildSpeed, rtsMinSquad, rtsMinWeight -> {
                     Team team = p1.team();
                     if(team != null){
                         float num = value.numf();
@@ -1523,6 +1523,7 @@ public class LExecutor{
                             case buildSpeed -> team.rules().buildSpeedMultiplier = Mathf.clamp(num, 0.001f, 50f);
                             case unitHealth -> team.rules().unitHealthMultiplier = Math.max(num, 0.001f);
                             case unitBuildSpeed -> team.rules().unitBuildSpeedMultiplier = Mathf.clamp(num, 0f, 50f);
+                            case unitMineSpeed -> team.rules().unitMineSpeedMultiplier = Math.max(num, 0f);
                             case unitCost -> team.rules().unitCostMultiplier = Math.max(num, 0f);
                             case unitDamage -> team.rules().unitDamageMultiplier = Math.max(num, 0f);
                             case blockHealth -> team.rules().blockHealthMultiplier = Math.max(num, 0.001f);

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -1515,7 +1515,7 @@ public class LExecutor{
                         state.rules.bannedUnits.remove(u);
                     }
                 }
-                case unitHealth, unitBuildSpeed, unitCrashDamage, unitMineSpeed, unitCost, unitDamage, blockHealth, blockDamage, buildSpeed, rtsMinSquad, rtsMinWeight -> {
+                case unitHealth, unitBuildSpeed, unitMineSpeed, unitCost, unitDamage, blockHealth, blockDamage, buildSpeed, rtsMinSquad, rtsMinWeight -> {
                     Team team = p1.team();
                     if(team != null){
                         float num = value.numf();
@@ -1523,7 +1523,6 @@ public class LExecutor{
                             case buildSpeed -> team.rules().buildSpeedMultiplier = Mathf.clamp(num, 0.001f, 50f);
                             case unitHealth -> team.rules().unitHealthMultiplier = Math.max(num, 0.001f);
                             case unitBuildSpeed -> team.rules().unitBuildSpeedMultiplier = Mathf.clamp(num, 0f, 50f);
-                            case unitCrashDamage -> team.rules().unitCrashDamageMultiplier = Math.max(num, 0f);
                             case unitMineSpeed -> team.rules().unitMineSpeedMultiplier = Math.max(num, 0f);
                             case unitCost -> team.rules().unitCostMultiplier = Math.max(num, 0f);
                             case unitDamage -> team.rules().unitDamageMultiplier = Math.max(num, 0f);

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -1552,7 +1552,7 @@ public class LStatements{
                     fields(table, "w", p3, s -> p3 = s);
                     fields(table, "h", p4, s -> p4 = s);
                 }
-                case buildSpeed, unitHealth, unitBuildSpeed, unitMineSpeed, unitCost, unitDamage, blockHealth, blockDamage, rtsMinSquad, rtsMinWeight -> {
+                case buildSpeed, unitHealth, unitBuildSpeed, unitCrashDamage, unitMineSpeed, unitCost, unitDamage, blockHealth, blockDamage, rtsMinSquad, rtsMinWeight -> {
                     if(p1.equals("0")){
                         p1 = "@sharded";
                     }

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -1552,7 +1552,7 @@ public class LStatements{
                     fields(table, "w", p3, s -> p3 = s);
                     fields(table, "h", p4, s -> p4 = s);
                 }
-                case buildSpeed, unitHealth, unitBuildSpeed, unitCrashDamage, unitMineSpeed, unitCost, unitDamage, blockHealth, blockDamage, rtsMinSquad, rtsMinWeight -> {
+                case buildSpeed, unitHealth, unitBuildSpeed, unitMineSpeed, unitCost, unitDamage, blockHealth, blockDamage, rtsMinSquad, rtsMinWeight -> {
                     if(p1.equals("0")){
                         p1 = "@sharded";
                     }

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -1552,7 +1552,7 @@ public class LStatements{
                     fields(table, "w", p3, s -> p3 = s);
                     fields(table, "h", p4, s -> p4 = s);
                 }
-                case buildSpeed, unitHealth, unitBuildSpeed, unitCost, unitDamage, blockHealth, blockDamage, rtsMinSquad, rtsMinWeight -> {
+                case buildSpeed, unitHealth, unitBuildSpeed, unitMineSpeed, unitCost, unitDamage, blockHealth, blockDamage, rtsMinSquad, rtsMinWeight -> {
                     if(p1.equals("0")){
                         p1 = "@sharded";
                     }

--- a/core/src/mindustry/logic/LogicRule.java
+++ b/core/src/mindustry/logic/LogicRule.java
@@ -23,6 +23,7 @@ public enum LogicRule{
     buildSpeed,
     unitHealth,
     unitBuildSpeed,
+    unitMineSpeed,
     unitCost,
     unitDamage,
     blockHealth,

--- a/core/src/mindustry/logic/LogicRule.java
+++ b/core/src/mindustry/logic/LogicRule.java
@@ -23,7 +23,6 @@ public enum LogicRule{
     buildSpeed,
     unitHealth,
     unitBuildSpeed,
-    unitCrashDamage,
     unitMineSpeed,
     unitCost,
     unitDamage,

--- a/core/src/mindustry/logic/LogicRule.java
+++ b/core/src/mindustry/logic/LogicRule.java
@@ -23,6 +23,7 @@ public enum LogicRule{
     buildSpeed,
     unitHealth,
     unitBuildSpeed,
+    unitCrashDamage,
     unitMineSpeed,
     unitCost,
     unitDamage,

--- a/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
+++ b/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
@@ -384,6 +384,7 @@ public class CustomRulesDialog extends BaseDialog{
 
                 number("@rules.unitdamagemultiplier", f -> teams.unitDamageMultiplier = f, () -> teams.unitDamageMultiplier);
                 number("@rules.unitcrashdamagemultiplier", f -> teams.unitCrashDamageMultiplier = f, () -> teams.unitCrashDamageMultiplier);
+                number("@rules.unitminespeedmultiplier", f -> teams.unitMineSpeedMultiplier = f, () -> teams.unitMineSpeedMultiplier);
                 number("@rules.unitbuildspeedmultiplier", f -> teams.unitBuildSpeedMultiplier = f, () -> teams.unitBuildSpeedMultiplier, 0.001f, 50f);
                 number("@rules.unitcostmultiplier", f -> teams.unitCostMultiplier = f, () -> teams.unitCostMultiplier);
                 number("@rules.unithealthmultiplier", f -> teams.unitHealthMultiplier = f, () -> teams.unitHealthMultiplier);

--- a/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
+++ b/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
@@ -265,6 +265,7 @@ public class CustomRulesDialog extends BaseDialog{
         numberi("@rules.unitcap", f -> rules.unitCap = f, () -> rules.unitCap, -999, 999);
         number("@rules.unitdamagemultiplier", f -> rules.unitDamageMultiplier = f, () -> rules.unitDamageMultiplier);
         number("@rules.unitcrashdamagemultiplier", f -> rules.unitCrashDamageMultiplier = f, () -> rules.unitCrashDamageMultiplier);
+        number("@rules.unitminespeedmultiplier", f -> rules.unitMineSpeedMultiplier = f, () -> rules.unitMineSpeedMultiplier);
         number("@rules.unitbuildspeedmultiplier", f -> rules.unitBuildSpeedMultiplier = f, () -> rules.unitBuildSpeedMultiplier, 0f, 50f);
         number("@rules.unitcostmultiplier", f -> rules.unitCostMultiplier = f, () -> rules.unitCostMultiplier);
         number("@rules.unithealthmultiplier", f -> rules.unitHealthMultiplier = f, () -> rules.unitHealthMultiplier);


### PR DESCRIPTION
### Implmentation
Implements https://github.com/Anuken/Mindustry-Suggestions/issues/5305

### Details
- [x] Implemented the main game rule itself

https://github.com/user-attachments/assets/ee2e68b4-8214-433f-b2a0-26f987e4794f

https://github.com/user-attachments/assets/236f11d1-9c49-460a-af62-e4a9b1b54408

- [x] World Processor being able to adjust it

https://github.com/user-attachments/assets/6f2bd796-57ee-4bb8-9ce4-06584f38e49c

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
