### PR TITLE
Add `select` operation

### DIFF
--- a/core/src/mindustry/logic/ConditionOp.java
+++ b/core/src/mindustry/logic/ConditionOp.java
@@ -28,6 +28,17 @@ public enum ConditionOp{
         this.objFunction = objFunction;
     }
 
+    public boolean test(LVar va, LVar vb){
+        if(this == ConditionOp.strictEqual){
+            return va.isobj == vb.isobj && ((va.isobj && va.objval == vb.objval) || (!va.isobj && va.numval == vb.numval));
+        }
+        if(objFunction != null && va.isobj && vb.isobj){
+            //use object function if both are objects
+            return objFunction.get(va.obj(), vb.obj());
+        }
+        return function.get(va.num(), vb.num());
+    }
+
     @Override
     public String toString(){
         return symbol;

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -780,15 +780,7 @@ public class LExecutor{
 
         @Override
         public void run(LExecutor exec){
-            if(!to.constant){
-                if(from.isobj){
-                    to.objval = from.objval;
-                    to.isobj = true;
-                }else{
-                    to.numval = LVar.invalid(from.numval) ? 0 : from.numval;
-                    to.isobj = false;
-                }
-            }
+            if(!to.constant) to.set(from);
         }
     }
 
@@ -821,6 +813,28 @@ public class LExecutor{
                 }
 
             }
+        }
+    }
+
+    public static class SelectI implements LInstruction{
+        public ConditionOp op = ConditionOp.notEqual;
+        public LVar result, comp0, comp1, a, b;
+
+        public SelectI(ConditionOp op, LVar result, LVar comp0, LVar comp1, LVar a, LVar b){
+            this.op = op;
+            this.result = result;
+            this.comp0 = comp0;
+            this.comp1 = comp1;
+            this.a = a;
+            this.b = b;
+        }
+
+        public SelectI(){}
+
+        @Override
+        public void run(LExecutor exec){
+            if(result.constant) return;
+            result.set(op.test(comp0, comp1) ? a : b);
         }
     }
 
@@ -1129,23 +1143,8 @@ public class LExecutor{
 
         @Override
         public void run(LExecutor exec){
-            if(address != -1){
-                LVar va = value;
-                LVar vb = compare;
-                boolean cmp;
-
-                if(op == ConditionOp.strictEqual){
-                    cmp = va.isobj == vb.isobj && ((va.isobj && va.objval == vb.objval) || (!va.isobj && va.numval == vb.numval));
-                }else if(op.objFunction != null && va.isobj && vb.isobj){
-                    //use object function if both are objects
-                    cmp = op.objFunction.get(value.obj(), compare.obj());
-                }else{
-                    cmp = op.function.get(value.num(), compare.num());
-                }
-
-                if(cmp){
-                    exec.counter.numval = address;
-                }
+            if(address != -1 && op.test(value, compare)){
+                exec.counter.numval = address;
             }
         }
     }

--- a/core/src/mindustry/logic/LVar.java
+++ b/core/src/mindustry/logic/LVar.java
@@ -101,6 +101,12 @@ public class LVar{
         isobj = true;
     }
 
+    public void set(LVar other){
+        isobj = other.isobj;
+        objval = other.objval;
+        numval = other.numval;
+    }
+
     public static boolean invalid(double d){
         return Double.isNaN(d) || Double.isInfinite(d);
     }

--- a/core/src/mindustry/world/blocks/logic/LogicBlock.java
+++ b/core/src/mindustry/world/blocks/logic/LogicBlock.java
@@ -386,9 +386,7 @@ public class LogicBlock extends Block{
                             if(!var.constant){
                                 LVar dest = asm.getVar(var.name);
                                 if(dest != null && !dest.constant){
-                                    dest.isobj = var.isobj;
-                                    dest.objval = var.objval;
-                                    dest.numval = var.numval;
+                                    dest.set(var);
                                 }
                             }
                         }


### PR DESCRIPTION
New instruction to quickly select between two variables without using jumps
Example usage:`select result notEqual x false a b`
![image](https://github.com/user-attachments/assets/39034baa-0fc0-4719-8d92-70d0486c07b1)

Maybe Conditional Set (`setcond`) would be a better name, `setcond` does sound like changing a condition similarly to `setprop`/`setrule`

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
