### PR TITLE
Fix NPE when payloadDraw `air`

### DIFF
--- a/core/src/mindustry/entities/comp/BuildingComp.java
+++ b/core/src/mindustry/entities/comp/BuildingComp.java
@@ -1217,6 +1217,7 @@ abstract class BuildingComp implements Posc, Teamc, Healthc, Buildingc, Timerc, 
     }
 
     public void payloadDraw(){
+        if(block.isAir()) return;
         draw();
     }
 


### PR DESCRIPTION
One NPE exception via specially constructed maps: `BuildPayload.draw` NPE with `Blocks.air`, as `Blocks.air` is the only block not invoking `Block.load`
BuildPayload.draw -> Building.draw -> block.region is null.

---
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
