### PR TITLE
fix: correct loop variable from i to j in TilePreChangeEvent's nearby check

### DIFF
--- a/core/src/mindustry/ai/Pathfinder.java
+++ b/core/src/mindustry/ai/Pathfinder.java
@@ -159,7 +159,7 @@ public class Pathfinder implements Runnable{
                         if(!other.solid()){
                             boolean otherNearSolid = false;
                             for(int j = 0; j < 4; j++){
-                                Tile othernear = other.nearby(i);
+                                Tile othernear = other.nearby(j);
                                 if(othernear != null && othernear.solid()){
                                     otherNearSolid = true;
                                     break;


### PR DESCRIPTION
## What was the issue?
In `TilePreChangeEvent` handling, there was a nested loop where:
```java
for(int j = 0; j < 4; j++){
    Tile othernear = other.nearby(i); // ❌ Used `i` instead of `j`
}
```
This caused the inner loop to **always check the same direction** (`i` from outer loop) instead of iterating through all 4 directions.

## What does this fix do?
- Changes `other.nearby(i)` to `other.nearby(j)` to properly check all adjacent tiles.

## Impact
- Fixes potential incorrect pathfinding updates when tiles are modified.
- No gameplay-breaking issues, but improves internal consistency.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
