### PR TITLE
fix of diode's strange behavior

### DIFF
--- a/core/src/mindustry/world/blocks/power/PowerDiode.java
+++ b/core/src/mindustry/world/blocks/power/PowerDiode.java
@@ -62,20 +62,23 @@ public class PowerDiode extends Block{
             PowerGraph frontGraph = front().power.graph;
             if(backGraph == frontGraph) return;
 
-            // 0f - 1f of battery capacity in use
-            float backStored = backGraph.getBatteryStored() / backGraph.getTotalBatteryCapacity();
-            float frontStored = frontGraph.getBatteryStored() / frontGraph.getTotalBatteryCapacity();
+            float backStored = backGraph.getBatteryStored();
+            float backCapacity = backGraph.getTotalBatteryCapacity();
+            float frontStored = frontGraph.getBatteryStored();
+            float frontCapacity = frontGraph.getTotalBatteryCapacity();
 
-            // try to send if the back side has more % capacity stored than the front side
-            if(backStored > frontStored){
-                // send half of the difference
-                float amount = backGraph.getBatteryStored() * (backStored - frontStored) / 2;
-                // prevent sending more than the front can handle
-                amount = Mathf.clamp(amount, 0, frontGraph.getTotalBatteryCapacity() * (1 - frontStored));
+            if(backStored/backCapacity <= frontStored/frontCapacity) return;
 
-                backGraph.transferPower(-amount);
-                frontGraph.transferPower(amount);
-            }
+            float targetPercentage = (frontStored + backStored) / (frontCapacity + backCapacity);
+
+            // send half of the difference
+            float amount = (targetPercentage * frontCapacity - frontStored) / 2;
+
+            // prevent sending more than the front can handle
+            amount = Mathf.clamp(amount, 0, frontCapacity - frontStored);
+
+            backGraph.transferPower(-amount);
+            frontGraph.transferPower(amount);
         }
     }
 }


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.

While experimenting with the power diode, I found inconsistencies in its behavior.

Its purpose is to transfer power when the back power graph has a higher percentage of stored energy than the front power graph, but it doesn't actually intend to balance them that way.

For example, a fully charged large battery will transfer 50000 * (1 - 0) / 2 = 25000 energy (clamped to 4000) to a small battery. However, intuitively it should be around 3700.

This code fixes the issue. I also believe that there is no longer any need for the clamp or for dividing by 2, but it remains unchanged.

Before:
![image](https://github.com/user-attachments/assets/c6e863e4-dcb1-442c-93e3-50d4852f08f1)
![image](https://github.com/user-attachments/assets/1a8f22bd-68ae-43cf-a0bf-b2b756a30039)
![image](https://github.com/user-attachments/assets/7b9f2d51-e345-42e2-a0d4-81277672f58e)

After:
![image](https://github.com/user-attachments/assets/78406be3-ac20-4f5c-9756-2cfec783d71c)
![image](https://github.com/user-attachments/assets/185acf4d-41d7-410c-8651-a2b2572d5df2)
![image](https://github.com/user-attachments/assets/335d7297-9061-49a3-8c74-16f8b5642b98)