### PR TITLE
Add server again

### DIFF
--- a/servers_v7.json
+++ b/servers_v7.json
@@ -310,5 +310,10 @@
       "server.mindustry-tool.com",
       "server.mindustry-tool.com:6568"
     ]
-  }
+  },
+  {
+    "name": "Korea",
+    "address": [
+      "mindustry.kr"
+    ]
 ]

--- a/servers_v7.json
+++ b/servers_v7.json
@@ -316,4 +316,5 @@
     "address": [
       "mindustry.kr"
     ]
+  }
 ]


### PR DESCRIPTION
There were about 400 people on average per year from overseas, and all of them were griefers. They didn't do griefing on their own servers, but almost 100% of them said they would go back to their own servers after griefing because it was Korea.

Since all overseas access is blocked except for Japan, which is relatively reliable, if you want to connect to the server from a region other than that, you will need to use a VPN or provide me with the IP you are trying to connect from.