### PR TITLE
Allow Integer.MIN_VALUE to be parsed as an unsigned bin or hex literal

### DIFF
--- a/core/src/mindustry/logic/LAssembler.java
+++ b/core/src/mindustry/logic/LAssembler.java
@@ -74,10 +74,9 @@ public class LAssembler{
         symbol = symbol.replace(' ', '_');
 
         //use a positive invalid number if number might be negative, else use a negative invalid number
-        long usedInvalidNum = symbol.length() > 0 && symbol.charAt(0) == '-' ? invalidNumPositive : invalidNumNegative;
-        double value = parseDouble(symbol, usedInvalidNum);
+        double value = parseDouble(symbol);
 
-        if(value == usedInvalidNum){
+        if(Double.isNaN(value)){
             return putVar(symbol);
         }else{
             //this creates a hidden const variable with the specified value
@@ -85,23 +84,24 @@ public class LAssembler{
         }
     }
 
-    double parseDouble(String symbol, long invalidNum){
+    double parseDouble(String symbol){
         //parse hex/binary syntax
-        if(symbol.startsWith("0b")) return Strings.parseLong(symbol, 2, 2, symbol.length(), invalidNum);
-        if(symbol.startsWith("+0b")) return Strings.parseLong(symbol, 2, 3, symbol.length(), invalidNum);
-        if(symbol.startsWith("-0b")) return -Strings.parseLong(symbol, 2, 3, symbol.length(), invalidNum);
-        if(symbol.startsWith("0x")) return Strings.parseLong(symbol, 16, 2, symbol.length(), invalidNum);
-        if(symbol.startsWith("+0x")) return Strings.parseLong(symbol, 16, 3, symbol.length(), invalidNum);
-        if(symbol.startsWith("-0x")) return -Strings.parseLong(symbol, 16, 3, symbol.length(), invalidNum);
-        if(symbol.startsWith("%[") && symbol.endsWith("]") && symbol.length() > 3){
-            double color = parseNamedColor(symbol);
-            if(color != -1d){
-                return color;
-            }
-        }
+        if(symbol.startsWith("0b")) return parseLong(false, symbol, 2, 2, symbol.length());
+        if(symbol.startsWith("+0b")) return parseLong(false, symbol, 2, 3, symbol.length());
+        if(symbol.startsWith("-0b")) return parseLong(true,symbol,  2, 3, symbol.length());
+        if(symbol.startsWith("0x")) return parseLong(false,symbol,  16, 2, symbol.length());
+        if(symbol.startsWith("+0x")) return parseLong(false,symbol,  16, 3, symbol.length());
+        if(symbol.startsWith("-0x")) return parseLong(true,symbol,  16, 3, symbol.length());
+        if(symbol.startsWith("%[") && symbol.endsWith("]") && symbol.length() > 3) return parseNamedColor(symbol);
         if(symbol.startsWith("%") && (symbol.length() == 7 || symbol.length() == 9)) return parseColor(symbol);
 
-        return Strings.parseDouble(symbol, invalidNum);
+        return Strings.parseDouble(symbol, Double.NaN);
+    }
+
+    double parseLong(boolean negative, String s, int radix, int start, int end) {
+        long usedInvalidNum = negative ? invalidNumPositive : invalidNumNegative;
+        long l = Strings.parseLong(s, radix, start, end, usedInvalidNum);
+        return l == usedInvalidNum ? Double.NaN : negative ? -l : l;
     }
 
     double parseColor(String symbol){
@@ -117,7 +117,7 @@ public class LAssembler{
     double parseNamedColor(String symbol){
         Color color = Colors.get(symbol.substring(2, symbol.length() - 1));
 
-        return color == null ? -1d : color.toDoubleBits();
+        return color == null ? Double.NaN : color.toDoubleBits();
     }
 
     /** Adds a constant value by name. */

--- a/core/src/mindustry/logic/LAssembler.java
+++ b/core/src/mindustry/logic/LAssembler.java
@@ -89,10 +89,10 @@ public class LAssembler{
         //parse hex/binary syntax
         if(symbol.startsWith("0b")) return Strings.parseLong(symbol, 2, 2, symbol.length(), invalidNum);
         if(symbol.startsWith("+0b")) return Strings.parseLong(symbol, 2, 3, symbol.length(), invalidNum);
-        if(symbol.startsWith("-0b")) return -Strings.parseLong(symbol, 2, 3, symbol.length(), invalidNum);//FIXME: breaks with Long.MIN_VALUE
+        if(symbol.startsWith("-0b")) return -Strings.parseLong(symbol, 2, 3, symbol.length(), invalidNum);
         if(symbol.startsWith("0x")) return Strings.parseLong(symbol, 16, 2, symbol.length(), invalidNum);
         if(symbol.startsWith("+0x")) return Strings.parseLong(symbol, 16, 3, symbol.length(), invalidNum);
-        if(symbol.startsWith("-0x")) return -Strings.parseLong(symbol, 16, 3, symbol.length(), invalidNum);//FIXME: breaks with Long.MIN_VALUE
+        if(symbol.startsWith("-0x")) return -Strings.parseLong(symbol, 16, 3, symbol.length(), invalidNum);
         if(symbol.startsWith("%[") && symbol.endsWith("]") && symbol.length() > 3){
             double color = parseNamedColor(symbol);
             if(color != -1d){

--- a/core/src/mindustry/logic/LAssembler.java
+++ b/core/src/mindustry/logic/LAssembler.java
@@ -11,8 +11,8 @@ import mindustry.logic.LExecutor.*;
 public class LAssembler{
     public static ObjectMap<String, Func<String[], LStatement>> customParsers = new ObjectMap<>();
 
-    private static final int invalidNumNegative = Integer.MIN_VALUE;
-    private static final int invalidNumPositive = Integer.MAX_VALUE;
+    private static final long invalidNumNegative = Long.MIN_VALUE;
+    private static final long invalidNumPositive = Long.MAX_VALUE;
 
     private boolean privileged;
     /** Maps names to variable. */
@@ -74,7 +74,7 @@ public class LAssembler{
         symbol = symbol.replace(' ', '_');
 
         //use a positive invalid number if number might be negative, else use a negative invalid number
-        int usedInvalidNum = symbol.length() > 0 && symbol.charAt(0) == '-' ? invalidNumPositive : invalidNumNegative;
+        long usedInvalidNum = symbol.length() > 0 && symbol.charAt(0) == '-' ? invalidNumPositive : invalidNumNegative;
         double value = parseDouble(symbol, usedInvalidNum);
 
         if(value == usedInvalidNum){
@@ -85,7 +85,7 @@ public class LAssembler{
         }
     }
 
-    double parseDouble(String symbol, int invalidNum){
+    double parseDouble(String symbol, long invalidNum){
         //parse hex/binary syntax
         if(symbol.startsWith("0b")) return Strings.parseLong(symbol, 2, 2, symbol.length(), invalidNum);
         if(symbol.startsWith("+0b")) return Strings.parseLong(symbol, 2, 3, symbol.length(), invalidNum);


### PR DESCRIPTION
Currently the number parsing routine uses `Integer.MIN_VALUE`/`Integer.MAX_VALUE` to indicate an invalid value when parsing numbers. That makes it impossible to parse this number in hexadecimal or binary when entered as an unsigned value: `print 0xFFFFFFFF80000000; printflush message1` outputs `null`.

This PR changes the number values used to indicate invalid numbers to `Long.MIN_VALUE` / `Long.MAX_VALUE`.

`Long.MIN_VALUE` cannot be parsed in any form anyway due to the limitations in `Strings.parseLong`. (To fix that, the arc library would have to be patched.) This PR therefore removes the limitation of not being able to parse `Integer.MIN_VALUE` without introducing any new non-parseable values.

After the fix, the following code

```
print -99
print "\n"
print 99
print "\n"
print -0xFF
print "\n"
print 0xFF
print "\n"
print -0b1111
print "\n"
print 0b1111
print "\n"
print 0xFFFFFFFF80000000
print "\n"
print 0x8000000000000000    # Long.MIN_VALUE, cannot be parsed
print "\n"
print -9223372036854775808  # Long.MIN_VALUE, cannot be parsed
printflush message1
```
produces

```
-99
99
-255
255
-15
15
-2147483648       <-- this is what this PR fixes
null
null
```

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
