### PR TITLE
Remove Aeyama from the mod browser due to botted stars

### DIFF
--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -32,7 +32,7 @@ import static mindustry.Vars.*;
 
 public class Mods implements Loadable{
     private static final String[] metaFiles = {"mod.json", "mod.hjson", "plugin.json", "plugin.hjson"};
-    private static final ObjectSet<String> blacklistedMods = ObjectSet.with("ui-lib", "braindustry");
+    private static final ObjectSet<String> blacklistedMods = ObjectSet.with("ui-lib", "braindustry", "aeyama");
 
     private Json json = new Json();
     private @Nullable Scripts scripts;


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

I believe that the mod Aeyama should be removed from the mod browser due to botted stars. The mod is of impressively low quality, which isn't a bad thing by itself, but it has over a hundred stars and counting despite its low quality. Additionally, at https://github.com/Aeyama-Mod/aeyama/stargazers, you can see that the majority of Aeyama's stars are from generic bot accounts.

<img width="1132" alt="image" src="https://github.com/user-attachments/assets/d9c2ffab-7ed5-46a7-8b13-64bcd7b204cb" />
<img width="1129" alt="image" src="https://github.com/user-attachments/assets/17b19cc7-071e-4c34-9650-6229341c54e6" />
The users not suspected to be bots have had their profiles censored for privacy. Within these two screenshots, there are 33 users who have starred the mod, but only seven have non-default profile pictures. Some of the users with default profile pictures are real, but it's very few. The second of the two screenshots is still on the Aeyama stargazers page, you can check it to verify.

<img width="1777" alt="image" src="https://github.com/user-attachments/assets/876fd72f-40a4-41c7-adf5-62c80a10b620" />
<img width="1828" alt="image" src="https://github.com/user-attachments/assets/0d040fa0-50b0-4cea-b206-e6a85544be4f" />
<img width="1805" alt="image" src="https://github.com/user-attachments/assets/408b4db8-ea95-4127-90b7-e80fc99e4eda" />
These three screenshots contain three of the bot accounts. Note how all have only starred Aeyama, except for the last one having their own (empty) repository starred as well.

Checking the stargazers page for another popular mod, such as BetaMindy, the vast majority of the users either have non-default profile pictures or have default profiles and are active in, and have starred, other repositories. I believe this indicates that Aeyama's abnormally high concrentration of suspected bot accounts were used for botting stars to illegitimately increase the popularity of the repository.

<img width="1126" alt="image" src="https://github.com/user-attachments/assets/e1cc8b45-7179-42ed-87c9-126a2c5433d5" />
<img width="1128" alt="image" src="https://github.com/user-attachments/assets/8ee108ff-f86e-4cc5-8547-e803f902cd37" />
<img width="1130" alt="image" src="https://github.com/user-attachments/assets/277f9bb8-8dc8-4a90-b6cf-62215da97d97" />
<img width="1127" alt="image" src="https://github.com/user-attachments/assets/72c5d72f-27c5-45a7-93d1-04db5063ad46" />
Others have expressed similar sentiment in the past as well, particularly in the modding chats in the Discord. Their usernames have been censored for privacy, but all of these messages can be found in the Discord, if verification is necessary.

To cap it off, there is a large amount of evidence implying Aeyama has illegitimately gained stars to inflate the popularity of the mod. I am not the only person to think it should be removed from the mod browser for this, as others with a similar viewpoint are posted above.