### PR TITLE
Add JVM argument for data directory

### DIFF
--- a/core/src/mindustry/ClientLauncher.java
+++ b/core/src/mindustry/ClientLauncher.java
@@ -35,7 +35,7 @@ public abstract class ClientLauncher extends ApplicationCore implements Platform
 
     @Override
     public void setup(){
-        String dataDir = OS.env("MINDUSTRY_DATA_DIR");
+        String dataDir = System.getProperty("mindustry.data.dir", OS.env("MINDUSTRY_DATA_DIR"));
         if(dataDir != null){
             Core.settings.setDataDirectory(files.absolute(dataDir));
         }


### PR DESCRIPTION
- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

This PR introduces a JVM argument (-Dmindustry.data.dir) to specify the data directory, reducing the dependency on the environment variable (MINDUSTRY_DATA_DIR). If the JVM argument is not provided, the fallback is still to use the environment variable. This simplifies configuration by allowing direct use of JVM arguments.

```sh
java -Dmindustry.data.dir=/your/custom/data/dir -jar desktop.jar
```
