### PR TITLE
Account for the frame of tileable displays

### DIFF
--- a/core/src/mindustry/world/blocks/logic/TileableLogicDisplay.java
+++ b/core/src/mindustry/world/blocks/logic/TileableLogicDisplay.java
@@ -148,8 +148,8 @@ public class TileableLogicDisplay extends LogicDisplay{
         @Override
         public double sense(LAccess sensor){
             return switch(sensor){
-                case displayWidth -> tilesWidth * 32f;
-                case displayHeight -> tilesHeight * 32f;
+                case displayWidth -> tilesWidth * 32f - 12f;    // accounts for display frame (2 * 6 pixels)
+                case displayHeight -> tilesHeight * 32f - 12f;
                 default -> super.sense(sensor);
             };
         }
@@ -238,7 +238,8 @@ public class TileableLogicDisplay extends LogicDisplay{
 
                     int rtx = (tile.x - originX), rty = (tile.y - originY);
 
-                    Tmp.tr1.set(rootDisplay.buffer.getTexture(), rtx * 32, rty * 32, 32, 32);
+                    // Offset the region to account for display frame (6 pixels)
+                    Tmp.tr1.set(rootDisplay.buffer.getTexture(), rtx * 32 - 6, rty * 32 - 6, 32, 32);
                     Draw.rect(Tmp.tr1, x, y, tilesize, -tilesize);
                 }
             });


### PR DESCRIPTION
Shifts the output of tileable displays so that (0, 0) corresponds to the first visible pixel (not hidden by the display frame), and updates the `displayWidth`/`displayHeight` properties to account for the frame and return the size of the area which is actually visible. `draw rect 0 0 display.@displayWidth display.@displayHeight` now matches the visible area of a rectangular display.

For non-rectangular displays, everything outside `(0, 0) - (displayWidth - 1, displayHeight - 1)` is either outside any single display, or covered by a frame.

I've hard-coded the frame width into the code, because I don't know how to obtain the frame width in a more systematic way.

I've tested the PR with a few display transformations (rotate, translate) and it appears to be working as expected.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
