### PR TITLE
Clamp ContinuousLaserBullet's visual effect length to > 0

### DIFF
--- a/core/src/mindustry/entities/bullet/ContinuousLaserBulletType.java
+++ b/core/src/mindustry/entities/bullet/ContinuousLaserBulletType.java
@@ -55,13 +55,13 @@ public class ContinuousLaserBulletType extends ContinuousBulletType{
             float ellipseLenScl = Mathf.lerp(1 - i / (float)(colors.length), 1f, pointyScaling);
 
             Lines.stroke(stroke);
-            Lines.lineAngle(b.x, b.y, rot, realLength - frontLength, false);
+            Lines.lineAngle(b.x, b.y, rot, Math.max(0, realLength - frontLength), false);
 
             //back ellipse
             Drawf.flameFront(b.x, b.y, divisions, rot + 180f, backLength, stroke / 2f);
 
             //front ellipse
-            Tmp.v1.trnsExact(rot, realLength - frontLength);
+            Tmp.v1.trnsExact(rot, Math.max(0, realLength - frontLength));
             Drawf.flameFront(b.x + Tmp.v1.x, b.y + Tmp.v1.y, divisions, rot, frontLength * ellipseLenScl, stroke / 2f);
         }
 


### PR DESCRIPTION
Clamp the length of the ContinuousLaserBullet's visual effect to be greater than zero, correcting an extremely minor visual weirdness where the laser moves behind the unit at the end of the animation when length becomes negative.

Before:

https://github.com/user-attachments/assets/28e971d5-d22a-4f9a-97b1-6bc965837540

After:

https://github.com/user-attachments/assets/fad62e85-1cc0-4ebb-9bef-ae006129167b


If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
