### PR TITLE
Made unitcap variable for logic

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -2507,6 +2507,8 @@ lglobal.@waveTime = Countdown timer for waves, in seconds
 lglobal.@mapw = Map width in tiles
 lglobal.@maph = Map height in tiles
 
+lglobal.@unitcap = The maximum number of units that can be on the map at once, based on the processor's team
+
 lglobal.sectionMap = Map
 lglobal.sectionGeneral = General
 lglobal.sectionNetwork = Network/Clientside [World Processor Only]

--- a/core/src/mindustry/logic/GlobalVars.java
+++ b/core/src/mindustry/logic/GlobalVars.java
@@ -46,6 +46,7 @@ public class GlobalVars{
         putEntryOnly("@thisy");
         putEntryOnly("@links");
         putEntryOnly("@ipt");
+        putEntryOnly("@unitcap");
 
         putEntryOnly("sectionGeneral");
 

--- a/core/src/mindustry/logic/LAssembler.java
+++ b/core/src/mindustry/logic/LAssembler.java
@@ -27,6 +27,8 @@ public class LAssembler{
         putConst("@unit", null);
         //reference to self
         putConst("@this", null);
+        //maps unitcap
+        putConst("@unitcap", 0);
     }
 
     public static LAssembler assemble(String data, boolean privileged){

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -45,8 +45,9 @@ public class LExecutor{
     public LInstruction[] instructions = {};
     /** Non-constant variables used for network sync */
     public LVar[] vars = {};
+    public LAssembler assembler;
 
-    public LVar counter, unit, thisv, ipt, unitcap;
+    public LVar counter, unit, thisv, ipt;
 
     public int[] binds;
     public boolean yield;
@@ -94,6 +95,7 @@ public class LExecutor{
 
     /** Loads with a specified assembler. Resets all variables. */
     public void load(LAssembler builder){
+        assembler = builder;
         nameMap = null;
         vars = builder.vars.values().toSeq().retainAll(var -> !var.constant).toArray(LVar.class);
         for(int i = 0; i < vars.length; i++){
@@ -104,7 +106,6 @@ public class LExecutor{
         counter = builder.getVar("@counter");
         unit = builder.getVar("@unit");
         thisv = builder.getVar("@this");
-        unitcap = builder.putConst("@unitcap", Math.max(0, state.rules.unitCapVariable ? state.rules.unitCap + team.data().unitCap : state.rules.unitCap));
         ipt = builder.putConst("@ipt", build != null ? build.ipt : 0);
     }
 

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -46,7 +46,7 @@ public class LExecutor{
     /** Non-constant variables used for network sync */
     public LVar[] vars = {};
 
-    public LVar counter, unit, thisv, ipt;
+    public LVar counter, unit, thisv, ipt, unitcap;
 
     public int[] binds;
     public boolean yield;
@@ -104,6 +104,7 @@ public class LExecutor{
         counter = builder.getVar("@counter");
         unit = builder.getVar("@unit");
         thisv = builder.getVar("@this");
+        unitcap = builder.putConst("@unitcap", Math.max(0, state.rules.unitCapVariable ? state.rules.unitCap + team.data().unitCap : state.rules.unitCap));
         ipt = builder.putConst("@ipt", build != null ? build.ipt : 0);
     }
 

--- a/core/src/mindustry/logic/LVar.java
+++ b/core/src/mindustry/logic/LVar.java
@@ -97,8 +97,14 @@ public class LVar{
     }
 
     public void setconst(Object value){
-        objval = value;
-        isobj = true;
+        if(value instanceof Number number){
+            numval = number.doubleValue();
+            objval = null;
+            isobj = false;
+        }else{
+            objval = value;
+            isobj = true;
+        }
     }
 
     public static boolean invalid(double d){

--- a/core/src/mindustry/world/blocks/logic/LogicBlock.java
+++ b/core/src/mindustry/world/blocks/logic/LogicBlock.java
@@ -406,6 +406,7 @@ public class LogicBlock extends Block{
                     asm.getVar("@this").setconst(this);
                     asm.putConst("@thisx", World.conv(x));
                     asm.putConst("@thisy", World.conv(y));
+                    asm.putConst("@unitcap", Math.max(0, state.rules.unitCapVariable ? state.rules.unitCap + executor.team.data().unitCap : state.rules.unitCap));
 
                     executor.load(asm);
                     executor.unit.objval = oldUnit;
@@ -471,6 +472,8 @@ public class LogicBlock extends Block{
             }
 
             executor.team = team;
+            executor.unitcap.setconst(Math.max(0, state.rules.unitCapVariable ? state.rules.unitCap + team.data().unitCap : state.rules.unitCap));
+            
 
             if(!checkedDuplicates){
                 checkedDuplicates = true;

--- a/core/src/mindustry/world/blocks/logic/LogicBlock.java
+++ b/core/src/mindustry/world/blocks/logic/LogicBlock.java
@@ -472,8 +472,10 @@ public class LogicBlock extends Block{
             }
 
             executor.team = team;
-            executor.unitcap.setconst(Math.max(0, state.rules.unitCapVariable ? state.rules.unitCap + team.data().unitCap : state.rules.unitCap));
-            
+            // update unitcap variable
+            if(executor.assembler != null){
+                executor.assembler.getVar("@unitcap").setconst(Math.max(0, state.rules.unitCapVariable ? state.rules.unitCap + team.data().unitCap : state.rules.unitCap));
+            }
 
             if(!checkedDuplicates){
                 checkedDuplicates = true;


### PR DESCRIPTION
Made logic @unitcap global variable, this allows processors to access their team's unitcap amount.

Begon the awful current ucap counting methods

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
