### PR TITLE
QoL: provide an easy way to restart a logic processor

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -525,6 +525,7 @@ details = Details...
 edit = Edit
 variables = Vars
 logic.clear.confirm = Are you sure you want to clear all code from this processor?
+logic.restart = Restart
 logic.globals = Built-in Variables
 
 editor.name = Name:

--- a/core/src/mindustry/logic/LogicDialog.java
+++ b/core/src/mindustry/logic/LogicDialog.java
@@ -31,7 +31,7 @@ public class LogicDialog extends BaseDialog{
     boolean privileged;
     @Nullable LExecutor executor;
     GlobalVarsDialog globalsDialog = new GlobalVarsDialog();
-    boolean wasRows, wasPortrait;
+    boolean wasRows, wasPortrait, forceRestart;
 
     public LogicDialog(){
         super("logic");
@@ -142,7 +142,14 @@ public class LogicDialog extends BaseDialog{
                         }catch(Throwable e){
                             ui.showException(e);
                         }
-                    }).marginLeft(12f).disabled(b -> Core.app.getClipboardText() == null);
+                    }).marginLeft(12f).disabled(b -> Core.app.getClipboardText() == null).row();
+
+                    t.button("@logic.restart", Icon.refresh, style, () -> {
+                        forceRestart = true;
+                        dialog.hide();
+                        hide();
+                    }).marginLeft(12f);
+
                 });
             });
 
@@ -336,6 +343,7 @@ public class LogicDialog extends BaseDialog{
     public void show(String code, LExecutor executor, boolean privileged, Cons<String> modified){
         this.executor = executor;
         this.privileged = privileged;
+        this.forceRestart = false;
         canvas.statements.clearChildren();
         canvas.rebuild();
         canvas.privileged = privileged;
@@ -346,7 +354,7 @@ public class LogicDialog extends BaseDialog{
             canvas.load("");
         }
         this.consumer = result -> {
-            if(!result.equals(code)){
+            if(forceRestart || !result.equals(code)){
                 modified.get(result);
             }
         };


### PR DESCRIPTION
This PR adds a button to restart the processor to the Edit logic dialog:

![{CA08FE87-0CC4-43CD-9E0F-57EE98B5F7E8}](https://github.com/user-attachments/assets/e2e7cbc5-6b2e-4458-ac86-a4fb88833b97)

I've used the refresh icon for the command. It looks quite fitting to me, but I can try to draw a new one if requested (e.g. a loop with an arrow pointing to the top).

The command resets all variables and restarts the processor (by enforcing recompilation). This operation is needed when the code in the processor performs some one-time initialization, and the user wants to re-run the initialization. Currently, the following workarounds are possible:

- Making a small modification to the program to force recompilation: not always practical, potentially dangerous.
- Implement the reinitalization logic in the logic code itself, e.g. on a switch: this is often not needed outside of code development, adding unnecessary cruft to logic. At the same time adding it ad-hoc to a program when it becomes needed may be error-prone, time-consuming and just not worth it.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
