### PR TITLE
Properly rounding numbers for display

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -966,8 +966,8 @@ public class LExecutor{
                 exec.textBuffer.append(strValue);
             }else{
                 //display integer version when possible
-                if(Math.abs(value.numval - (long)value.numval) < 0.00001){
-                    exec.textBuffer.append((long)value.numval);
+                if(Math.abs(value.numval - (long)(value.numval+0.5)) < 0.00001){
+                    exec.textBuffer.append((long)(value.numval+0.5));
                 }else{
                     exec.textBuffer.append(value.numval);
                 }
@@ -1027,8 +1027,8 @@ public class LExecutor{
                 exec.textBuffer.replace(placeholderIndex, placeholderIndex + 3, strValue);
             }else{
                 //display integer version when possible
-                if(Math.abs(value.numval - (long)value.numval) < 0.00001){
-                    exec.textBuffer.replace(placeholderIndex, placeholderIndex + 3, (long)value.numval + "");
+                if(Math.abs(value.numval - (long)(value.numval+0.5)) < 0.00001){
+                    exec.textBuffer.replace(placeholderIndex, placeholderIndex + 3, (long)(value.numval+0.5) + "");
                 }else{
                     exec.textBuffer.replace(placeholderIndex, placeholderIndex + 3, value.numval + "");
                 }

--- a/core/src/mindustry/logic/LogicDialog.java
+++ b/core/src/mindustry/logic/LogicDialog.java
@@ -188,7 +188,7 @@ public class LogicDialog extends BaseDialog{
                             Label label = out.add("").style(Styles.outlineLabel).padLeft(4).padRight(4).width(140f).wrap().get();
                             label.update(() -> {
                                 if(counter[0] < 0 || (counter[0] += Time.delta) >= period){
-                                    String text = s.isobj ? PrintI.toString(s.objval) : Math.abs(s.numval - (long)s.numval) < 0.00001 ? (long)s.numval + "" : s.numval + "";
+                                    String text = s.isobj ? PrintI.toString(s.objval) : Math.abs(s.numval - (long)(s.numval+0.5)) < 0.00001 ? (long)(s.numval+0.5) + "" : s.numval + "";
                                     if(!label.textEquals(text)){
                                         label.setText(text);
                                         if(counter[0] >= 0f){


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

-----------------

This PR implements this suggestion: https://github.com/Anuken/Mindustry-Suggestions/issues/5319.

Currently, numbers slightly above an integer are rounded down to the integer when printed/displayed, but numbers slightly below an integer aren't rounded. The PR makes the numbers slightly below an integer rounded towards the integer value too.

Test code:

```
print 0.9999999999
print "\n"
print 1.0000000001
printflush message1
```

Before the change, the code outputs:

```
0.9999999999
1
```

After the change, the code outputs

```
1
1
```
