### PR TITLE
Rework sceptor reign

### DIFF
--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -242,28 +242,28 @@ public class UnitTypes{
             }},
 
             new Weapon("large-artillery"){{
-                reload = 48f;
+                reload = 75f;
                 x = 8.5f;
                 y = -3f;
                 rotate = true;
                 rotationLimit = 60f;
                 shootSound = Sounds.artillery;
                 ejectEffect = Fx.casing3Double;
-                bullet = new BasicBulletType(7f, 20f){{
+                bullet = new BasicBulletType(4f, 80f){{
                         width = 14f;
                         height = 24f;
                         absorbable = false;
                         reflectable = false;
-                        lifetime = 33f;
+                        lifetime = 58f;
                         hitColor = backColor = trailColor = Pal.lightPyraFlame;
                         hitEffect = Fx.flakExplosion;
                         pierce = true;
                         pierceCap = 2;
                         pierceBuilding = true;
-                        lightning = 4;
+                        lightning = 5;
                         lightningLength = 7;
                         lightningColor = Pal.surge;
-                        lightningDamage = 40;
+                        lightningDamage = 60;
                         lightningCone = 120f;
                         incendChance = 0.2f;
                         incendSpread = 5f;
@@ -274,7 +274,7 @@ public class UnitTypes{
         }};
 
         reign = new UnitType("reign"){{
-            speed = 0.5f;
+            speed = 0.53f;
             hitSize = 30f;
             rotateSpeed = 1.65f;
             health = 27000;
@@ -294,14 +294,14 @@ public class UnitTypes{
                 x = 21.5f;
                 shootY = 11f;
                 reload = 30f;
-                shoot.shots = 20;
+                shoot.shots = 15;
                 velocityRnd = 0.3f;
                 shake = 2f;
                 inaccuracy = 7f;
                 shootSound = Sounds.flame;
 
                 bullet = new LiquidBulletType(Liquids.slag){{
-                    lifetime = 30f;
+                    lifetime = 32f;
                     scaleLife = true;
                     speed = 8f;
                     puddleSize = 28f;
@@ -335,7 +335,7 @@ public class UnitTypes{
                         height = 24f;
                         absorbable = false;
                         reflectable = false;
-                        lifetime = 40f;
+                        lifetime = 43f;
                         hitColor = backColor = trailColor = Pal.surge;
                         hitEffect = Fx.scatheExplosion;
                         status = StatusEffects.burning;
@@ -359,7 +359,7 @@ public class UnitTypes{
                         height = 24f;
                         absorbable = false;
                         reflectable = false;
-                        lifetime = 40f;
+                        lifetime = 43f;
                         hitColor = backColor = trailColor = Pal.surge;
                         hitEffect = Fx.scatheExplosion;
                         status = StatusEffects.burning;

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -214,10 +214,10 @@ public class UnitTypes{
                 shoot.shots = 3;
                 shoot.shotDelay = 3f;
 
-                bullet = new BasicBulletType(16f, 40){{
-                    width = 12f;
-                    height = 24f;
-                    hitSize = 6;
+                bullet = new BasicBulletType(16f, 35f){{
+                    width = 10f;
+                    height = 18f;
+                    hitSize = 5f;
                     lifetime = 14f;
                     shootEffect = Fx.shootBig;
                     
@@ -242,7 +242,7 @@ public class UnitTypes{
                 }};
             }},
 
-            new Weapon("large-bullet-mount"){{
+            new Weapon("large-artillery"){{
                 reload = 30f;
                 x = 8.5f;
                 y = -2f;
@@ -250,15 +250,15 @@ public class UnitTypes{
                 rotationLimit = 60f;
                 shootSound = Sounds.artillery;
                 ejectEffect = Fx.casing3Double;
-                bullet = new ArtilleryBulletType(7f, 20){{
-                        width = 6f;
-                        height = 14f;
+                bullet = new ArtilleryBulletType(7f, 20f){{
+                        width = 14f;
+                        height = 24f;
                         absorbable = false;
                         reflectable = false;
                         lifetime = 33f;
                         hitColor = backColor = trailColor = Pal.lightPyraFlame;
                         hitEffect = Fx.flakExplosion;
-                        splashDamage = 80f;
+                        splashDamage = 70f;
                         splashDamageRadius = 40f;
                         makeFire = true;
                     }};
@@ -293,8 +293,8 @@ public class UnitTypes{
                 bullet = new LiquidBulletType(Liquids.slag){{
                     lifetime = 21f;
                     speed = 12f;
-                    puddleSize = 24f;
-                    orbSize = 8f;
+                    puddleSize = 28f;
+                    orbSize = 4f;
                     damage = 35f;
                     statusDuration = 60f * 4f;
                     absorbable = false;
@@ -309,44 +309,44 @@ public class UnitTypes{
                 }};
             }},
 
-            new Weapon("artillery"){{
+            new Weapon("large-bullet-mount"){{
                 reload = 40f;
-                x = 15f;
+                x = 17f;
                 y = -11f;
                 rotate = true;
                 rotationLimit = 60f;
                 shootSound = Sounds.largeCannon;
                 ejectEffect = Fx.casing3Double;
                 bullet = new ArtilleryBulletType(7f, 20){{
-                        width = 6f;
-                        height = 14f;
+                        width = 14f;
+                        height = 24f;
                         absorbable = false;
                         reflectable = false;
                         lifetime = 36f;
                         hitColor = backColor = trailColor = Pal.surge;
                         hitEffect = Fx.flakExplosion;
-                        splashDamage = 150f;
+                        splashDamage = 210f;
                         splashDamageRadius = 48f;
                         fragBullets = 15;
                         fragRandomSpread = 0f;
                         fragSpread = 24f;
                         fragBullet = new LiquidBulletType(Liquids.oil){{
-                            lifetime = 2f;
-                            speed = 8f;
+                            lifetime = 4f;
+                            speed = 4f;
                             absorbable = false;
                             reflectable = false;
-                            collidesTiles = false;
+                            collides = false;
                             puddleSize = 32f;
                             orbSize = 4f;
-                            statusDuration = 60f * 4f;
+                            statusDuration = 60f * 6f;
                             damage = 2f;
                         }};
                     }};
             }},
 
-            new Weapon("artillery"){{
+            new Weapon("large-bullet-mount"){{
                 reload = 40f;
-                x = -9f;
+                x = -7f;
                 y = -11f;
                 rotate = true;
                 rotationLimit = 60f;
@@ -354,8 +354,8 @@ public class UnitTypes{
                 shoot.firstShotDelay = 20f;
                 ejectEffect = Fx.casing3Double;
                 bullet = new ArtilleryBulletType(7f, 20){{
-                        width = 6f;
-                        height = 14f;
+                        width = 14f;
+                        height = 24f;
                         absorbable = false;
                         reflectable = false;
                         lifetime = 36f;
@@ -367,14 +367,14 @@ public class UnitTypes{
                         fragRandomSpread = 0f;
                         fragSpread = 24f;
                         fragBullet = new LiquidBulletType(Liquids.oil){{
-                            lifetime = 2f;
-                            speed = 8f;
+                            lifetime = 4f;
+                            speed = 4f;
                             absorbable = false;
                             reflectable = false;
-                            collidesTiles = false;
+                            collides = false;
                             puddleSize = 32f;
                             orbSize = 4f;
-                            statusDuration = 60f * 4f;
+                            statusDuration = 60f * 6f;
                             damage = 2f;
                         }};
                     }};

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -214,13 +214,12 @@ public class UnitTypes{
                 shoot.shots = 3;
                 shoot.shotDelay = 3f;
 
-                bullet = new BasicBulletType(16f, 35f){{
+                bullet = new BasicBulletType(16f, 30f){{
                     width = 10f;
                     height = 18f;
                     hitSize = 5f;
                     lifetime = 14f;
                     shootEffect = Fx.shootBig;
-                    
                     absorbable = false;
                     reflectable = false;
                     pierceArmor = true;
@@ -243,14 +242,14 @@ public class UnitTypes{
             }},
 
             new Weapon("large-artillery"){{
-                reload = 30f;
+                reload = 48f;
                 x = 8.5f;
                 y = -3f;
                 rotate = true;
                 rotationLimit = 60f;
                 shootSound = Sounds.artillery;
                 ejectEffect = Fx.casing3Double;
-                bullet = new ArtilleryBulletType(7f, 20f){{
+                bullet = new BasicBulletType(7f, 20f){{
                         width = 14f;
                         height = 24f;
                         absorbable = false;
@@ -258,8 +257,13 @@ public class UnitTypes{
                         lifetime = 33f;
                         hitColor = backColor = trailColor = Pal.lightPyraFlame;
                         hitEffect = Fx.flakExplosion;
-                        splashDamage = 70f;
-                        splashDamageRadius = 40f;
+                        pierce = true;
+                        pierceCap = 2;
+                        pierceBuilding = true;
+                        lightning = 4;
+                        lightningLength = 7;
+                        lightningColor = Pal.surge;
+                        lightningDamage = 30;
                         incendChance = 0.2f;
                         incendSpread = 5f;
                         incendAmount = 1;
@@ -288,13 +292,16 @@ public class UnitTypes{
                 y = 1f;
                 x = 21.5f;
                 shootY = 11f;
-                reload = 3f;
+                reload = 20f;
+                shoot.shots = 30;
+                velocityRnd = 0.3f;
                 shake = 2f;
-                inaccuracy = 6f;
+                inaccuracy = 7f;
                 shootSound = Sounds.flame;
 
                 bullet = new LiquidBulletType(Liquids.slag){{
-                    lifetime = 31f;
+                    lifetime = 30f;
+                    scaleLife = true;
                     speed = 8f;
                     puddleSize = 28f;
                     orbSize = 4f;
@@ -304,9 +311,10 @@ public class UnitTypes{
                     reflectable = false;
                     pierceArmor = true;
                     pierce = true;
-                    pierceCap = 4;
+                    pierceCap = 3;
                     pierceBuilding = true;
                     makeFire = true;
+                    shootEffect = Fx.shootBig;
                     trailEffect = Fx.missileTrail;
                     trailInterval = 2f;
                     hitEffect = Fx.hitMeltdown;
@@ -314,45 +322,49 @@ public class UnitTypes{
             }},
 
             new Weapon("large-bullet-mount"){{
-                reload = 40f;
+                reload = 80f;
                 x = 16f;
                 y = -8f;
                 rotate = true;
                 rotationLimit = 30f;
                 shootSound = Sounds.mediumCannon;
                 ejectEffect = Fx.casing3Double;
-                bullet = new ArtilleryBulletType(6f, 80f){{
+                bullet = new BasicBulletType(6f, 80f){{
                         width = 14f;
                         height = 24f;
                         absorbable = false;
                         reflectable = false;
-                        lifetime = 41f;
+                        lifetime = 40f;
                         hitColor = backColor = trailColor = Pal.surge;
-                        hitEffect = Fx.flakExplosion;
-                        splashDamage = 210f;
-                        splashDamageRadius = 48f; 
+                        hitEffect = Fx.impactReactorExplosion;
+                        status = StatusEffects.burning;
+                        statusDuration = 60f * 4f;
+                        splashDamage = 270f;
+                        splashDamageRadius = 64f; 
                     }};
             }},
 
             new Weapon("large-bullet-mount"){{
-                reload = 40f;
+                reload = 80f;
                 x = -9f;
                 y = -8f;
                 rotate = true;
                 rotationLimit = 30f;
                 shootSound = Sounds.mediumCannon;
-                shoot.firstShotDelay = 20f;
+                shoot.firstShotDelay = 40f;
                 ejectEffect = Fx.casing3Double;
-                bullet = new ArtilleryBulletType(6f, 80f){{
+                bullet = new BasicBulletType(6f, 80f){{
                         width = 14f;
                         height = 24f;
                         absorbable = false;
                         reflectable = false;
-                        lifetime = 41f;
+                        lifetime = 40f;
                         hitColor = backColor = trailColor = Pal.surge;
-                        hitEffect = Fx.flakExplosion;
-                        splashDamage = 210f;
-                        splashDamageRadius = 48f;
+                        hitEffect = Fx.impactReactorExplosion;
+                        status = StatusEffects.burning;
+                        statusDuration = 60f * 4f;
+                        splashDamage = 270f;
+                        splashDamageRadius = 64f;
                     }};
             }}
             );

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -303,8 +303,6 @@ public class UnitTypes{
                     pierce = true;
                     pierceCap = 4;
                     pierceBuilding = true;
-                    frontColor = Pal.lightishOrange;
-                    backColor = Pal.lightOrange;
                     makeFire = true;
                     trailEffect = Fx.incendTrail;
                     hitEffect = Fx.hitMeltdown;

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -214,7 +214,7 @@ public class UnitTypes{
                 shoot.shots = 3;
                 shoot.shotDelay = 3f;
 
-                bullet = new BasicBulletType(16f, 30f){{
+                bullet = new BasicBulletType(16f, 50f){{
                     width = 10f;
                     height = 18f;
                     hitSize = 5f;
@@ -235,7 +235,7 @@ public class UnitTypes{
                         pierceBuilding = true;
                         puddleSize = 16f;
                         orbSize = 4f;
-                        damage = 30f;
+                        damage = 20f;
                         statusDuration = 60f * 4f;
                     }};
                 }};
@@ -263,7 +263,8 @@ public class UnitTypes{
                         lightning = 4;
                         lightningLength = 7;
                         lightningColor = Pal.surge;
-                        lightningDamage = 30;
+                        lightningDamage = 40;
+                        lightningCone = 120f;
                         incendChance = 0.2f;
                         incendSpread = 5f;
                         incendAmount = 1;
@@ -292,7 +293,7 @@ public class UnitTypes{
                 y = 1f;
                 x = 21.5f;
                 shootY = 11f;
-                reload = 20f;
+                reload = 30f;
                 shoot.shots = 30;
                 velocityRnd = 0.3f;
                 shake = 2f;
@@ -329,17 +330,17 @@ public class UnitTypes{
                 rotationLimit = 30f;
                 shootSound = Sounds.mediumCannon;
                 ejectEffect = Fx.casing3Double;
-                bullet = new BasicBulletType(6f, 80f){{
+                bullet = new BasicBulletType(6f, 70f){{
                         width = 14f;
                         height = 24f;
                         absorbable = false;
                         reflectable = false;
                         lifetime = 40f;
                         hitColor = backColor = trailColor = Pal.surge;
-                        hitEffect = Fx.impactReactorExplosion;
+                        hitEffect = Fx.scatheExplosion;
                         status = StatusEffects.burning;
                         statusDuration = 60f * 4f;
-                        splashDamage = 270f;
+                        splashDamage = 210f;
                         splashDamageRadius = 64f; 
                     }};
             }},
@@ -353,17 +354,17 @@ public class UnitTypes{
                 shootSound = Sounds.mediumCannon;
                 shoot.firstShotDelay = 40f;
                 ejectEffect = Fx.casing3Double;
-                bullet = new BasicBulletType(6f, 80f){{
+                bullet = new BasicBulletType(6f, 70f){{
                         width = 14f;
                         height = 24f;
                         absorbable = false;
                         reflectable = false;
                         lifetime = 40f;
                         hitColor = backColor = trailColor = Pal.surge;
-                        hitEffect = Fx.impactReactorExplosion;
+                        hitEffect = Fx.scatheExplosion;
                         status = StatusEffects.burning;
                         statusDuration = 60f * 4f;
-                        splashDamage = 270f;
+                        splashDamage = 210f;
                         splashDamageRadius = 64f;
                     }};
             }}

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -187,8 +187,8 @@ public class UnitTypes{
             speed = 0.65f;
             hitSize = 22f;
             rotateSpeed = 2.4f;
-            health = 9000;
-            armor = 18f;
+            health = 9800;
+            armor = 22f;
             mechFrontSway = 1f;
             ammoType = new ItemAmmoType(Items.thorium);
 
@@ -274,11 +274,11 @@ public class UnitTypes{
         }};
 
         reign = new UnitType("reign"){{
-            speed = 0.55f;
+            speed = 0.5f;
             hitSize = 30f;
             rotateSpeed = 1.65f;
-            health = 24000;
-            armor = 30f;
+            health = 27000;
+            armor = 36f;
             mechStepParticles = true;
             stepShake = 0.75f;
             drownTimeMultiplier = 6f;
@@ -306,7 +306,7 @@ public class UnitTypes{
                     speed = 8f;
                     puddleSize = 28f;
                     orbSize = 4f;
-                    damage = 35f;
+                    damage = 55f;
                     statusDuration = 60f * 4f;
                     absorbable = false;
                     reflectable = false;
@@ -330,7 +330,7 @@ public class UnitTypes{
                 rotationLimit = 30f;
                 shootSound = Sounds.mediumCannon;
                 ejectEffect = Fx.casing3Double;
-                bullet = new BasicBulletType(6f, 70f){{
+                bullet = new BasicBulletType(6f, 90f){{
                         width = 14f;
                         height = 24f;
                         absorbable = false;
@@ -340,7 +340,7 @@ public class UnitTypes{
                         hitEffect = Fx.scatheExplosion;
                         status = StatusEffects.burning;
                         statusDuration = 60f * 4f;
-                        splashDamage = 210f;
+                        splashDamage = 360f;
                         splashDamageRadius = 64f; 
                     }};
             }},
@@ -354,7 +354,7 @@ public class UnitTypes{
                 shootSound = Sounds.mediumCannon;
                 shoot.firstShotDelay = 40f;
                 ejectEffect = Fx.casing3Double;
-                bullet = new BasicBulletType(6f, 70f){{
+                bullet = new BasicBulletType(6f, 90f){{
                         width = 14f;
                         height = 24f;
                         absorbable = false;
@@ -364,7 +364,7 @@ public class UnitTypes{
                         hitEffect = Fx.scatheExplosion;
                         status = StatusEffects.burning;
                         statusDuration = 60f * 4f;
-                        splashDamage = 210f;
+                        splashDamage = 360f;
                         splashDamageRadius = 64f;
                     }};
             }}

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -233,7 +233,7 @@ public class UnitTypes{
                         pierceArmor = true;
                         puddleSize = 16f;
                         orbSize = 4f;
-                        damage = 20f;
+                        damage = 30f;
                         statusDuration = 60f * 4f;
                     }};
                 }};
@@ -255,10 +255,10 @@ public class UnitTypes{
                         lifetime = 58f;
                         hitColor = backColor = trailColor = Pal.lightPyraFlame;
                         hitEffect = Fx.flakExplosion;
-                        lightning = 5;
+                        lightning = 3;
                         lightningLength = 7;
                         lightningColor = Pal.surge;
-                        lightningDamage = 40;
+                        lightningDamage = 50;
                         lightningCone = 120f;
                         incendChance = 0.2f;
                         incendSpread = 5f;
@@ -289,7 +289,7 @@ public class UnitTypes{
                 x = 21.5f;
                 shootY = 11f;
                 reload = 30f;
-                shoot.shots = 12;
+                shoot.shots = 15;
                 velocityRnd = 0.2f;
                 shake = 2f;
                 inaccuracy = 7f;
@@ -301,7 +301,7 @@ public class UnitTypes{
                     speed = 8f;
                     puddleSize = 28f;
                     orbSize = 4f;
-                    damage = 45f;
+                    damage = 60f;
                     statusDuration = 60f * 4f;
                     absorbable = false;
                     reflectable = false;
@@ -336,7 +336,7 @@ public class UnitTypes{
                         status = StatusEffects.burning;
                         statusDuration = 60f * 4f;
                         splashDamage = 300f;
-                        splashDamageRadius = 64f; 
+                        splashDamageRadius = 72f; 
                     }};
             }},
 
@@ -360,7 +360,7 @@ public class UnitTypes{
                         status = StatusEffects.burning;
                         statusDuration = 60f * 4f;
                         splashDamage = 300f;
-                        splashDamageRadius = 64f;
+                        splashDamageRadius = 72f;
                     }};
             }}
             );

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -184,7 +184,7 @@ public class UnitTypes{
         }};
 
         scepter = new UnitType("scepter"){{
-            speed = 0.75f;
+            speed = 0.65f;
             hitSize = 22f;
             rotateSpeed = 2.4f;
             health = 9000;
@@ -197,7 +197,7 @@ public class UnitTypes{
             singleTarget = true;
             drownTimeMultiplier = 4f;
 
-            immunities = ObjectSet.with(StatusEffects.electrified, StatusEffects.melting);
+            immunities = ObjectSet.with(StatusEffects.electrified, StatusEffects.shocked);
 
             weapons.add(
             new Weapon("scepter-weapon"){{
@@ -245,7 +245,7 @@ public class UnitTypes{
             new Weapon("large-artillery"){{
                 reload = 30f;
                 x = 8.5f;
-                y = -2f;
+                y = -3f;
                 rotate = true;
                 rotationLimit = 60f;
                 shootSound = Sounds.artillery;
@@ -260,14 +260,16 @@ public class UnitTypes{
                         hitEffect = Fx.flakExplosion;
                         splashDamage = 70f;
                         splashDamageRadius = 40f;
-                        makeFire = true;
+                        incendChance = 0.2f;
+                        incendSpread = 5f;
+                        incendAmount = 1;
                     }};
             }}
             );
         }};
 
         reign = new UnitType("reign"){{
-            speed = 0.625f;
+            speed = 0.55f;
             hitSize = 30f;
             rotateSpeed = 1.65f;
             health = 24000;
@@ -277,6 +279,7 @@ public class UnitTypes{
             drownTimeMultiplier = 6f;
             mechFrontSway = 1.9f;
             mechSideSway = 0.6f;
+            immunities = ObjectSet.with(StatusEffects.burning, StatusEffects.melting);
             ammoType = new ItemAmmoType(Items.thorium);
 
             weapons.add(
@@ -291,8 +294,8 @@ public class UnitTypes{
                 shootSound = Sounds.flame;
 
                 bullet = new LiquidBulletType(Liquids.slag){{
-                    lifetime = 21f;
-                    speed = 12f;
+                    lifetime = 31f;
+                    speed = 8f;
                     puddleSize = 28f;
                     orbSize = 4f;
                     damage = 35f;
@@ -304,79 +307,52 @@ public class UnitTypes{
                     pierceCap = 4;
                     pierceBuilding = true;
                     makeFire = true;
-                    trailEffect = Fx.incendTrail;
+                    trailEffect = Fx.missileTrail;
+                    trailInterval = 2f;
                     hitEffect = Fx.hitMeltdown;
                 }};
             }},
 
             new Weapon("large-bullet-mount"){{
                 reload = 40f;
-                x = 17f;
-                y = -11f;
+                x = 16f;
+                y = -8f;
                 rotate = true;
-                rotationLimit = 60f;
-                shootSound = Sounds.largeCannon;
+                rotationLimit = 30f;
+                shootSound = Sounds.mediumCannon;
                 ejectEffect = Fx.casing3Double;
-                bullet = new ArtilleryBulletType(7f, 20){{
+                bullet = new ArtilleryBulletType(6f, 80f){{
                         width = 14f;
                         height = 24f;
                         absorbable = false;
                         reflectable = false;
-                        lifetime = 36f;
+                        lifetime = 41f;
                         hitColor = backColor = trailColor = Pal.surge;
                         hitEffect = Fx.flakExplosion;
                         splashDamage = 210f;
-                        splashDamageRadius = 48f;
-                        fragBullets = 15;
-                        fragRandomSpread = 0f;
-                        fragSpread = 24f;
-                        fragBullet = new LiquidBulletType(Liquids.oil){{
-                            lifetime = 4f;
-                            speed = 4f;
-                            absorbable = false;
-                            reflectable = false;
-                            collides = false;
-                            puddleSize = 32f;
-                            orbSize = 4f;
-                            statusDuration = 60f * 6f;
-                            damage = 2f;
-                        }};
+                        splashDamageRadius = 48f; 
                     }};
             }},
 
             new Weapon("large-bullet-mount"){{
                 reload = 40f;
-                x = -7f;
-                y = -11f;
+                x = -9f;
+                y = -8f;
                 rotate = true;
-                rotationLimit = 60f;
-                shootSound = Sounds.largeCannon;
+                rotationLimit = 30f;
+                shootSound = Sounds.mediumCannon;
                 shoot.firstShotDelay = 20f;
                 ejectEffect = Fx.casing3Double;
-                bullet = new ArtilleryBulletType(7f, 20){{
+                bullet = new ArtilleryBulletType(6f, 80f){{
                         width = 14f;
                         height = 24f;
                         absorbable = false;
                         reflectable = false;
-                        lifetime = 36f;
+                        lifetime = 41f;
                         hitColor = backColor = trailColor = Pal.surge;
                         hitEffect = Fx.flakExplosion;
-                        splashDamage = 150f;
+                        splashDamage = 210f;
                         splashDamageRadius = 48f;
-                        fragBullets = 15;
-                        fragRandomSpread = 0f;
-                        fragSpread = 24f;
-                        fragBullet = new LiquidBulletType(Liquids.oil){{
-                            lifetime = 4f;
-                            speed = 4f;
-                            absorbable = false;
-                            reflectable = false;
-                            collides = false;
-                            puddleSize = 32f;
-                            orbSize = 4f;
-                            statusDuration = 60f * 6f;
-                            damage = 2f;
-                        }};
                     }};
             }}
             );

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -184,11 +184,11 @@ public class UnitTypes{
         }};
 
         scepter = new UnitType("scepter"){{
-            speed = 0.36f;
+            speed = 0.75f;
             hitSize = 22f;
-            rotateSpeed = 2.1f;
+            rotateSpeed = 2.4f;
             health = 9000;
-            armor = 10f;
+            armor = 18f;
             mechFrontSway = 1f;
             ammoType = new ItemAmmoType(Items.thorium);
 
@@ -197,13 +197,7 @@ public class UnitTypes{
             singleTarget = true;
             drownTimeMultiplier = 4f;
 
-            abilities.add(new ShieldRegenFieldAbility(25f, 250f, 60f * 1, 60f));
-
-            BulletType smallBullet = new BasicBulletType(3f, 10){{
-                width = 7f;
-                height = 9f;
-                lifetime = 50f;
-            }};
+            immunities = ObjectSet.with(StatusEffects.electrified, StatusEffects.melting);
 
             weapons.add(
             new Weapon("scepter-weapon"){{
@@ -211,54 +205,73 @@ public class UnitTypes{
                 y = 1f;
                 x = 16f;
                 shootY = 8f;
-                reload = 45f;
-                recoil = 5f;
-                shake = 2f;
+                reload = 30f;
+                recoil = 3f;
+                shake = 1f;
                 ejectEffect = Fx.casing3;
-                shootSound = Sounds.bang;
-                inaccuracy = 3f;
-
+                shootSound = Sounds.shotgun;
+                inaccuracy = 1f;
                 shoot.shots = 3;
-                shoot.shotDelay = 4f;
+                shoot.shotDelay = 3f;
 
-                bullet = new BasicBulletType(8f, 80){{
-                    width = 11f;
-                    height = 20f;
-                    lifetime = 27f;
+                bullet = new BasicBulletType(16f, 40){{
+                    width = 12f;
+                    height = 24f;
+                    hitSize = 6;
+                    lifetime = 14f;
                     shootEffect = Fx.shootBig;
-                    lightning = 2;
-                    lightningLength = 6;
-                    lightningColor = Pal.surge;
-                    //standard bullet damage is far too much for lightning
-                    lightningDamage = 20;
+                    
+                    absorbable = false;
+                    reflectable = false;
+                    pierceArmor = true;
+                    fragBullets = 2;
+                    fragRandomSpread = 8f;
+                    fragBullet = new LiquidBulletType(Liquids.slag){{
+                        lifetime = 4f;
+                        speed = 8f;
+                        absorbable = false;
+                        reflectable = false;
+                        pierceArmor = true;
+                        pierce = true;
+                        pierceBuilding = true;
+                        puddleSize = 16f;
+                        orbSize = 4f;
+                        damage = 30f;
+                        statusDuration = 60f * 4f;
+                    }};
                 }};
             }},
 
-            new Weapon("mount-weapon"){{
-                reload = 13f;
+            new Weapon("large-bullet-mount"){{
+                reload = 30f;
                 x = 8.5f;
-                y = 6f;
+                y = -2f;
                 rotate = true;
-                ejectEffect = Fx.casing1;
-                bullet = smallBullet;
-            }},
-            new Weapon("mount-weapon"){{
-                reload = 16f;
-                x = 8.5f;
-                y = -7f;
-                rotate = true;
-                ejectEffect = Fx.casing1;
-                bullet = smallBullet;
+                rotationLimit = 60f;
+                shootSound = Sounds.artillery;
+                ejectEffect = Fx.casing3Double;
+                bullet = new ArtilleryBulletType(7f, 20){{
+                        width = 6f;
+                        height = 14f;
+                        absorbable = false;
+                        reflectable = false;
+                        lifetime = 33f;
+                        hitColor = backColor = trailColor = Pal.lightPyraFlame;
+                        hitEffect = Fx.flakExplosion;
+                        splashDamage = 80f;
+                        splashDamageRadius = 40f;
+                        makeFire = true;
+                    }};
             }}
             );
         }};
 
         reign = new UnitType("reign"){{
-            speed = 0.4f;
+            speed = 0.625f;
             hitSize = 30f;
             rotateSpeed = 1.65f;
             health = 24000;
-            armor = 18f;
+            armor = 30f;
             mechStepParticles = true;
             stepShake = 0.75f;
             drownTimeMultiplier = 6f;
@@ -272,44 +285,102 @@ public class UnitTypes{
                 y = 1f;
                 x = 21.5f;
                 shootY = 11f;
-                reload = 9f;
-                recoil = 5f;
+                reload = 3f;
                 shake = 2f;
-                ejectEffect = Fx.casing4;
-                shootSound = Sounds.bang;
+                inaccuracy = 6f;
+                shootSound = Sounds.flame;
 
-                bullet = new BasicBulletType(13f, 80){{
+                bullet = new LiquidBulletType(Liquids.slag){{
+                    lifetime = 21f;
+                    speed = 12f;
+                    puddleSize = 24f;
+                    orbSize = 8f;
+                    damage = 35f;
+                    statusDuration = 60f * 4f;
+                    absorbable = false;
+                    reflectable = false;
+                    pierceArmor = true;
                     pierce = true;
-                    pierceCap = 10;
-                    width = 14f;
-                    height = 33f;
-                    lifetime = 15f;
-                    shootEffect = Fx.shootBig;
-                    fragVelocityMin = 0.4f;
-
-                    hitEffect = Fx.blastExplosion;
-                    splashDamage = 18f;
-                    splashDamageRadius = 13f;
-
-                    fragBullets = 3;
-                    fragLifeMin = 0f;
-                    fragRandomSpread = 30f;
-
-                    fragBullet = new BasicBulletType(9f, 20){{
-                        width = 10f;
-                        height = 10f;
-                        pierce = true;
-                        pierceBuilding = true;
-                        pierceCap = 3;
-
-                        lifetime = 20f;
-                        hitEffect = Fx.flakExplosion;
-                        splashDamage = 15f;
-                        splashDamageRadius = 10f;
-                    }};
+                    pierceCap = 4;
+                    pierceBuilding = true;
+                    frontColor = Pal.lightishOrange;
+                    backColor = Pal.lightOrange;
+                    makeFire = true;
+                    trailEffect = Fx.incendTrail;
+                    hitEffect = Fx.hitMeltdown;
                 }};
-            }}
+            }},
 
+            new Weapon("artillery"){{
+                reload = 40f;
+                x = 15f;
+                y = -11f;
+                rotate = true;
+                rotationLimit = 60f;
+                shootSound = Sounds.largeCannon;
+                ejectEffect = Fx.casing3Double;
+                bullet = new ArtilleryBulletType(7f, 20){{
+                        width = 6f;
+                        height = 14f;
+                        absorbable = false;
+                        reflectable = false;
+                        lifetime = 36f;
+                        hitColor = backColor = trailColor = Pal.surge;
+                        hitEffect = Fx.flakExplosion;
+                        splashDamage = 150f;
+                        splashDamageRadius = 48f;
+                        fragBullets = 15;
+                        fragRandomSpread = 0f;
+                        fragSpread = 24f;
+                        fragBullet = new LiquidBulletType(Liquids.oil){{
+                            lifetime = 2f;
+                            speed = 8f;
+                            absorbable = false;
+                            reflectable = false;
+                            collidesTiles = false;
+                            puddleSize = 32f;
+                            orbSize = 4f;
+                            statusDuration = 60f * 4f;
+                            damage = 2f;
+                        }};
+                    }};
+            }},
+
+            new Weapon("artillery"){{
+                reload = 40f;
+                x = -9f;
+                y = -11f;
+                rotate = true;
+                rotationLimit = 60f;
+                shootSound = Sounds.largeCannon;
+                shoot.firstShotDelay = 20f;
+                ejectEffect = Fx.casing3Double;
+                bullet = new ArtilleryBulletType(7f, 20){{
+                        width = 6f;
+                        height = 14f;
+                        absorbable = false;
+                        reflectable = false;
+                        lifetime = 36f;
+                        hitColor = backColor = trailColor = Pal.surge;
+                        hitEffect = Fx.flakExplosion;
+                        splashDamage = 150f;
+                        splashDamageRadius = 48f;
+                        fragBullets = 15;
+                        fragRandomSpread = 0f;
+                        fragSpread = 24f;
+                        fragBullet = new LiquidBulletType(Liquids.oil){{
+                            lifetime = 2f;
+                            speed = 8f;
+                            absorbable = false;
+                            reflectable = false;
+                            collidesTiles = false;
+                            puddleSize = 32f;
+                            orbSize = 4f;
+                            statusDuration = 60f * 4f;
+                            damage = 2f;
+                        }};
+                    }};
+            }}
             );
         }};
 

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -209,9 +209,9 @@ public class UnitTypes{
                 recoil = 3f;
                 shake = 1f;
                 ejectEffect = Fx.casing3;
-                shootSound = Sounds.shotgun;
+                shootSound = Sounds.dullExplosion;
                 inaccuracy = 1f;
-                shoot.shots = 4;
+                shoot.shots = 3;
                 shoot.shotDelay = 3f;
 
                 bullet = new BasicBulletType(16f, 50f){{
@@ -231,8 +231,6 @@ public class UnitTypes{
                         absorbable = false;
                         reflectable = false;
                         pierceArmor = true;
-                        pierce = true;
-                        pierceBuilding = true;
                         puddleSize = 16f;
                         orbSize = 4f;
                         damage = 20f;
@@ -257,13 +255,10 @@ public class UnitTypes{
                         lifetime = 58f;
                         hitColor = backColor = trailColor = Pal.lightPyraFlame;
                         hitEffect = Fx.flakExplosion;
-                        pierce = true;
-                        pierceCap = 2;
-                        pierceBuilding = true;
                         lightning = 5;
                         lightningLength = 7;
                         lightningColor = Pal.surge;
-                        lightningDamage = 60;
+                        lightningDamage = 40;
                         lightningCone = 120f;
                         incendChance = 0.2f;
                         incendSpread = 5f;
@@ -294,8 +289,8 @@ public class UnitTypes{
                 x = 21.5f;
                 shootY = 11f;
                 reload = 30f;
-                shoot.shots = 15;
-                velocityRnd = 0.3f;
+                shoot.shots = 12;
+                velocityRnd = 0.2f;
                 shake = 2f;
                 inaccuracy = 7f;
                 shootSound = Sounds.flame;

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -211,7 +211,7 @@ public class UnitTypes{
                 ejectEffect = Fx.casing3;
                 shootSound = Sounds.shotgun;
                 inaccuracy = 1f;
-                shoot.shots = 3;
+                shoot.shots = 4;
                 shoot.shotDelay = 3f;
 
                 bullet = new BasicBulletType(16f, 50f){{
@@ -223,7 +223,7 @@ public class UnitTypes{
                     absorbable = false;
                     reflectable = false;
                     pierceArmor = true;
-                    fragBullets = 2;
+                    fragBullets = 1;
                     fragRandomSpread = 8f;
                     fragBullet = new LiquidBulletType(Liquids.slag){{
                         lifetime = 4f;
@@ -294,7 +294,7 @@ public class UnitTypes{
                 x = 21.5f;
                 shootY = 11f;
                 reload = 30f;
-                shoot.shots = 30;
+                shoot.shots = 20;
                 velocityRnd = 0.3f;
                 shake = 2f;
                 inaccuracy = 7f;
@@ -306,7 +306,7 @@ public class UnitTypes{
                     speed = 8f;
                     puddleSize = 28f;
                     orbSize = 4f;
-                    damage = 55f;
+                    damage = 45f;
                     statusDuration = 60f * 4f;
                     absorbable = false;
                     reflectable = false;
@@ -340,7 +340,7 @@ public class UnitTypes{
                         hitEffect = Fx.scatheExplosion;
                         status = StatusEffects.burning;
                         statusDuration = 60f * 4f;
-                        splashDamage = 360f;
+                        splashDamage = 300f;
                         splashDamageRadius = 64f; 
                     }};
             }},
@@ -364,7 +364,7 @@ public class UnitTypes{
                         hitEffect = Fx.scatheExplosion;
                         status = StatusEffects.burning;
                         statusDuration = 60f * 4f;
-                        splashDamage = 360f;
+                        splashDamage = 300f;
                         splashDamageRadius = 64f;
                     }};
             }}

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -221,10 +221,11 @@ public class UnitTypes{
                     lifetime = 14f;
                     shootEffect = Fx.shootBig;
                     absorbable = false;
-                    reflectable = false;
-                    pierceArmor = true;
+                    pierce = true;
+                    pierceCap = 2;
+                    pierceBuilding = true;
                     fragBullets = 1;
-                    fragRandomSpread = 8f;
+                    fragRandomSpread = 0f;
                     fragBullet = new LiquidBulletType(Liquids.slag){{
                         lifetime = 4f;
                         speed = 8f;
@@ -244,7 +245,8 @@ public class UnitTypes{
                 x = 8.5f;
                 y = -3f;
                 rotate = true;
-                rotationLimit = 60f;
+                rotationLimit = 40f;
+                rotateSpeed = 0.7f;
                 shootSound = Sounds.artillery;
                 ejectEffect = Fx.casing3Double;
                 bullet = new BasicBulletType(4f, 80f){{
@@ -256,13 +258,13 @@ public class UnitTypes{
                         hitColor = backColor = trailColor = Pal.lightPyraFlame;
                         hitEffect = Fx.flakExplosion;
                         lightning = 3;
-                        lightningLength = 7;
+                        lightningLength = 11;
                         lightningColor = Pal.surge;
-                        lightningDamage = 50;
+                        lightningDamage = 55;
                         lightningCone = 120f;
-                        incendChance = 0.2f;
+                        incendChance = 0.3f;
                         incendSpread = 5f;
-                        incendAmount = 1;
+                        incendAmount = 2;
                     }};
             }}
             );
@@ -291,8 +293,8 @@ public class UnitTypes{
                 reload = 30f;
                 shoot.shots = 15;
                 velocityRnd = 0.2f;
-                shake = 2f;
-                inaccuracy = 7f;
+                shake = 1f;
+                inaccuracy = 5f;
                 shootSound = Sounds.flame;
 
                 bullet = new LiquidBulletType(Liquids.slag){{
@@ -323,6 +325,7 @@ public class UnitTypes{
                 y = -8f;
                 rotate = true;
                 rotationLimit = 30f;
+                rotateSpeed = 0.7f;
                 shootSound = Sounds.mediumCannon;
                 ejectEffect = Fx.casing3Double;
                 bullet = new BasicBulletType(6f, 90f){{
@@ -346,6 +349,7 @@ public class UnitTypes{
                 y = -8f;
                 rotate = true;
                 rotationLimit = 30f;
+                rotateSpeed = 0.7f;
                 shootSound = Sounds.mediumCannon;
                 shoot.firstShotDelay = 40f;
                 ejectEffect = Fx.casing3Double;


### PR DESCRIPTION
Both units get better mobility & survivability.

Both units get shield-piercing slag weapon & shoulder-mount cannon, specialized in siege while also offer good defensive fire power against units.

Scepter's fast moving bullet provides good air-defense while cannon shell defeats shield with ease.

Reign got supreme fire power to compensate slow movement & large hit-size.

Alternative download link of JAR file on Discord: https://discord.com/channels/391020510269669376/813425645518061678/1353191849682272296

<img width="281" alt="image" src="https://github.com/user-attachments/assets/c2d12232-9c69-4793-8159-7cfed8c14480" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/5b842e49-574c-4f22-ae54-dd7d9a68e18e" />

![scepter1](https://github.com/user-attachments/assets/735c8106-afcf-4a17-bebb-c91f8ee52881)

![reign1](https://github.com/user-attachments/assets/66dd6b50-67a9-40c6-b675-a1bd0d4c5bbb)



If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
