### PR TITLE
Fix markers incorrect index

### DIFF
--- a/core/src/mindustry/game/MapMarkers.java
+++ b/core/src/mindustry/game/MapMarkers.java
@@ -20,6 +20,7 @@ public class MapMarkers implements Iterable<ObjectiveMarker>{
         var prev = map.put(id, marker);
         if(prev != null){
             all.set(prev.arrayIndex, marker);
+            marker.arrayIndex = prev.arrayIndex;
         }else{
             all.add(marker);
             marker.arrayIndex = all.size - 1;


### PR DESCRIPTION
Ensure the marker has the proper `arrayIndex` when a marker with the same id already exists. Fixes weird behaviour of markers when recreating an existing marker.

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
