### PR TITLE
Add Keyboard Shortcut for "Next Wave" Feature

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -1358,6 +1358,7 @@ keybind.shoot.name = Shoot
 keybind.zoom.name = Zoom
 keybind.menu.name = Menu
 keybind.pause.name = Pause
+keybind.skip_wave.name = Skip Wave
 keybind.pause_building.name = Pause/Resume Building
 keybind.minimap.name = Minimap
 keybind.planet_map.name = Planet Map

--- a/core/assets/bundles/bundle_id_ID.properties
+++ b/core/assets/bundles/bundle_id_ID.properties
@@ -1357,6 +1357,7 @@ keybind.shoot.name = Menembak
 keybind.zoom.name = Perbesar
 keybind.menu.name = Menu
 keybind.pause.name = Jeda
+keybind.skip_wave.name = Percepat Gelombang
 keybind.pause_building.name = Jeda/Lanjut Membangun
 keybind.minimap.name = Peta Kecil
 keybind.planet_map.name = Peta Planet

--- a/core/assets/contributors
+++ b/core/assets/contributors
@@ -173,3 +173,4 @@ BlueTheCube
 sasha0552
 1ue999
 6-BennyLi-9
+neoBedjo

--- a/core/src/mindustry/input/Binding.java
+++ b/core/src/mindustry/input/Binding.java
@@ -85,6 +85,7 @@ public enum Binding implements KeyBind{
     menu(Vars.android ? KeyCode.back : KeyCode.escape),
     fullscreen(KeyCode.f11),
     pause(KeyCode.space),
+    skip_wave(KeyCode.f9),
     minimap(KeyCode.m),
     research(KeyCode.j),
     planet_map(KeyCode.n),

--- a/core/src/mindustry/ui/fragments/HudFragment.java
+++ b/core/src/mindustry/ui/fragments/HudFragment.java
@@ -311,6 +311,16 @@ public class HudFragment{
                 //wave info button with text
                 s.add(makeStatusTable()).grow().name("status");
 
+                s.update(() -> {
+                    if(Core.input.keyTap(Binding.skip_wave) && canSkipWave()){
+                        if(net.client() && player.admin){
+                            Call.adminRequest(player, AdminAction.wave, null);
+                        }else{
+                            logic.skipWave();
+                        }
+                    }
+                });
+
                 var rightStyle = new ImageButtonStyle(){{
                     over = buttonRightOver;
                     down = buttonRightDown;


### PR DESCRIPTION
### Pull Request: Add Keyboard Shortcut for "Next Wave" Functionality

#### Problem Description
Currently, there is no keyboard shortcut available for triggering the "next wave" feature in Mindustry. This limitation restricts the ability to integrate the game into interactive platforms like Twitch, Youtube, TikTok, where user actions (e.g., sending gifts) could trigger specific in-game events. Additionally, players who prefer keyboard shortcuts over mouse clicks lack an alternative input method for this functionality.

#### Proposed Solution
I have implemented a new keyboard shortcut (`F9`) to trigger the "next wave" functionality. This addition enables users to map an action (e.g., pressing `F9`) to advance to the next wave in the game. The shortcut is intuitive and can be further configured or remapped if needed.

This feature enhances interactivity and engagement, particularly for streamers using platforms like TikTok, Twitch, or YouTube. For example:
- When viewers send virtual gifts during a live stream, the gift could trigger the "next wave" shortcut.
- This creates a dynamic and engaging experience for both the streamer and their audience.

#### Implementation Details
- Added a new keyboard shortcut (`F9`) to trigger the "next wave" functionality.
- Ensured compatibility with existing game mechanics and ensured no conflicts with other shortcuts.
- The shortcut is simple to use and integrates seamlessly into the game's current input system.

#### Use Case
Streamers using TikTok or similar platforms can configure the game to respond to viewer interactions:
- Gifts sent by viewers simulate a trigger (via the proposed shortcut) to start the next wave automatically.
- This creates a more interactive and entertaining experience for both the streamer and their audience.

#### Benefits of This Feature
1. **Integration with Streaming Platforms**:
   - Enables streamers to create engaging, interactive experiences by linking viewer actions (e.g., sending gifts) to in-game events.
   - Enhances the entertainment value of live streams and encourages audience participation.

2. **Improved Accessibility**:
   - Provides an alternative input method for players who prefer keyboard shortcuts over mouse clicks.
   - Makes the game more accessible to users with different preferences or physical limitations.

3. **Enhanced Gameplay Customization**:
   - Allows players to tailor their gameplay experience to their liking.
   - Aligns with modern gaming trends that emphasize personalization and player agency.

4. **Filling a Niche for Interactive Gaming**:
   - Positions Mindustry as a forward-thinking option for creators looking to leverage interactive mechanics in their content.
   - Attracts a broader audience, including streamers and content creators.

#### Additional Context
The implementation of this feature is lightweight and non-intrusive. It aligns with the game's existing architecture and does not introduce significant complexity. The simplicity of adding a keyboard shortcut makes this a low-effort, high-impact improvement that greatly benefits the game's ecosystem.

#### Requested Outcome
- A new keyboard shortcut (`F9`) to trigger the "next wave."

#### How This Feature Will Improve the Game
Adding a keyboard shortcut for the "next wave" functionality will significantly enhance the interactivity and versatility of Mindustry, especially in modern gaming and streaming environments. By enabling players to trigger the next wave via a simple keypress, this feature opens up new gameplay options and use cases:
- Integration with streaming platforms like TikTok, Twitch, and YouTube.
- Improved accessibility for players who prefer keyboard shortcuts.
- Enhanced gameplay customization and personalization.
- Filling a niche for interactive gaming and community-driven content.

This feature positions Mindustry as a more versatile and engaging game, attracting a broader audience and enhancing the overall player experience.

---

### Testing
- Verified that the `F9` shortcut triggers the "next wave" functionality correctly.
- Ensured no conflicts with existing shortcuts or game mechanics.
- Tested in various scenarios, including single-player and multiplayer modes.

### Future Considerations
- Explore the possibility of making the shortcut configurable via the game's settings menu.
- Investigate compatibility with external tools or APIs for programmatic triggering.

---

Thank you for considering this contribution! I believe this feature will add significant value to Mindustry and its community. Let me know if any additional changes or clarifications are needed.
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:
- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
