### PR TITLE
why are noisemesh seeds planet id dependent?

### DIFF
--- a/core/src/mindustry/content/Planets.java
+++ b/core/src/mindustry/content/Planets.java
@@ -92,7 +92,7 @@ public class Planets{
         }};
 
         //TODO names
-        gier = makeAsteroid("gier", erekir, Blocks.ferricStoneWall, Blocks.carbonWall, 0.4f, 7, 1f, gen -> {
+        gier = makeAsteroid("gier", erekir, Blocks.ferricStoneWall, Blocks.carbonWall, 2, 0.4f, 7, 1f, gen -> {
             gen.min = 25;
             gen.max = 35;
             gen.carbonChance = 0.6f;
@@ -100,7 +100,7 @@ public class Planets{
             gen.berylChance = 0.1f;
         });
 
-        notva = makeAsteroid("notva", sun, Blocks.ferricStoneWall, Blocks.beryllicStoneWall, 0.55f, 9, 1.3f, gen -> {
+        notva = makeAsteroid("notva", sun, Blocks.ferricStoneWall, Blocks.beryllicStoneWall, 3, 0.55f, 9, 1.3f, gen -> {
             gen.berylChance = 0.8f;
             gen.iceChance = 0f;
             gen.carbonChance = 0.01f;
@@ -156,7 +156,7 @@ public class Planets{
             landCloudColor = Pal.spore.cpy().a(0.5f);
         }};
 
-        verilus = makeAsteroid("verlius", sun, Blocks.stoneWall, Blocks.iceWall, 0.5f, 12, 2f, gen -> {
+        verilus = makeAsteroid("verlius", sun, Blocks.stoneWall, Blocks.iceWall, 6, 0.5f, 12, 2f, gen -> {
             gen.berylChance = 0f;
             gen.iceChance = 0.6f;
             gen.carbonChance = 0.1f;
@@ -164,7 +164,7 @@ public class Planets{
         });
     }
 
-    private static Planet makeAsteroid(String name, Planet parent, Block base, Block tint, float tintThresh, int pieces, float scale, Cons<AsteroidGenerator> cgen){
+    private static Planet makeAsteroid(String name, Planet parent, Block base, Block tint, int seed, float tintThresh, int pieces, float scale, Cons<AsteroidGenerator> cgen){
         return new Planet(name, parent, 0.12f){{
             hasAtmosphere = false;
             updateLighting = false;
@@ -187,13 +187,13 @@ public class Planets{
                 Rand rand = new Rand(id + 2);
 
                 meshes.add(new NoiseMesh(
-                    this, 0, 2, radius, 2, 0.55f, 0.45f, 14f,
+                    this, seed, 2, radius, 2, 0.55f, 0.45f, 14f,
                     color, tinted, 3, 0.6f, 0.38f, tintThresh
                 ));
 
                 for(int j = 0; j < pieces; j++){
                     meshes.add(new MatMesh(
-                        new NoiseMesh(this, j + 1, 1, 0.022f + rand.random(0.039f) * scale, 2, 0.6f, 0.38f, 20f,
+                        new NoiseMesh(this, seed + j + 1, 1, 0.022f + rand.random(0.039f) * scale, 2, 0.6f, 0.38f, 20f,
                         color, tinted, 3, 0.6f, 0.38f, tintThresh),
                         new Mat3D().setToTranslation(Tmp.v31.setToRandomDirection(rand).setLength(rand.random(0.44f, 1.4f) * scale)))
                     );

--- a/core/src/mindustry/content/Planets.java
+++ b/core/src/mindustry/content/Planets.java
@@ -92,7 +92,7 @@ public class Planets{
         }};
 
         //TODO names
-        gier = makeAsteroid("gier", erekir, Blocks.ferricStoneWall, Blocks.carbonWall, 2, 0.4f, 7, 1f, gen -> {
+        gier = makeAsteroid("gier", erekir, Blocks.ferricStoneWall, Blocks.carbonWall, -5, 0.4f, 7, 1f, gen -> {
             gen.min = 25;
             gen.max = 35;
             gen.carbonChance = 0.6f;
@@ -100,7 +100,7 @@ public class Planets{
             gen.berylChance = 0.1f;
         });
 
-        notva = makeAsteroid("notva", sun, Blocks.ferricStoneWall, Blocks.beryllicStoneWall, 3, 0.55f, 9, 1.3f, gen -> {
+        notva = makeAsteroid("notva", sun, Blocks.ferricStoneWall, Blocks.beryllicStoneWall, -4, 0.55f, 9, 1.3f, gen -> {
             gen.berylChance = 0.8f;
             gen.iceChance = 0f;
             gen.carbonChance = 0.01f;
@@ -156,7 +156,7 @@ public class Planets{
             landCloudColor = Pal.spore.cpy().a(0.5f);
         }};
 
-        verilus = makeAsteroid("verlius", sun, Blocks.stoneWall, Blocks.iceWall, 6, 0.5f, 12, 2f, gen -> {
+        verilus = makeAsteroid("verlius", sun, Blocks.stoneWall, Blocks.iceWall, -1, 0.5f, 12, 2f, gen -> {
             gen.berylChance = 0f;
             gen.iceChance = 0.6f;
             gen.carbonChance = 0.1f;

--- a/core/src/mindustry/graphics/g3d/HexSkyMesh.java
+++ b/core/src/mindustry/graphics/g3d/HexSkyMesh.java
@@ -27,7 +27,7 @@ public class HexSkyMesh extends PlanetMesh{
 
             @Override
             public boolean skip(Vec3 position){
-                return Simplex.noise3d(planet.id + seed, octaves, persistence, scl, position.x, position.y * 3f, position.z) >= thresh;
+                return Simplex.noise3d(7 + seed, octaves, persistence, scl, position.x, position.y * 3f, position.z) >= thresh;
             }
         }, divisions, false, planet.radius, radius), Shaders.clouds);
 

--- a/core/src/mindustry/graphics/g3d/NoiseMesh.java
+++ b/core/src/mindustry/graphics/g3d/NoiseMesh.java
@@ -14,7 +14,7 @@ public class NoiseMesh extends HexMesh{
         this.mesh = MeshBuilder.buildHex(new HexMesher(){
             @Override
             public float getHeight(Vec3 position){
-                return Simplex.noise3d(planet.id + seed, octaves, persistence, scale, 5f + position.x, 5f + position.y, 5f + position.z) * mag;
+                return Simplex.noise3d(7 + seed, octaves, persistence, scale, 5f + position.x, 5f + position.y, 5f + position.z) * mag;
             }
 
             @Override
@@ -31,12 +31,12 @@ public class NoiseMesh extends HexMesh{
         this.mesh = MeshBuilder.buildHex(new HexMesher(){
             @Override
             public float getHeight(Vec3 position){
-                return Simplex.noise3d(planet.id + seed, octaves, persistence, scale, 5f + position.x, 5f + position.y, 5f + position.z) * mag;
+                return Simplex.noise3d(7 + seed, octaves, persistence, scale, 5f + position.x, 5f + position.y, 5f + position.z) * mag;
             }
 
             @Override
             public Color getColor(Vec3 position){
-                return Simplex.noise3d(planet.id + seed + 1, coct, cper, cscl, 5f + position.x, 5f + position.y, 5f + position.z) > cthresh ? color2 : color1;
+                return Simplex.noise3d(8 + seed, coct, cper, cscl, 5f + position.x, 5f + position.y, 5f + position.z) > cthresh ? color2 : color1;
             }
         }, divisions, false, radius, 0.2f);
     }


### PR DESCRIPTION
really awesome installing another mod that happens to add planets only for your planet to look different and have its sector placement and landmarks mismatch

the value added to the actual seed is now a constant 7 (except for 2 colored noisemeshes in which case the color seed has 8 added instead of 7, as in the base game the seed used for the color is planet.id + seed + 1) instead of the planet's id since thats the planet id of most modded planets. this way mods that add only 1 planet dont have to make any changes to keep their planet's appearance

additionally, the makeAsteroid function now has a seed value so that gier, notva and verlius (verilus?) dont look different after this pr since they use noisemeshes

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
