### PR TITLE
Erekir rebalance 2: more balancing round up and power rebalanced

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -6220,7 +6220,7 @@ public class Blocks{
         }};
 
         mechRefabricator = new Reconstructor("mech-refabricator"){{
-            requirements(Category.units, with(Items.beryllium, 250, Items.tungsten, 120, Items.silicon, 150));
+            requirements(Category.units, with(Items.beryllium, 250, Items.tungsten, 175, Items.silicon, 150));
             regionSuffix = "-dark";
 
             size = 3;

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -1184,7 +1184,7 @@ public class Blocks{
             ambientSoundVolume = 0.12f;
 
             consumeItems(with(Items.graphite, 1, Items.sand, 4));
-            consumePower(6f);
+            consumePower(5f);
         }};
 
         electrolyzer = new GenericCrafter("electrolyzer"){{
@@ -1448,7 +1448,7 @@ public class Blocks{
 
             consumeItem(Items.silicon, 3);
             consumeLiquid(Liquids.slag, 40f / 60f);
-            consumePower(2f);
+            consumePower(1.5f);
         }};
 
         cyanogenSynthesizer = new HeatCrafter("cyanogen-synthesizer"){{
@@ -2534,8 +2534,8 @@ public class Blocks{
         }};
 
         chemicalCombustionChamber = new ConsumeGenerator("chemical-combustion-chamber"){{
-            requirements(Category.power, with(Items.graphite, 40, Items.tungsten, 40, Items.oxide, 40f, Items.silicon, 30));
-            powerProduction = 10f;
+            requirements(Category.power, with(Items.graphite, 40, Items.tungsten, 20, Items.oxide, 40f, Items.silicon, 30));
+            powerProduction = 550f / 60f;
             researchCost = with(Items.graphite, 2000, Items.tungsten, 1000, Items.oxide, 10, Items.silicon, 1500);
             consumeLiquids(LiquidStack.with(Liquids.ozone, 2f / 60f, Liquids.arkycite, 40f / 60f));
             size = 3;
@@ -2557,7 +2557,7 @@ public class Blocks{
 
         pyrolysisGenerator = new ConsumeGenerator("pyrolysis-generator"){{
             requirements(Category.power, with(Items.graphite, 50, Items.carbide, 50, Items.oxide, 60f, Items.silicon, 50));
-            powerProduction = 25f;
+            powerProduction = 1250f / 60f;
 
             drawer = new DrawMulti(new DrawRegion("-bottom"), new DrawPistons(){{
                 sinMag = 2.75f;
@@ -2586,8 +2586,8 @@ public class Blocks{
         }};
 
         fluxReactor = new VariableReactor("flux-reactor"){{
-            requirements(Category.power, with(Items.graphite, 300, Items.carbide, 200, Items.oxide, 100, Items.silicon, 600, Items.surgeAlloy, 300));
-            powerProduction = 240f;
+            requirements(Category.power, with(Items.graphite, 300, Items.carbide, 100, Items.oxide, 100, Items.silicon, 600, Items.surgeAlloy, 200));
+            powerProduction = 265f;
             maxHeat = 150f;
 
             consumeLiquid(Liquids.cyanogen, 9f / 60f);
@@ -2622,7 +2622,7 @@ public class Blocks{
         }};
 
         neoplasiaReactor = new HeaterGenerator("neoplasia-reactor"){{
-            requirements(Category.power, with(Items.tungsten, 1000, Items.carbide, 300, Items.oxide, 150, Items.silicon, 500, Items.phaseFabric, 300, Items.surgeAlloy, 200));
+            requirements(Category.power, with(Items.tungsten, 750, Items.carbide, 300, Items.oxide, 150, Items.silicon, 500, Items.phaseFabric, 150, Items.surgeAlloy, 200));
 
             size = 5;
             liquidCapacity = 80f;
@@ -4379,7 +4379,7 @@ public class Blocks{
             outlineColor = Pal.darkOutline;
 
             liquidCapacity = 50f;
-            liquidConsumed = 10f / 60f;
+            liquidConsumed = 15f / 60f;
             targetInterval = 5f;
             newTargetInterval = 30f;
             targetUnderBlocks = false;
@@ -4404,6 +4404,7 @@ public class Blocks{
             Liquids.cyanogen, new ContinuousFlameBulletType(){{
                 damage = 130f;
                 rangeChange = 70f;
+                ammoMultiplier = 1.5f;
                 length = r + rangeChange;
                 knockback = 2f;
                 pierceCap = 3;
@@ -6157,7 +6158,7 @@ public class Blocks{
             researchCost = with(Items.beryllium, 200, Items.graphite, 80, Items.silicon, 80);
             regionSuffix = "-dark";
             fogRadius = 3;
-            consumePower(2f);
+            consumePower(1.5f);
         }};
 
         shipFabricator = new UnitFactory("ship-fabricator"){{
@@ -6169,18 +6170,18 @@ public class Blocks{
             regionSuffix = "-dark";
             fogRadius = 3;
             researchCostMultiplier = 0.5f;
-            consumePower(2f);
+            consumePower(1.5f);
         }};
 
         mechFabricator = new UnitFactory("mech-fabricator"){{
-            requirements(Category.units, with(Items.silicon, 200, Items.graphite, 300, Items.tungsten, 60));
+            requirements(Category.units, with(Items.silicon, 200, Items.beryllium, 250, Items.tungsten, 5));
             size = 3;
             configurable = false;
             plans.add(new UnitPlan(UnitTypes.merui, 60f * 40f, with(Items.beryllium, 50, Items.silicon, 70)));
             regionSuffix = "-dark";
             fogRadius = 3;
             researchCostMultiplier = 0.65f;
-            consumePower(2f);
+            consumePower(1.5f);
         }};
 
         tankRefabricator = new Reconstructor("tank-refabricator"){{
@@ -6201,7 +6202,7 @@ public class Blocks{
         }};
 
         shipRefabricator = new Reconstructor("ship-refabricator"){{
-            requirements(Category.units, with(Items.beryllium, 200, Items.tungsten, 100, Items.silicon, 150, Items.oxide, 40));
+            requirements(Category.units, with(Items.beryllium, 250, Items.tungsten, 120, Items.silicon, 150, Items.oxide, 15));
             regionSuffix = "-dark";
 
             size = 3;
@@ -6243,7 +6244,7 @@ public class Blocks{
             researchCostMultipliers.put(Items.thorium, 0.2f);
 
             size = 5;
-            consumePower(5f);
+            consumePower(4.5f);
             consumeLiquid(Liquids.nitrogen, 10f / 60f);
             consumeItems(with(Items.thorium, 80, Items.silicon, 100));
 

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -6174,7 +6174,7 @@ public class Blocks{
         }};
 
         mechFabricator = new UnitFactory("mech-fabricator"){{
-            requirements(Category.units, with(Items.silicon, 200, Items.beryllium, 250, Items.tungsten, 5));
+            requirements(Category.units, with(Items.silicon, 200, Items.beryllium, 250, Items.tungsten, 10));
             size = 3;
             configurable = false;
             plans.add(new UnitPlan(UnitTypes.merui, 60f * 40f, with(Items.beryllium, 50, Items.silicon, 70)));

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -2556,8 +2556,8 @@ public class Blocks{
         }};
 
         pyrolysisGenerator = new ConsumeGenerator("pyrolysis-generator"){{
-            requirements(Category.power, with(Items.graphite, 50, Items.carbide, 50, Items.oxide, 60f, Items.silicon, 50));
-            powerProduction = 1250f / 60f;
+            requirements(Category.power, with(Items.graphite, 100, Items.carbide, 60, Items.oxide, 60f, Items.silicon, 100));
+            powerProduction = 1400f / 60f;
 
             drawer = new DrawMulti(new DrawRegion("-bottom"), new DrawPistons(){{
                 sinMag = 2.75f;

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -3092,7 +3092,7 @@ public class UnitTypes{
                 shootSound = Sounds.blaster;
                 x = 14f / 4f;
                 y = 33f / 4f;
-                reload = 27f;
+                reload = 33f;
                 layerOffset = -0.002f;
                 alternate = false;
                 heatColor = Color.red;

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -2624,7 +2624,7 @@ public class UnitTypes{
         }};
 
         precept = new TankUnitType("precept"){{
-            hitSize = 26f;
+            hitSize = 24f;
             treadPullOffset = 5;
             speed = 0.64f;
             rotateSpeed = 1.5f;
@@ -2641,7 +2641,7 @@ public class UnitTypes{
                 shootY = 16f;
                 recoil = 3f;
                 rotate = true;
-                rotateSpeed = 1.3f;
+                rotateSpeed = 1.625f;
                 mirror = false;
                 shootCone = 2f;
                 x = 0f;
@@ -3005,7 +3005,7 @@ public class UnitTypes{
                 x = 0f;
                 y = 1f;
                 shootY = 4f;
-                reload = 60f;
+                reload = 63f;
                 cooldownTime = 42f;
                 heatColor = Pal.turretHeat;
 
@@ -3023,7 +3023,7 @@ public class UnitTypes{
                     frontColor = Color.white;
 
                     knockback = 0.8f;
-                    lifetime = 50f;
+                    lifetime = 46f;
                     width = height = 9f;
                     splashDamageRadius = 19f;
                     splashDamage = 30f;
@@ -3050,7 +3050,7 @@ public class UnitTypes{
         }};
 
         cleroi = new ErekirUnitType("cleroi"){{
-            speed = 0.7f;
+            speed = 0.6f;
             drag = 0.1f;
             hitSize = 14f;
             rotateSpeed = 3f;
@@ -3092,7 +3092,7 @@ public class UnitTypes{
                 shootSound = Sounds.blaster;
                 x = 14f / 4f;
                 y = 33f / 4f;
-                reload = 30f;
+                reload = 27f;
                 layerOffset = -0.002f;
                 alternate = false;
                 heatColor = Color.red;
@@ -3654,7 +3654,7 @@ public class UnitTypes{
             flying = true;
             drag = 0.08f;
             speed = 2f;
-            rotateSpeed = 4f;
+            rotateSpeed = 8f;
             accel = 0.09f;
             health = 1100f;
             armor = 3f;


### PR DESCRIPTION
### Describe what you would like changed, and why.

   **Sublimate:**
   Liquid usage 10/s -> 15/s
   Cyanogen 1.5x ammo multiplier 
_Ozone sub is too dominant an option in PvE. This will tamp down its convenience as an all-in-one defensive option._

   **Merui:** 
   Rate of fire decreased to ~95% (60->63 frames)
   Range: 18->17 tiles

   **Mech Fabricator:** 
   Tungsten:  60->5
   Graphite: 300->0
   Beryllium: 0->250
   
_Merui's extreme tungsten cost excludes it from being a practical choice. With slight modification merui will be balanced without it, and the berry discount likewise makes the unit usable without awkward rollouts. Balance point assumes cost performance parity with stell at 20 merui. Merui becomes a soft counter for stell above that._

   **Cleroi:** 
   Rate of fire decreased to ~.90% (60->66 frames). 
   Speed decreased to ~85%•

   **Mech refabricator:** 
   Tungsten: 120->175

_Cleroi is too good at too many things. Lowering its DPS will force it to be used as a support tool rather than a dominant option. Lowering its speed limits its ability to snipe cores._

   **Precept:** 
   Hitbox: 3.25^2 ->3.0^2.
   Turret rotation: Improved to 125%•
    Consider changing into a punchier sfx for the cannon•

_While balanced on open terrain, precept is still a little too awkward and suffers badly in chokepoints. A modest decrease to hitbox size lets 17% more units fit in the same space and a faster turret speed lets precept fire while maneuvering to imitate Tecta's maneuverability)
(Hitbox reduction may be rejected based on the problem of visual of overlap, or reduced to 3.125^2_

   **Avert:** 
   Unit rotation speed: Raised to 200%

   **Ship refabricator:** 
  Oxide: 40->15
  Beryllium: 200->250
  Tungsten: 100->120

_While Avert needs to retain its oxide cost to delay its rush potential,  a lower oxide cost will let it deploy quickly enough to be useful. Faster rotation will make it more fun and rewarding as a micro-intensive unit without helping it in army fights_

**Quell**: https://discord.com/channels/391020510269669376/404384551037698065/1362620039164858378

_Quell is indisputably underpowered and requires a rework to be buffed safely. Details linked._

   **Silicon arc:** 360>300

   **Surge crucible** 120>90

   **T1 Fabricators:** 120>90
   
   **T3 Prime Refabricator:** 300>270 
_compensation to keep pace with T4's extra T1 count_

   **Chemical Combustion Chamber:** 550 power
_zeroed at 6 CCC to 3 silicon arcs and 3 T1's_
   Tungsten cost: 40>20
_For printing speed and electrolysis count_

   **Pyrolysis:** 1500>1250 power
_Edit: Change was raised from 1200 to 1250 to increase backwards map compatibility._

   **Flux reactor:** 14,400>15,900 power
   Carbide cost: 200>100
   Surge cost: 300>200

   **Neoplasia reactor:**
   Phase cost: 300>150
   Tungsten cost: 1000>750
   
![image](https://github.com/user-attachments/assets/f5d24b0e-ab75-47c9-a729-7ec9a247434d)
![image](https://github.com/user-attachments/assets/d2d4aa31-6317-4df8-9f18-da654f118a83)

The goals with this rework are to increase early power availability, buff units across the board to keep up with the newly added defensive options, buff T1 especially to fill niche roles like HP tank alongside T2, and to encourage use of flux and neoplasia as options in normal length games not just the ultra lategame. Flux and surge production needed additional buffs and Pyrolysis an especially large nerf. Calculations below are expected to be accurate enough to be indicative.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
