### PR TITLE
Malign balancing

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -5285,7 +5285,7 @@ public class Blocks{
             maxHeatEfficiency = 2f;
             warmupMaintainTime = 120f;
             consumePower(40f);
-
+            unitSort = UnitSorts.strongest;
             shoot = new ShootSummon(0f, 0f, circleRad, 20f);
 
             minWarmup = 0.96f;

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -4973,7 +4973,7 @@ public class Blocks{
         }};
 
         malign = new PowerTurret("malign"){{
-            requirements(Category.turret, with(Items.carbide, 400, Items.beryllium, 2000, Items.silicon, 800, Items.graphite, 800, Items.phaseFabric, 300));
+            requirements(Category.turret, with(Items.carbide, 200, Items.beryllium, 1000, Items.silicon, 500, Items.graphite, 500, Items.phaseFabric, 200));
 
             var haloProgress = PartProgress.warmup;
             Color haloColor = Color.valueOf("d370d3"), heatCol = Color.purple;
@@ -5281,26 +5281,26 @@ public class Blocks{
             }};
 
             velocityRnd = 0.15f;
-            heatRequirement = 90f;
+            heatRequirement = 72f;
             maxHeatEfficiency = 2f;
             warmupMaintainTime = 120f;
-            consumePower(10f);
+            consumePower(40f);
 
-            shoot = new ShootSummon(0f, 0f, circleRad, 48f);
+            shoot = new ShootSummon(0f, 0f, circleRad, 20f);
 
             minWarmup = 0.96f;
-            shootWarmupSpeed = 0.03f;
+            shootWarmupSpeed = 0.08f;
 
             shootY = circleY - 5f;
 
             outlineColor = Pal.darkOutline;
             envEnabled |= Env.space;
-            reload = 9f;
-            range = 370;
+            reload = 7f;
+            range = 380;
             trackingRange = range * 1.4f;
             shootCone = 100f;
             scaledHealth = 370;
-            rotateSpeed = 2f;
+            rotateSpeed = 2.6f;
             recoil = 0.5f;
             recoilTime = 30f;
             shake = 3f;


### PR DESCRIPTION
Significantly reduce resources cost, matching Malign's value to its cost
(building still takes 44 s) while units and turrets with new ammo could be much more cost effective than Malign with its original cost.

Slightly reduce heat consumption & offset by increasing power consumption, since power would be more than abundant in late game but heat supply for Malign occupies lots of frontline space. Malign need to gain some space efficiency.

Reload & range improvement to stay attractive compared to turrets with new ammo.

Much quicker warm up & aiming, less spread by shootSummon pattern to offer better missile defense ability.

Unit sort to select strongest unit therefore damage effectiveness gets improved.

Changes has been agreed following discussion in #balancing on Discord

video comparing 1 new Malign to 8 Afflicts
https://github.com/user-attachments/assets/c2769238-87cb-408c-99c6-4e824a568e5f

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
