### PR TITLE
reconstructor balancing

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -5930,7 +5930,7 @@ public class Blocks{
             requirements(Category.units, with(Items.metaglass, 2000, Items.silicon, 1500, Items.graphite, 1000, Items.thorium, 1000, Items.plastanium, 400, Items.phaseFabric, 100));
 
             size = 7;
-            consumePower(100f);
+            consumePower(80f);
             consumeItems(with(Items.silicon, 480, Items.titanium, 480, Items.plastanium, 360));
             consumeLiquid(Liquids.cryofluid, 0.4f);
 
@@ -5952,7 +5952,7 @@ public class Blocks{
             requirements(Category.units, with(Items.metaglass, 3000, Items.silicon, 2000, Items.graphite, 2000, Items.plastanium, 500, Items.phaseFabric, 500, Items.surgeAlloy, 500));
 
             size = 9;
-            consumePower(300f);
+            consumePower(200f);
             consumeItems(with(Items.silicon, 720, Items.plastanium, 480, Items.surgeAlloy, 360, Items.phaseFabric, 240));
             consumeLiquid(Liquids.cryofluid, 0.8f);
 

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -5927,14 +5927,14 @@ public class Blocks{
         }};
 
         exponentialReconstructor = new Reconstructor("exponential-reconstructor"){{
-            requirements(Category.units, with(Items.lead, 2000, Items.silicon, 1000, Items.titanium, 2000, Items.thorium, 750, Items.plastanium, 450, Items.phaseFabric, 600));
+            requirements(Category.units, with(Items.metaglass, 2000, Items.silicon, 1500, Items.graphite, 1000, Items.thorium, 1000, Items.plastanium, 400, Items.phaseFabric, 100));
 
             size = 7;
-            consumePower(13f);
-            consumeItems(with(Items.silicon, 850, Items.titanium, 750, Items.plastanium, 650));
-            consumeLiquid(Liquids.cryofluid, 1f);
+            consumePower(100f);
+            consumeItems(with(Items.silicon, 450, Items.titanium, 450, Items.plastanium, 350));
+            consumeLiquid(Liquids.cryofluid, 0.4f);
 
-            constructTime = 60f * 60f * 1.5f;
+            constructTime = 80f * 60f;
             liquidCapacity = 60f;
 
             upgrades.addAll(
@@ -5949,14 +5949,14 @@ public class Blocks{
         }};
 
         tetrativeReconstructor = new Reconstructor("tetrative-reconstructor"){{
-            requirements(Category.units, with(Items.lead, 4000, Items.silicon, 3000, Items.thorium, 1000, Items.plastanium, 600, Items.phaseFabric, 600, Items.surgeAlloy, 800));
+            requirements(Category.units, with(Items.metaglass, 3000, Items.silicon, 2000, Items.graphite, 2000, Items.plastanium, 500, Items.phaseFabric, 500, Items.surgeAlloy, 500));
 
             size = 9;
-            consumePower(25f);
-            consumeItems(with(Items.silicon, 1000, Items.plastanium, 600, Items.surgeAlloy, 500, Items.phaseFabric, 350));
-            consumeLiquid(Liquids.cryofluid, 3f);
+            consumePower(400f);
+            consumeItems(with(Items.silicon, 720, Items.plastanium, 480, Items.surgeAlloy, 420, Items.phaseFabric, 420));
+            consumeLiquid(Liquids.cryofluid, 0.8f);
 
-            constructTime = 60f * 60f * 4;
+            constructTime = 120f * 60f;
             liquidCapacity = 180f;
 
             upgrades.addAll(

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -5931,7 +5931,7 @@ public class Blocks{
 
             size = 7;
             consumePower(100f);
-            consumeItems(with(Items.silicon, 450, Items.titanium, 450, Items.plastanium, 350));
+            consumeItems(with(Items.silicon, 480, Items.titanium, 480, Items.plastanium, 360));
             consumeLiquid(Liquids.cryofluid, 0.4f);
 
             constructTime = 80f * 60f;
@@ -5952,8 +5952,8 @@ public class Blocks{
             requirements(Category.units, with(Items.metaglass, 3000, Items.silicon, 2000, Items.graphite, 2000, Items.plastanium, 500, Items.phaseFabric, 500, Items.surgeAlloy, 500));
 
             size = 9;
-            consumePower(400f);
-            consumeItems(with(Items.silicon, 720, Items.plastanium, 480, Items.surgeAlloy, 420, Items.phaseFabric, 420));
+            consumePower(300f);
+            consumeItems(with(Items.silicon, 720, Items.plastanium, 480, Items.surgeAlloy, 360, Items.phaseFabric, 240));
             consumeLiquid(Liquids.cryofluid, 0.8f);
 
             constructTime = 120f * 60f;

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ org.gradle.caching=true
 org.gradle.internal.http.socketTimeout=100000
 org.gradle.internal.http.connectionTimeout=100000
 android.enableR8.fullMode=false
-archash=deacd9c98e
+archash=23264f9514


### PR DESCRIPTION
Screenshots for quick comparison. Input item type not changed as shown.

<img width="785" alt="e1_comp" src="https://github.com/user-attachments/assets/bc2b9e43-fb69-4531-822a-42a5528be3e9" />

<img width="1002" alt="t1_comp" src="https://github.com/user-attachments/assets/66913a4b-0924-4fc8-a069-b15879755a58" />

Block build cost reduced & switched raw ores to refined materials.

Unit production speed increased to prevent game being too lengthy especially in end-game attack maps.

Reduced cryo consumption to accommodate space & water limitation on map, while greatly increased power consumption to encourage the use of impact reactor & overdrive.

(T4 factory requires 5 differential to power, T5 factory needs ~2 impacts, not too difficult to setup (due to power production could be setup wherever convenient) while still within acceptable level if player use thorium reactor / differential gen instead.)

json mod on Discord: https://discord.com/channels/391020510269669376/813425645518061678/1368664260951150703

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
