### PR TITLE
Allow updateEffect spread to be customized or disabled for GenericCrafter

### DIFF
--- a/core/src/mindustry/world/blocks/production/GenericCrafter.java
+++ b/core/src/mindustry/world/blocks/production/GenericCrafter.java
@@ -40,8 +40,7 @@ public class GenericCrafter extends Block{
     public Effect craftEffect = Fx.none;
     public Effect updateEffect = Fx.none;
     public float updateEffectChance = 0.04f;
-    public boolean updateEffectSpread = true;
-    public float updateEffectSpreadMag = 4f;
+    public float updateEffectSpread = 4f;
     public float warmupSpeed = 0.019f;
     /** Only used for legacy cultivator blocks. */
     public boolean legacyReadWarmup = false;
@@ -235,11 +234,7 @@ public class GenericCrafter extends Block{
                 }
 
                 if(wasVisible && Mathf.chanceDelta(updateEffectChance)){
-                    if(updateEffectSpread){
-                        updateEffect.at(x + Mathf.range(size * updateEffectSpreadMag), y + Mathf.range(size * updateEffectSpreadMag));
-                    }else{
-                        updateEffect.at(x, y);
-                    }
+                    updateEffect.at(x + Mathf.range(size * updateEffectSpread), y + Mathf.range(size * updateEffectSpread));
                 }
             }else{
                 warmup = Mathf.approachDelta(warmup, 0f, warmupSpeed);

--- a/core/src/mindustry/world/blocks/production/GenericCrafter.java
+++ b/core/src/mindustry/world/blocks/production/GenericCrafter.java
@@ -40,6 +40,8 @@ public class GenericCrafter extends Block{
     public Effect craftEffect = Fx.none;
     public Effect updateEffect = Fx.none;
     public float updateEffectChance = 0.04f;
+    public boolean updateEffectSpread = true;
+    public float updateEffectSpreadMag = 4f;
     public float warmupSpeed = 0.019f;
     /** Only used for legacy cultivator blocks. */
     public boolean legacyReadWarmup = false;
@@ -233,7 +235,11 @@ public class GenericCrafter extends Block{
                 }
 
                 if(wasVisible && Mathf.chanceDelta(updateEffectChance)){
-                    updateEffect.at(x + Mathf.range(size * 4f), y + Mathf.range(size * 4));
+                    if(updateEffectSpread){
+                        updateEffect.at(x + Mathf.range(size * updateEffectSpreadMag), y + Mathf.range(size * updateEffectSpreadMag));
+                    }else{
+                        updateEffect.at(x, y);
+                    }
                 }
             }else{
                 warmup = Mathf.approachDelta(warmup, 0f, warmupSpeed);


### PR DESCRIPTION
Adds an updateEffectSpread and updateEffectSpreadMag for customization of where the updateEffect appears on a GenericCrafter. Previously, you couldn't ensure it appears at a given location, as it would always be placed all around the sprite. By default, this does the spread and also has the same spread magnitude as before, so it's backwards-compatible.

I've read the guidelines, compiled and tested the game, and ensured that it works properly.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
