### PR TITLE
Rework quell disrupt

### DIFF
--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -3816,8 +3816,8 @@ public class UnitTypes{
             speed = 0.95f;
             rotateSpeed = 3.2f;
             accel = 0.1f;
-            health = 5700f;
-            armor = 8f;
+            health = 5600f;
+            armor = 9f;
             hitSize = 36f;
             payloadCapacity = Mathf.sqr(3f) * tilePayload;
             researchCostMultiplier = 0f;
@@ -3926,7 +3926,7 @@ public class UnitTypes{
                 mirror = true;
                 rotate = true;
                 rotateSpeed = 0.8f;
-                reload = 240f;
+                reload = 216f;
                 layerOffset = -20f;
                 recoil = 1f;
                 rotationLimit = 9f;
@@ -3981,8 +3981,8 @@ public class UnitTypes{
                         outlineColor = Pal.darkOutline;
                         health = 240;
                         lifetime = 62f;
-                        homingDelay = 18f;
-                        homingPower = 0.05f;
+                        homingDelay = 20f;
+                        homingPower = 0.04f;
                         lowAltitude = true;
                         engineSize = 3f;
                         engineColor = trailColor = Pal.sapBulletBack;
@@ -4016,7 +4016,7 @@ public class UnitTypes{
                             mirror = false;
                             reload = 1f;
                             shootOnDeath = true;
-                            bullet = new ExplosionBulletType(160f, 36f){{
+                            bullet = new ExplosionBulletType(220f, 44f){{
                                 collidesAir = false;
                                 suppressionRange = 140f;
                                 shootEffect = new ExplosionEffect(){{

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -3813,7 +3813,7 @@ public class UnitTypes{
             lowAltitude = false;
             flying = true;
             drag = 0.06f;
-            speed = 1.2f;
+            speed = 0.95f;
             rotateSpeed = 3.2f;
             accel = 0.1f;
             health = 5700f;
@@ -3865,8 +3865,8 @@ public class UnitTypes{
                     hitSize = 6f;
                     homingPower = 0.08f;
                     knockback = 1.6f;
-                    splashDamage = 120f;
-                    splashDamageRadius = 32f;
+                    splashDamage = 100f;
+                    splashDamageRadius = 28f;
                 }};
             }});
 
@@ -3883,7 +3883,7 @@ public class UnitTypes{
             lowAltitude = false;
             flying = true;
             drag = 0.07f;
-            speed = 1.2f;
+            speed = 1.1f;
             rotateSpeed = 0.8f;
             accel = 0.1f;
             health = 12000f;
@@ -3926,7 +3926,7 @@ public class UnitTypes{
                 mirror = true;
                 rotate = true;
                 rotateSpeed = 0.8f;
-                reload = 360f;
+                reload = 240f;
                 layerOffset = -20f;
                 recoil = 1f;
                 rotationLimit = 9f;
@@ -3979,10 +3979,10 @@ public class UnitTypes{
                         speed = 6f;
                         maxRange = 5f;
                         outlineColor = Pal.darkOutline;
-                        health = 270;
+                        health = 240;
                         lifetime = 62f;
-                        homingDelay = 12f;
-                        homingPower = 0.07f;
+                        homingDelay = 18f;
+                        homingPower = 0.05f;
                         lowAltitude = true;
                         engineSize = 3f;
                         engineColor = trailColor = Pal.sapBulletBack;

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -3813,11 +3813,11 @@ public class UnitTypes{
             lowAltitude = false;
             flying = true;
             drag = 0.06f;
-            speed = 1.1f;
+            speed = 1.2f;
             rotateSpeed = 3.2f;
             accel = 0.1f;
-            health = 6000f;
-            armor = 4f;
+            health = 5700f;
+            armor = 8f;
             hitSize = 36f;
             payloadCapacity = Mathf.sqr(3f) * tilePayload;
             researchCostMultiplier = 0f;
@@ -3837,41 +3837,36 @@ public class UnitTypes{
                 y = 5 / 4f;
                 rotate = true;
                 rotateSpeed = 2f;
-                reload = 55f;
+                reload = 60f;
                 layerOffset = -0.001f;
                 recoil = 1f;
                 rotationLimit = 60f;
 
-                bullet = new BulletType(){{
+                bullet = new ArtilleryBulletType(8f, 30){{
                     shootEffect = Fx.shootBig;
                     smokeEffect = Fx.shootBigSmoke2;
+                    despawnEffect = hitEffect = new ExplosionEffect(){{
+                        waveColor = Pal.sapBullet;
+                        smokeColor = Color.gray;
+                        sparkColor = Pal.sap;
+                        waveStroke = 4f;
+                        waveRad = 40f;
+                    }};
+                    hitColor = backColor = trailColor = Pal.suppress;
                     shake = 1f;
-                    speed = 0f;
                     keepVelocity = false;
                     collidesAir = false;
-
-                    spawnUnit = new MissileUnitType("quell-missile"){{
-                        targetAir = false;
-                        speed = 4.3f;
-                        maxRange = 6f;
-                        lifetime = 60f * 1.4f;
-                        outlineColor = Pal.darkOutline;
-                        engineColor = trailColor = Pal.sapBulletBack;
-                        engineLayer = Layer.effect;
-                        health = 45;
-                        loopSoundVolume = 0.1f;
-
-                        weapons.add(new Weapon(){{
-                            shootCone = 360f;
-                            mirror = false;
-                            reload = 1f;
-                            shootOnDeath = true;
-                            bullet = new ExplosionBulletType(110f, 25f){{
-                                shootEffect = Fx.massiveExplosion;
-                                collidesAir = false;
-                            }};
-                        }});
-                    }};
+                    sprite = "missile-large";
+                    width = 9f;
+                    height = 12f;
+                    trailWidth = 2.5f;
+                    trailLength = 16f;
+                    lifetime = 31f;
+                    hitSize = 6f;
+                    homingPower = 0.08f;
+                    knockback = 1.6f;
+                    splashDamage = 120f;
+                    splashDamageRadius = 32f;
                 }};
             }});
 
@@ -3888,8 +3883,8 @@ public class UnitTypes{
             lowAltitude = false;
             flying = true;
             drag = 0.07f;
-            speed = 1f;
-            rotateSpeed = 2f;
+            speed = 1.2f;
+            rotateSpeed = 0.8f;
             accel = 0.1f;
             health = 12000f;
             armor = 9f;
@@ -3900,12 +3895,14 @@ public class UnitTypes{
             engineSize = 6f;
             engineOffset = 25.25f;
 
-            float orbRad = 5f, partRad = 3f;
+            float orbRad = 6f, partRad = 4f;
             int parts = 10;
 
             abilities.add(new SuppressionFieldAbility(){{
                 orbRadius = orbRad;
                 particleSize = partRad;
+                reload = 150;
+                range = 360;
                 y = 10f;
                 particles = parts;
             }});
@@ -3928,18 +3925,32 @@ public class UnitTypes{
                 y = -10f / 4f;
                 mirror = true;
                 rotate = true;
-                rotateSpeed = 0.4f;
-                reload = 70f;
+                rotateSpeed = 0.8f;
+                reload = 360f;
                 layerOffset = -20f;
                 recoil = 1f;
-                rotationLimit = 22f;
+                rotationLimit = 9f;
                 minWarmup = 0.95f;
                 shootWarmupSpeed = 0.1f;
                 shootY = 2f;
-                shootCone = 40f;
-                shoot.shots = 3;
-                shoot.shotDelay = 5f;
-                inaccuracy = 28f;
+                shootCone = 12f;
+                alternate = false;
+                shoot = new ShootBarrel(){{
+                barrels = new float[]{
+                    0, 0, -72f,
+                    0, 0, -56f,
+                    0, 0, 0,
+                    0, 0, -48f,
+                    0, 0, -32f,
+                    0, 0, 0,
+                    0, 0, -24f,
+                    0, 0, -8f,
+                    0, 0, 0
+                };
+                shots = 9;
+                shotDelay = 3f;
+            }};
+                inaccuracy = 0f;
 
                 parts.add(new RegionPart("-blade"){{
                     heatProgress = PartProgress.warmup;
@@ -3965,11 +3976,12 @@ public class UnitTypes{
 
                     spawnUnit = new MissileUnitType("disrupt-missile"){{
                         targetAir = false;
-                        speed = 4.6f;
+                        speed = 6f;
                         maxRange = 5f;
                         outlineColor = Pal.darkOutline;
-                        health = 70;
-                        homingDelay = 10f;
+                        health = 270;
+                        homingDelay = 12f;
+                        homingPower = 0.07f;
                         lowAltitude = true;
                         engineSize = 3f;
                         engineColor = trailColor = Pal.sapBulletBack;
@@ -4002,20 +4014,20 @@ public class UnitTypes{
                             mirror = false;
                             reload = 1f;
                             shootOnDeath = true;
-                            bullet = new ExplosionBulletType(140f, 25f){{
+                            bullet = new ExplosionBulletType(160f, 36f){{
                                 collidesAir = false;
                                 suppressionRange = 140f;
                                 shootEffect = new ExplosionEffect(){{
-                                    lifetime = 50f;
+                                    lifetime = 30f;
                                     waveStroke = 5f;
                                     waveLife = 8f;
                                     waveColor = Color.white;
                                     sparkColor = smokeColor = Pal.suppress;
                                     waveRad = 40f;
                                     smokeSize = 4f;
-                                    smokes = 7;
+                                    smokes = 5;
                                     smokeSizeBase = 0f;
-                                    sparks = 10;
+                                    sparks = 6;
                                     sparkRad = 40f;
                                     sparkLen = 6f;
                                     sparkStroke = 2f;

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -3809,7 +3809,7 @@ public class UnitTypes{
         quell = new ErekirUnitType("quell"){{
             aiController = FlyingFollowAI::new;
             envDisabled = 0;
-
+            fogRadius = 44f;
             lowAltitude = false;
             flying = true;
             drag = 0.06f;
@@ -3879,7 +3879,7 @@ public class UnitTypes{
         disrupt = new ErekirUnitType("disrupt"){{
             aiController = FlyingFollowAI::new;
             envDisabled = 0;
-
+            fogRadius = 60f;    
             lowAltitude = false;
             flying = true;
             drag = 0.07f;
@@ -3980,6 +3980,7 @@ public class UnitTypes{
                         maxRange = 5f;
                         outlineColor = Pal.darkOutline;
                         health = 270;
+                        lifetime = 62f;
                         homingDelay = 12f;
                         homingPower = 0.07f;
                         lowAltitude = true;
@@ -3988,6 +3989,7 @@ public class UnitTypes{
                         engineLayer = Layer.effect;
                         deathExplosionEffect = Fx.none;
                         loopSoundVolume = 0.1f;
+                        fogRadius = 6f;
 
                         parts.add(new ShapePart(){{
                             layer = Layer.effect;

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -3860,7 +3860,7 @@ public class UnitTypes{
                     width = 9f;
                     height = 12f;
                     trailWidth = 2.5f;
-                    trailLength = 16f;
+                    trailLength = 12;
                     lifetime = 31f;
                     hitSize = 6f;
                     homingPower = 0.08f;


### PR DESCRIPTION
Quell switched to homing artillery to get more effective damage output by ignoring wall(not collide tile).

Armor increased but health down to fit the commando role, cutting enemy ammo line & power for ground units but cannot handle heavy resistance.

Disrupt gets more durable missiles & strong salvo fire to get better chance overwhelming anti-air defense.
Expanding missile salvo helps distract enemy turrets but not suitable for close range attack.
Repair suppression range almost match weapon range.

Both units got slightly better mobility & fog clearing range.

Alternative download link of JAR file on Discord: https://discord.com/channels/391020510269669376/813425645518061678/1348143264963760159

<img width="294" alt="image" src="https://github.com/user-attachments/assets/9c5e4813-9f94-4cc2-ad97-013f48366270" />

<img width="447" alt="image" src="https://github.com/user-attachments/assets/ec2f3083-8b07-4c7e-8eaf-70e9055d4c7d" />

![quell1](https://github.com/user-attachments/assets/f8ddaecd-4e90-4064-b887-ca0c6bbefd2f)

![disrupt1](https://github.com/user-attachments/assets/c382f538-38d5-473b-9703-ba728e7cab42)


If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
