### PR TITLE
fix: don't copy items from storage blocks that were connected to core

### DIFF
--- a/core/src/mindustry/world/blocks/storage/StorageBlock.java
+++ b/core/src/mindustry/world/blocks/storage/StorageBlock.java
@@ -112,7 +112,7 @@ public class StorageBlock extends Block{
             //only add prev items when core is not linked
             if(linkedCore == null){
                 for(Building other : previous){
-                    if(other.items != null && other.items != items){
+                    if(other.items != null && other.items != items && !(other instanceof StorageBuild && ((StorageBuild) other).linkedCore != null)){
                         items.add(other.items);
                     }
                 }


### PR DESCRIPTION
Fix of a bug that I got pinged for (also pls tell how to manually sync items in a building, I need to backport this to v7, thanks)

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
