### PR TITLE
Map reloads counter - new processor variable

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -2518,6 +2518,7 @@ lglobal.@waveNumber = Current wave number, if waves are enabled
 lglobal.@waveTime = Countdown timer for waves, in seconds
 lglobal.@mapw = Map width in tiles
 lglobal.@maph = Map height in tiles
+lglobal.@mapReloads = Number of times the map was loaded since the start of the program
 
 lglobal.sectionMap = Map
 lglobal.sectionGeneral = General

--- a/core/src/mindustry/logic/GlobalVars.java
+++ b/core/src/mindustry/logic/GlobalVars.java
@@ -74,6 +74,7 @@ public class GlobalVars{
 
         varMapW = putEntry("@mapw", 0);
         varMapH = putEntry("@maph", 0);
+        putEntryOnly("@mapReloads");
         varWait = put("@wait", null, true, true);
 
         putEntryOnly("sectionNetwork");

--- a/core/src/mindustry/logic/LAssembler.java
+++ b/core/src/mindustry/logic/LAssembler.java
@@ -27,6 +27,8 @@ public class LAssembler{
         putConst("@unit", null);
         //reference to self
         putConst("@this", null);
+        // number of map reloads since program start
+        putVar("@mapReloads").isobj = false;
     }
 
     public static LAssembler assemble(String data, boolean privileged){

--- a/core/src/mindustry/world/blocks/logic/LogicBlock.java
+++ b/core/src/mindustry/world/blocks/logic/LogicBlock.java
@@ -767,6 +767,8 @@ public class LogicBlock extends Block{
                         if(value instanceof Number num){
                             var.numval = num.doubleValue();
                             var.isobj = false;
+
+                            if (var.name.equals("@mapReloads")) var.numval++;
                         }else{
                             var.objval = value;
                             var.isobj = true;


### PR DESCRIPTION
Adds a `@mapReloads` processor variable. The variable is set to zero on code compilation, and gets incremented each time a map is loaded. It serves for easy detection of map reload events (either from a save file, or by switching a sector in campaign). Since display content is not stored in the map file, this allows programs that update their display incrementally to detect the display needs to be fully redrawn. There might be other use cases; maybe world processors could trigger some events in custom maps when a map gets loaded.

Reload detection is possible in two ways: firstly, the last value of `@mapReloads` can be stored in a variable; when a difference is found, the stored value is updated and the display is redrawn. Secondly, since `@mapReloads` is writable, it is possible to set it back to zero when a non-zero value, and thus a map reload, is detected.

The variable is displayed in the **Vars** screen, which makes it perhaps more prominent than it deserves. If this is a problem, I'll try to add a fix to hide it from this list. (I've also added it to the list of built-in variables, even though `@counter` isn't there.)

Notes:
* I'm not aware of any other mechanism to detect map reloads (except "ghost cells", which is not really all that usable), despite asking around. If there already is another way, then this can be scrapped - I'd just like to know what is the way.
* Map reloads could be tracked within the map itself. Adding a just processor variable seemed simpler to me - the code added is minimal. The possibility to reset the flag independently by each processor is a bonus which makes using the variable easier.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
