### PR TITLE
Fixed shockwaveTower efficiency

### DIFF
--- a/core/src/mindustry/world/blocks/defense/ShockwaveTower.java
+++ b/core/src/mindustry/world/blocks/defense/ShockwaveTower.java
@@ -69,7 +69,7 @@ public class ShockwaveTower extends Block{
 
         @Override
         public void updateTile(){
-            if(potentialEfficiency > 0 && (reloadCounter += Time.delta) >= reload && timer(timerCheck, checkInterval)){
+            if(potentialEfficiency > 0 && (reloadCounter += edelta()) >= reload && timer(timerCheck, checkInterval)){
                 targets.clear();
                 Groups.bullet.intersect(x - range, y - range, range * 2, range * 2, b -> {
                     if(b.team != team && b.type.hittable){
@@ -110,7 +110,7 @@ public class ShockwaveTower extends Block{
 
         @Override
         public boolean shouldConsume(){
-            return targets.size != 0;
+            return reloadCounter < reload;
         }
 
         @Override


### PR DESCRIPTION
Fix  shockwaveTower only consumer overdrived and full reload with non zero efficiency

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
