### PR TITLE
Improve CargoAI

### DIFF
--- a/core/src/mindustry/ai/types/CargoAI.java
+++ b/core/src/mindustry/ai/types/CargoAI.java
@@ -74,18 +74,20 @@ public class CargoAI extends AIController{
 
                     //deposit items when it's possible
                     if(max > 0){
-                        noDestTimer = 0f;
                         Call.transferItemTo(unit, unit.item(), max, unit.x, unit.y, unloadTarget);
 
-                        //try the next target later
+                        //reset wait timer if we can't fill the unload point.
                         if(!unit.hasItem()){
-                            targetIndex ++;
+                            noDestTimer = 0f;
                         }
-                    }else if((noDestTimer += dropSpacing) >= emptyWaitTime){
+                    }
+                    //keep the target for at most emptyWaitTime, then we try change if other need.
+                    if((noDestTimer += dropSpacing) >= emptyWaitTime){
                         //oh no, it's out of space - wait for a while, and if nothing changes, try the next destination
 
                         //next targeting attempt will try the next destination point
                         targetIndex = findDropTarget(unit.item(), targetIndex, unloadTarget) + 1;
+                        noDestTimer = 0f;
 
                         //nothing found at all, clear item
                         if(unloadTarget == null){


### PR DESCRIPTION
OLD:
Only when can't `transferItemTo` current unloader or unit's items empty, the cargo changes the target.
(cargos may keep on one unloader for minutes , transfering a little items each time, while others may be empty.

NEW:
When filled current unloader, the cargo will try to change the target to fill.

https://github.com/user-attachments/assets/a9e4d11e-5dc1-45fe-a769-778ae212291d


---

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
