### PR TITLE
Prevent setting counter to null using write instruction

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -88,6 +88,7 @@ public class LExecutor{
         }
 
         if(counter.numval < instructions.length){
+            counter.isobj = false;
             instructions[(int)(counter.numval++)].run(this);
         }
     }
@@ -605,7 +606,7 @@ public class LExecutor{
                 mem.memory[address] = value.num();
             }else if(from instanceof LogicBuild logic && (exec.privileged || (from.team == exec.team && !from.block.privileged)) && position.isobj && position.objval instanceof String name){
                 LVar toVar = logic.executor.optionalVar(name);
-                if(toVar != null && !toVar.constant && (toVar != logic.executor.counter || !value.isobj)){
+                if(toVar != null && !toVar.constant){
                     toVar.objval = value.objval;
                     toVar.numval = value.numval;
                     toVar.isobj = value.isobj;
@@ -781,10 +782,8 @@ public class LExecutor{
         public void run(LExecutor exec){
             if(!to.constant){
                 if(from.isobj){
-                    if(to != exec.counter){
-                        to.objval = from.objval;
-                        to.isobj = true;
-                    }
+                    to.objval = from.objval;
+                    to.isobj = true;
                 }else{
                     to.numval = LVar.invalid(from.numval) ? 0 : from.numval;
                     to.isobj = false;

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -605,7 +605,7 @@ public class LExecutor{
                 mem.memory[address] = value.num();
             }else if(from instanceof LogicBuild logic && (exec.privileged || (from.team == exec.team && !from.block.privileged)) && position.isobj && position.objval instanceof String name){
                 LVar toVar = logic.executor.optionalVar(name);
-                if(toVar != null && !toVar.constant){
+                if(toVar != null && !toVar.constant && (toVar != logic.executor.counter || !value.isobj)){
                     toVar.objval = value.objval;
                     toVar.numval = value.numval;
                     toVar.isobj = value.isobj;


### PR DESCRIPTION
While the `set` instruction doesn't allow to write `null` to `@counter`, this check is missing when setting the `@counter` using `write` instruction. This PR adds this check.

(Setting `@counter` to `null` doesn't stop the processor, but it causes the value of the `@counter` to be read as `null` on when accessed from logic, leading to problems with all `@counter`-based logic.)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
