### PR TITLE
Afflict balancing

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -4368,11 +4368,11 @@ public class Blocks{
                 trailEffect = Fx.missileTrail;
                 trailInterval = 3f;
                 trailParam = 4f;
-                pierceCap = 2;
+                pierceCap = 3;
                 buildingDamageMultiplier = 0.5f;
                 fragOnHit = false;
                 speed = 7f;
-                damage = 180f;
+                damage = 280f;
                 lifetime = 57f;
                 width = height = 16f;
                 backColor = Pal.surge;
@@ -4393,7 +4393,7 @@ public class Blocks{
                 //TODO shoot sound
                 shootSound = Sounds.cannon;
 
-                fragBullet = intervalBullet = new BasicBulletType(5f, 35){{
+                fragBullet = intervalBullet = new BasicBulletType(5f, 45){{
                     width = 9f;
                     hitSize = 5f;
                     height = 15f;

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -4420,7 +4420,7 @@ public class Blocks{
                 intervalAngle = 180f;
                 intervalSpread = 300f;
 
-                fragBullets = 20;
+                fragBullets = 16;
                 fragVelocityMin = 0.5f;
                 fragVelocityMax = 1.5f;
                 fragLifeMin = 0.5f;

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -4363,7 +4363,7 @@ public class Blocks{
                 }});
                 smokeEffect = Fx.shootSmokeTitan;
                 hitColor = Pal.surge;
-
+                homingPower = 0.5f;
                 sprite = "large-orb";
                 trailEffect = Fx.missileTrail;
                 trailInterval = 3f;
@@ -4371,9 +4371,9 @@ public class Blocks{
                 pierceCap = 2;
                 buildingDamageMultiplier = 0.5f;
                 fragOnHit = false;
-                speed = 5f;
+                speed = 7f;
                 damage = 180f;
-                lifetime = 80f;
+                lifetime = 57f;
                 width = height = 16f;
                 backColor = Pal.surge;
                 frontColor = Color.white;
@@ -4393,12 +4393,12 @@ public class Blocks{
                 //TODO shoot sound
                 shootSound = Sounds.cannon;
 
-                fragBullet = intervalBullet = new BasicBulletType(3f, 35){{
+                fragBullet = intervalBullet = new BasicBulletType(5f, 35){{
                     width = 9f;
                     hitSize = 5f;
                     height = 15f;
                     pierce = true;
-                    lifetime = 35f;
+                    lifetime = 20f;
                     pierceBuilding = true;
                     hitColor = backColor = trailColor = Pal.surge;
                     frontColor = Color.white;
@@ -4411,7 +4411,7 @@ public class Blocks{
                         lifetime = 10f;
                     }};
                     buildingDamageMultiplier = 0.3f;
-                    homingPower = 0.2f;
+                    
                 }};
 
                 bulletInterval = 3f;
@@ -4449,7 +4449,7 @@ public class Blocks{
                 }});
             }};
 
-            consumePower(5f);
+            consumePower(10f);
             heatRequirement = 10f;
             maxHeatEfficiency = 2f;
 

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -4420,7 +4420,7 @@ public class Blocks{
                 intervalAngle = 180f;
                 intervalSpread = 300f;
 
-                fragBullets = 16;
+                fragBullets = 10;
                 fragVelocityMin = 0.5f;
                 fragVelocityMax = 1.5f;
                 fragLifeMin = 0.5f;

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -4450,7 +4450,7 @@ public class Blocks{
             }};
 
             consumePower(10f);
-            heatRequirement = 10f;
+            heatRequirement = 12f;
             maxHeatEfficiency = 2f;
 
             newTargetInterval = 40f;


### PR DESCRIPTION
Power cost increased to reduce turret spamming;

All bullets speed up & lifetime reduced, keeping range the same but less objects to fill the screen, also less interval & frag get generated;

Move homing to main bullet only so intervals & frags no longer go after missile & fleeing units, offering some room for micro & give missile units some chance to be useful. T2 swarm get some chance to retreat if attacker decided so.

Orb, frag & interval damage increased to compensate quantity reduction, minor heat demand increase.

Resolved most of the dispute in #balancing.

Test video against 30 precepts:

https://github.com/user-attachments/assets/d1655999-9c18-47d7-af8d-1b34ff041a64


Json mod for preview & play test:
[afflict_tweak_json_orb.zip](https://github.com/user-attachments/files/18806967/afflict_tweak_json_orb.zip)

map used for play test:
[afflict_test6.zip](https://github.com/user-attachments/files/18806972/afflict_test6.zip)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
