### PR TITLE
Rework Antumbra & Eclipse

### DIFF
--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -1121,8 +1121,10 @@ public class UnitTypes{
                 splashDamageRadius = 36f;
                 splashDamage = 60f;
                 ammoMultiplier = 4f;
+                homingPower = 0.02f;
                 lifetime = 35f;
-                hitEffect = Fx.blastExplosion;
+                scaleLife = true;
+                hitEffect = Fx.flakExplosion;
                 despawnEffect = Fx.blastExplosion;
                 collidesTiles = false;
                 status = StatusEffects.blasted;
@@ -1142,6 +1144,7 @@ public class UnitTypes{
                 bullet = missiles;
                 shootSound = Sounds.missileLarge;
                 rotate = true;
+                rotationLimit = 60f;
                 shadow = 6f;
             }},
             new Weapon("large-bullet-mount"){{
@@ -1154,6 +1157,7 @@ public class UnitTypes{
                 bullet = missiles;
                 shootSound = Sounds.missileLarge;
                 rotate = true;
+                rotationLimit = 60f;
                 shadow = 6f;
             }}
             );
@@ -1176,14 +1180,15 @@ public class UnitTypes{
             targetFlags = new BlockFlag[]{BlockFlag.reactor, BlockFlag.battery, BlockFlag.core, null};
             ammoType = new ItemAmmoType(Items.thorium);
 
-            BulletType fragBullet = new BasicBulletType(9f, 45f){{
+            BulletType fragBullet = new BasicBulletType(9f, 50f){{
                 shootEffect = Fx.shootBig;
+                hitEffect = Fx.flakExplosion;
                 width = 9f;
                 height = 16f;
                 hitSize = 6f;
                 ammoMultiplier = 4f;
-                splashDamage = 65f;
-                splashDamageRadius = 25f;
+                splashDamage = 70f;
+                splashDamageRadius = 28f;
                 collidesTiles = false;
                 lifetime = 27f;
                 scaleLife = true;
@@ -1203,7 +1208,7 @@ public class UnitTypes{
                 y = 32f;
                 mirror = false;
                 layerOffset = -0.2f;
-                reload = 210f;
+                reload = 240f;
                 recoil = 4f;
                 chargeSound = Sounds.lasercharge2;
                 shootSound = Sounds.laser;
@@ -1215,12 +1220,13 @@ public class UnitTypes{
                     sprite = "large-orb";
                     chargeEffect = Fx.lancerLaserCharge;
                     hitEffect = new MultiEffect(Fx.titanExplosion, Fx.titanSmoke);
+                    hitSound = Sounds.titanExplosion;
                     width = 18f;
                     height = 18f;
                     hitSize = 8f;
                     ammoMultiplier = 4f;
                     splashDamage = 480f;
-                    splashDamageRadius = 64f;
+                    splashDamageRadius = 40f;
                     collidesTiles = false;
                     lifetime = 34f;
                     scaleLife = true;
@@ -1240,7 +1246,7 @@ public class UnitTypes{
                 x = 15f;
                 y = 28f;
                 rotateSpeed = 2f;
-                reload = 15f;
+                reload = 20f;
                 shootSound = Sounds.mediumCannon;
                 shadow = 7f;
                 rotate = true;
@@ -1251,7 +1257,7 @@ public class UnitTypes{
             new Weapon("large-artillery"){{
                 y = 16f;
                 x = -28f;
-                reload = 15f;
+                reload = 20f;
                 ejectEffect = Fx.casing1;
                 rotateSpeed = 2f;
                 shake = 1f;
@@ -1259,7 +1265,7 @@ public class UnitTypes{
                 rotate = true;
                 shadow = 7f;
                 shootY = 7.25f;
-                shoot.firstShotDelay = 7f;
+                shoot.firstShotDelay = 9f;
                 bullet = fragBullet;
             }});
         }};

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -1096,137 +1096,152 @@ public class UnitTypes{
         }};
 
         antumbra = new UnitType("antumbra"){{
-            speed = 0.8f;
+            speed = 1.05f;
             accel = 0.04f;
             drag = 0.04f;
-            rotateSpeed = 1.9f;
+            rotateSpeed = 2.2f;
             flying = true;
             lowAltitude = true;
-            health = 7200;
-            armor = 9f;
+            health = 6400;
+            armor = 12f;
+            fogRadius = 48f;
             engineOffset = 21;
             engineSize = 5.3f;
-            hitSize = 46f;
+            hitSize = 44f;
             targetFlags = new BlockFlag[]{BlockFlag.generator, BlockFlag.core, null};
+            immunities.add(StatusEffects.wet);
             ammoType = new ItemAmmoType(Items.thorium);
 
-            BulletType missiles = new MissileBulletType(2.7f, 18){{
-                width = 8f;
-                height = 8f;
+            BulletType missiles = new MissileBulletType(6f, 45f){{
+                sprite = "missile-large";
+                width = 14f;
+                height = 20f;
                 shrinkY = 0f;
-                drag = -0.01f;
-                splashDamageRadius = 20f;
-                splashDamage = 37f;
+                drag = -0.001f;
+                splashDamageRadius = 36f;
+                splashDamage = 60f;
                 ammoMultiplier = 4f;
-                lifetime = 50f;
+                lifetime = 35f;
                 hitEffect = Fx.blastExplosion;
                 despawnEffect = Fx.blastExplosion;
-
+                collidesTiles = false;
                 status = StatusEffects.blasted;
                 statusDuration = 60f;
+                incendChance = 0.25f;
+                incendSpread = 5f;
+                incendAmount = 2;
             }};
 
             weapons.add(
-            new Weapon("missiles-mount"){{
-                y = 8f;
-                x = 17f;
-                reload = 20f;
+            new Weapon("large-bullet-mount"){{
+                y = 7f;
+                x = 8f;
+                reload = 30f;
                 ejectEffect = Fx.casing1;
                 rotateSpeed = 8f;
                 bullet = missiles;
-                shootSound = Sounds.missile;
-                rotate = true;
-                shadow = 6f;
-            }},
-            new Weapon("missiles-mount"){{
-                y = -8f;
-                x = 17f;
-                reload = 35;
-                rotateSpeed = 8f;
-                ejectEffect = Fx.casing1;
-                bullet = missiles;
-                shootSound = Sounds.missile;
+                shootSound = Sounds.missileLarge;
                 rotate = true;
                 shadow = 6f;
             }},
             new Weapon("large-bullet-mount"){{
-                y = 2f;
-                x = 10f;
-                shootY = 10f;
-                reload = 12;
-                shake = 1f;
-                rotateSpeed = 2f;
+                y = 7f;
+                x = 20f;
+                reload = 30;
+                shoot.firstShotDelay = 15f;
+                rotateSpeed = 8f;
                 ejectEffect = Fx.casing1;
-                shootSound = Sounds.shootBig;
+                bullet = missiles;
+                shootSound = Sounds.missileLarge;
                 rotate = true;
-                shadow = 8f;
-                bullet = new BasicBulletType(7f, 55){{
-                    width = 12f;
-                    height = 18f;
-                    lifetime = 25f;
-                    shootEffect = Fx.shootBig;
-                }};
+                shadow = 6f;
             }}
             );
         }};
 
         eclipse = new UnitType("eclipse"){{
-            speed = 0.54f;
+            speed = 0.95f;
             accel = 0.04f;
             drag = 0.04f;
-            rotateSpeed = 1f;
+            rotateSpeed = 1.2f;
             flying = true;
             lowAltitude = true;
-            health = 22000;
+            health = 20000;
             engineOffset = 38;
             engineSize = 7.3f;
             hitSize = 58f;
-            armor = 13f;
+            armor = 19f;
+            fogRadius = 72f;
+            immunities = ObjectSet.with(StatusEffects.wet, StatusEffects.sapped);
             targetFlags = new BlockFlag[]{BlockFlag.reactor, BlockFlag.battery, BlockFlag.core, null};
             ammoType = new ItemAmmoType(Items.thorium);
 
-            BulletType fragBullet = new FlakBulletType(4f, 15){{
+            BulletType fragBullet = new BasicBulletType(9f, 45f){{
                 shootEffect = Fx.shootBig;
+                width = 9f;
+                height = 16f;
+                hitSize = 6f;
                 ammoMultiplier = 4f;
                 splashDamage = 65f;
                 splashDamageRadius = 25f;
-                collidesGround = true;
-                lifetime = 47f;
-
+                collidesTiles = false;
+                lifetime = 27f;
+                scaleLife = true;
+                trailEffect = Fx.artilleryTrail;
                 status = StatusEffects.blasted;
                 statusDuration = 60f;
+                incendChance = 0.2f;
+                incendSpread = 5f;
+                incendAmount = 1;
             }};
 
             weapons.add(
             new Weapon("large-laser-mount"){{
                 shake = 4f;
                 shootY = 9f;
-                x = 18f;
-                y = 5f;
-                rotateSpeed = 2f;
-                reload = 45f;
+                x = 0f;
+                y = 32f;
+                mirror = false;
+                layerOffset = -0.2f;
+                reload = 210f;
                 recoil = 4f;
+                chargeSound = Sounds.lasercharge2;
                 shootSound = Sounds.laser;
                 shadow = 20f;
-                rotate = true;
+                rotate = false;
+                shoot.firstShotDelay = Fx.lancerLaserCharge.lifetime - 1f;
 
-                bullet = new LaserBulletType(){{
-                    damage = 115f;
-                    sideAngle = 20f;
-                    sideWidth = 1.5f;
-                    sideLength = 80f;
-                    width = 25f;
-                    length = 230f;
-                    shootEffect = Fx.shockwave;
-                    colors = new Color[]{Color.valueOf("ec7458aa"), Color.valueOf("ff9c5a"), Color.white};
+                bullet = new BasicBulletType(7f, 180f){{
+                    sprite = "large-orb";
+                    chargeEffect = Fx.lancerLaserCharge;
+                    hitEffect = new MultiEffect(Fx.titanExplosion, Fx.titanSmoke);
+                    width = 18f;
+                    height = 18f;
+                    hitSize = 8f;
+                    ammoMultiplier = 4f;
+                    splashDamage = 480f;
+                    splashDamageRadius = 64f;
+                    collidesTiles = false;
+                    lifetime = 34f;
+                    scaleLife = true;
+                    trailLength = 12;
+                    trailWidth = 2.2f;
+                    frontColor = Pal.lightishOrange;
+                    hitColor = backColor = Pal.lightOrange;
+                    trailEffect = Fx.incendTrail;
+                    status = StatusEffects.blasted;
+                    statusDuration = 60f;
+                    incendChance = 0.6f;
+                    incendSpread = 5f;
+                    incendAmount = 3;
                 }};
             }},
             new Weapon("large-artillery"){{
-                x = 11f;
-                y = 27f;
+                x = 15f;
+                y = 28f;
                 rotateSpeed = 2f;
-                reload = 9f;
-                shootSound = Sounds.shoot;
+                reload = 15f;
+                shootSound = Sounds.mediumCannon;
                 shadow = 7f;
                 rotate = true;
                 recoil = 0.5f;
@@ -1234,16 +1249,17 @@ public class UnitTypes{
                 bullet = fragBullet;
             }},
             new Weapon("large-artillery"){{
-                y = -13f;
-                x = 20f;
-                reload = 12f;
+                y = 16f;
+                x = -28f;
+                reload = 15f;
                 ejectEffect = Fx.casing1;
-                rotateSpeed = 7f;
+                rotateSpeed = 2f;
                 shake = 1f;
-                shootSound = Sounds.shoot;
+                shootSound = Sounds.mediumCannon;
                 rotate = true;
-                shadow = 12f;
+                shadow = 7f;
                 shootY = 7.25f;
+                shoot.firstShotDelay = 7f;
                 bullet = fragBullet;
             }});
         }};

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -1103,7 +1103,7 @@ public class UnitTypes{
             flying = true;
             lowAltitude = true;
             health = 6400;
-            armor = 12f;
+            armor = 16f;
             fogRadius = 48f;
             engineOffset = 21;
             engineSize = 5.3f;
@@ -1170,11 +1170,11 @@ public class UnitTypes{
             rotateSpeed = 1.2f;
             flying = true;
             lowAltitude = true;
-            health = 17000;
+            health = 18000;
             engineOffset = 38;
             engineSize = 7.3f;
             hitSize = 58f;
-            armor = 19f;
+            armor = 22f;
             fogRadius = 72f;
             immunities = ObjectSet.with(StatusEffects.wet, StatusEffects.sapped);
             targetFlags = new BlockFlag[]{BlockFlag.reactor, BlockFlag.battery, BlockFlag.core, null};
@@ -1190,7 +1190,7 @@ public class UnitTypes{
                 splashDamage = 120f;
                 splashDamageRadius = 28f;
                 collidesTiles = false;
-                lifetime = 27f;
+                lifetime = 28f;
                 scaleLife = true;
                 trailEffect = Fx.artilleryTrail;
                 status = StatusEffects.blasted;
@@ -1208,12 +1208,14 @@ public class UnitTypes{
                 y = 30f;
                 mirror = false;
                 layerOffset = -0.2f;
-                reload = 270f;
+                reload = 240f;
                 recoil = 4f;
                 chargeSound = Sounds.lasercharge2;
                 shootSound = Sounds.laser;
                 shadow = 20f;
-                rotate = false;
+                rotate = true;
+                rotateSpeed = 0.8f;
+                rotationLimit = 50f;
                 shoot.firstShotDelay = Fx.lancerLaserCharge.lifetime - 1f;
 
                 bullet = new BasicBulletType(7f, 180f){{
@@ -1227,7 +1229,7 @@ public class UnitTypes{
                     splashDamage = 640f;
                     splashDamageRadius = 40f;
                     collidesTiles = false;
-                    lifetime = 34f;
+                    lifetime = 36f;
                     scaleLife = true;
                     trailLength = 12;
                     trailWidth = 2.2f;

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -1112,14 +1112,14 @@ public class UnitTypes{
             immunities.add(StatusEffects.wet);
             ammoType = new ItemAmmoType(Items.thorium);
 
-            BulletType missiles = new MissileBulletType(6f, 45f){{
+            BulletType missiles = new MissileBulletType(6f, 60f){{
                 sprite = "missile-large";
                 width = 14f;
                 height = 20f;
                 shrinkY = 0f;
                 drag = -0.001f;
                 splashDamageRadius = 36f;
-                splashDamage = 60f;
+                splashDamage = 80f;
                 ammoMultiplier = 4f;
                 homingPower = 0.02f;
                 lifetime = 35f;
@@ -1170,7 +1170,7 @@ public class UnitTypes{
             rotateSpeed = 1.2f;
             flying = true;
             lowAltitude = true;
-            health = 20000;
+            health = 17000;
             engineOffset = 38;
             engineSize = 7.3f;
             hitSize = 58f;
@@ -1180,14 +1180,14 @@ public class UnitTypes{
             targetFlags = new BlockFlag[]{BlockFlag.reactor, BlockFlag.battery, BlockFlag.core, null};
             ammoType = new ItemAmmoType(Items.thorium);
 
-            BulletType fragBullet = new BasicBulletType(9f, 50f){{
+            BulletType fragBullet = new BasicBulletType(9f, 80f){{
                 shootEffect = Fx.shootBig;
                 hitEffect = Fx.flakExplosion;
                 width = 9f;
                 height = 16f;
                 hitSize = 6f;
                 ammoMultiplier = 4f;
-                splashDamage = 70f;
+                splashDamage = 120f;
                 splashDamageRadius = 28f;
                 collidesTiles = false;
                 lifetime = 27f;
@@ -1205,10 +1205,10 @@ public class UnitTypes{
                 shake = 4f;
                 shootY = 9f;
                 x = 0f;
-                y = 32f;
+                y = 30f;
                 mirror = false;
                 layerOffset = -0.2f;
-                reload = 240f;
+                reload = 270f;
                 recoil = 4f;
                 chargeSound = Sounds.lasercharge2;
                 shootSound = Sounds.laser;
@@ -1221,11 +1221,10 @@ public class UnitTypes{
                     chargeEffect = Fx.lancerLaserCharge;
                     hitEffect = new MultiEffect(Fx.titanExplosion, Fx.titanSmoke);
                     hitSound = Sounds.titanExplosion;
-                    width = 18f;
-                    height = 18f;
+                    width = height = 20f;
                     hitSize = 8f;
                     ammoMultiplier = 4f;
-                    splashDamage = 480f;
+                    splashDamage = 640f;
                     splashDamageRadius = 40f;
                     collidesTiles = false;
                     lifetime = 34f;


### PR DESCRIPTION
Changes make these units actually useful to beat new endgame maps.

Longer range helps compensate large hit-size of these units when used in groups, but if player choose to out-range enemy defense then units at the back could not contribute to damage output.

Both unit gets better moving speed & armor but reduced health, also projectiles not collide tiles(as they come from above) to fit air unit characteristic & encourage defender to use point defense, shield or tractor beam.

Both unit got wet immunity to better survive surge turret synergy. Also both unit got incendiary weapon to be actual threat to areas lack of fire protection.

Antumbra uses missile, as a direct upgrade from Zenith.
Eclipse gets strong cannons on both sides & slow-firing energy weapon in the middle to better fit the battle cruiser vibe.

Alternative download link of JAR file on Discord: https://discord.com/channels/391020510269669376/813425645518061678/1350853681855336573

<img width="280" alt="image" src="https://github.com/user-attachments/assets/c86121f8-26f3-483b-aabc-299f4818102a" />

<img width="396" alt="image" src="https://github.com/user-attachments/assets/ab005506-e191-4a90-b949-8458cc7726f9" />

![antum1](https://github.com/user-attachments/assets/0cef3c13-db36-4a11-81da-0289611ba6d4)

![eclipse](https://github.com/user-attachments/assets/03e3f70a-2a8a-4ff7-b6ae-53d08273201c)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
