### PR TITLE
Rebalancing for Foreshadow,Lustreand Smite

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -4008,7 +4008,7 @@ public class Blocks{
                     pointEffect = Fx.instTrail;
                     despawnEffect = Fx.instBomb;
                     pointEffectSpace = 20f;
-                    damage = 1350;
+                    damage = 1360;
                     buildingDamageMultiplier = 0.2f;
                     maxDamageFraction = 0.6f;
                     pierceDamageFactor = 1f;
@@ -4980,8 +4980,8 @@ public class Blocks{
             shootWarmupSpeed = 0.08f;
             shootCone = 360f;
 
-            aimChangeSpeed = 0.9f;
-            rotateSpeed = 0.9f;
+            aimChangeSpeed = 1.0f;
+            rotateSpeed = 1.0f;
 
             shootY = 0.5f;
             outlineColor = Pal.darkOutline;
@@ -4993,7 +4993,7 @@ public class Blocks{
             unitSort = UnitSorts.strongest;
 
             consumeLiquid(Liquids.nitrogen, 6f / 60f);
-            consumePower(200f / 60f);
+            consumePower(150f / 60f);
         }};
 
         scathe = new ItemTurret("scathe"){{
@@ -5474,7 +5474,7 @@ public class Blocks{
             }});
 
             shootSound = Sounds.shootSmite;
-            minWarmup = 0.99f;
+            minWarmup = 0.95f;
             coolantMultiplier = 15f;
 
             var haloProgress = PartProgress.warmup.delay(0.5f);
@@ -5649,7 +5649,7 @@ public class Blocks{
                 }
             }};
 
-            shootWarmupSpeed = 0.04f;
+            shootWarmupSpeed = 0.05f;
             shootY = 15f;
             outlineColor = Pal.darkOutline;
             size = 5;


### PR DESCRIPTION
https://github.com/Anuken/Mindustry-Suggestions/issues/5570

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

Foreshadow: Damage increased to 1360
Smite: Slightly reduce warm-up time
Lustre: Increase rotation speed, reduce power consumption to 100/s
Rationale:
High-HP units become harder to eliminate when surrounded
Smite's slow warm-up hinders effectiveness against fast units
Lustre's sluggish rotation limits it to countering slow-moving targets