### PR TITLE
Display mod version

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -144,6 +144,7 @@ mod.enabled = [lightgray]Enabled
 mod.disabled = [red]Disabled
 mod.multiplayer.compatible = [gray]Multiplayer Compatible
 mod.disable = Disable
+mod.version = Version:
 mod.content = Content:
 mod.delete.error = Unable to delete mod. File may be in use.
 

--- a/core/src/mindustry/ui/dialogs/ModsDialog.java
+++ b/core/src/mindustry/ui/dialogs/ModsDialog.java
@@ -415,6 +415,12 @@ public class ModsDialog extends BaseDialog{
                 desc.add(mod.meta.author).growX().wrap().padTop(2);
                 desc.row();
             }
+            if(mod.meta.version != null){
+                desc.add("@mod.version").padRight(10).color(Color.gray).top();
+                desc.row();
+                desc.add(mod.meta.version).growX().wrap().padTop(2);
+                desc.row();
+            }
             if(mod.meta.description != null){
                 desc.add("@editor.description").padRight(10).color(Color.gray).top();
                 desc.row();


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5d6846b8-d11a-4b64-9560-148d54dd9ec1)

Bug reports on mods usually request the version of the mod, which isn't displayed anywhere in-game.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
