### PR TITLE
Allow block info hotkey to also work on units

### DIFF
--- a/core/src/mindustry/ui/fragments/PlacementFragment.java
+++ b/core/src/mindustry/ui/fragments/PlacementFragment.java
@@ -251,10 +251,9 @@ public class PlacementFragment{
         }
 
         if(Core.input.keyTap(Binding.blockInfo)){
-            if (hovered() instanceof Unit unit && unit.type.unlockedNow()){
+            if(hovered() instanceof Unit unit && unit.type.unlockedNow()){
                 ui.content.show(unit.type());
-            }
-            else{
+            }else{
                 var build = world.buildWorld(Core.input.mouseWorld().x, Core.input.mouseWorld().y);
                 Block hovering = build == null ? null : build instanceof ConstructBuild c ? c.current : build.block;
                 Block displayBlock = menuHoverBlock != null ? menuHoverBlock : input.block != null ? input.block : hovering;

--- a/core/src/mindustry/ui/fragments/PlacementFragment.java
+++ b/core/src/mindustry/ui/fragments/PlacementFragment.java
@@ -251,12 +251,17 @@ public class PlacementFragment{
         }
 
         if(Core.input.keyTap(Binding.blockInfo)){
-            var build = world.buildWorld(Core.input.mouseWorld().x, Core.input.mouseWorld().y);
-            Block hovering = build == null ? null : build instanceof ConstructBuild c ? c.current : build.block;
-            Block displayBlock = menuHoverBlock != null ? menuHoverBlock : input.block != null ? input.block : hovering;
-            if(displayBlock != null && displayBlock.unlockedNow()){
-                ui.content.show(displayBlock);
-                Events.fire(new BlockInfoEvent());
+            if (hovered() instanceof Unit unit && unit.type.unlockedNow()){
+                ui.content.show(unit.type());
+            }
+            else{
+                var build = world.buildWorld(Core.input.mouseWorld().x, Core.input.mouseWorld().y);
+                Block hovering = build == null ? null : build instanceof ConstructBuild c ? c.current : build.block;
+                Block displayBlock = menuHoverBlock != null ? menuHoverBlock : input.block != null ? input.block : hovering;
+                if(displayBlock != null && displayBlock.unlockedNow()){
+                    ui.content.show(displayBlock);
+                    Events.fire(new BlockInfoEvent());
+                }
             }
         }
 


### PR DESCRIPTION
Allow the block info hotkey to show the core database entry for researched units on the player's team. Hovered units take precedence over the blocks beneath them for the hotkey, matching the behavior of the hover information already shown in the lower right.

The hotkey might be better called "Info" or "Block/Unit Info" with this change but I didn't rename it myself since it would break translations-- FWIW

---

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
