### PR TITLE
Properly rounding numbers for display - fix for negative numbers

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -966,8 +966,8 @@ public class LExecutor{
                 exec.textBuffer.append(strValue);
             }else{
                 //display integer version when possible
-                if(Math.abs(value.numval - (long)(value.numval+0.5)) < 0.00001){
-                    exec.textBuffer.append((long)(value.numval+0.5));
+                if(Math.abs(value.numval - Math.round(value.numval)) < 0.00001){
+                    exec.textBuffer.append(Math.round(value.numval));
                 }else{
                     exec.textBuffer.append(value.numval);
                 }
@@ -1027,8 +1027,8 @@ public class LExecutor{
                 exec.textBuffer.replace(placeholderIndex, placeholderIndex + 3, strValue);
             }else{
                 //display integer version when possible
-                if(Math.abs(value.numval - (long)(value.numval+0.5)) < 0.00001){
-                    exec.textBuffer.replace(placeholderIndex, placeholderIndex + 3, (long)(value.numval+0.5) + "");
+                if(Math.abs(value.numval - Math.round(value.numval)) < 0.00001){
+                    exec.textBuffer.replace(placeholderIndex, placeholderIndex + 3, Math.round(value.numval) + "");
                 }else{
                     exec.textBuffer.replace(placeholderIndex, placeholderIndex + 3, value.numval + "");
                 }

--- a/core/src/mindustry/logic/LogicDialog.java
+++ b/core/src/mindustry/logic/LogicDialog.java
@@ -188,7 +188,7 @@ public class LogicDialog extends BaseDialog{
                             Label label = out.add("").style(Styles.outlineLabel).padLeft(4).padRight(4).width(140f).wrap().get();
                             label.update(() -> {
                                 if(counter[0] < 0 || (counter[0] += Time.delta) >= period){
-                                    String text = s.isobj ? PrintI.toString(s.objval) : Math.abs(s.numval - (long)(s.numval+0.5)) < 0.00001 ? (long)(s.numval+0.5) + "" : s.numval + "";
+                                    String text = s.isobj ? PrintI.toString(s.objval) : Math.abs(s.numval - Math.round(s.numval)) < 0.00001 ? Math.round(s.numval) + "" : s.numval + "";
                                     if(!label.textEquals(text)){
                                         label.setText(text);
                                         if(counter[0] >= 0f){


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

I didn't realize casting `double` to `long` truncates towards zero and broken the formatting for negative numbers. Sorry for the blunder.

To fix it, I've replaced the casting with `Math.round()`, which works for all `double` values and returns a `long` out of the box. This works for all numbers up to `2^63 - 1` - the largest long that can de represented by a `double`.

Test code:

```
set a 0.0000000001
set two 2
op sub b 1 a
op add c 1 a
op sub d -1 a
op add e -1 a
op pow __tmp4 two 53
op sub x __tmp4 1
op add f x a
op add g x 0.5
op pow __tmp8 two 63
op sub h __tmp8 1
print b
print "\n"
print c
print "\n"
print d
print "\n"
print e
print "\n"
print f
print "\n"
print g
print "\n"
print h
print "\n"
printflush message1
```

Output:

```
1
1
-1
-1
9007199254740991
9007199254740992            // Exceeded the double precision, thus the rounding up
9223372036854775807
```
