### PR TITLE
Fixed calculation problems when deconstruct

### DIFF
--- a/core/src/mindustry/world/blocks/ConstructBlock.java
+++ b/core/src/mindustry/world/blocks/ConstructBlock.java
@@ -372,7 +372,6 @@ public class ConstructBlock extends Block{
                         int used = totalCost - itemsLeft[i] + refundedItems[i];
                         int target = Mathf.round(used * state.rules.deconstructRefundMultiplier);
                         int remaining = target - refundedItems[i];
-                        Log.err(String.valueOf(remaining));
                         if(requirements[i].item.unlockedNowHost()){
                             core.items.add(requirements[i].item, Mathf.clamp(remaining, 0, core.storageCapacity - core.items.get(requirements[i].item)));
                         }

--- a/core/src/mindustry/world/blocks/ConstructBlock.java
+++ b/core/src/mindustry/world/blocks/ConstructBlock.java
@@ -352,6 +352,9 @@ public class ConstructBlock extends Block{
                         core.items.add(requirements[i].item, accepting);
                         itemsLeft[i] += accepting;
                         accumulator[i] -= accepting;
+                        if (refundedItems == null) {
+                            refundedItems = new int[requirements.length];
+                        }
                         refundedItems[i] += accepting;
                     }else{
                         accumulator[i] -= accumulated;
@@ -484,7 +487,6 @@ public class ConstructBlock extends Block{
                     write.f(accumulator[i]);
                     write.f(totalAccumulator[i]);
                     write.i(itemsLeft[i]);
-                    write.i(refundedItems[i]);
                 }
             }
         }
@@ -501,13 +503,11 @@ public class ConstructBlock extends Block{
                 accumulator = new float[acsize];
                 totalAccumulator = new float[acsize];
                 itemsLeft = new int[acsize];
-                refundedItems = new int[acsize];
                 for(int i = 0; i < acsize; i++){
                     accumulator[i] = read.f();
                     totalAccumulator[i] = read.f();
                     if(revision >= 1){
                         itemsLeft[i] = read.i();
-                        refundedItems[i] = read.i();
                     }
                 }
             }

--- a/core/src/mindustry/world/blocks/ConstructBlock.java
+++ b/core/src/mindustry/world/blocks/ConstructBlock.java
@@ -369,13 +369,9 @@ public class ConstructBlock extends Block{
                         int used = totalCost - itemsLeft[i] + refundedItems[i];
                         int target = Mathf.round(used * state.rules.deconstructRefundMultiplier);
                         int remaining = target - refundedItems[i];
+                        Log.err(String.valueOf(remaining));
                         if(requirements[i].item.unlockedNowHost()){
-                            if(remaining >= 0){
-                                core.items.add(requirements[i].item, Mathf.clamp(remaining, 0, core.storageCapacity - core.items.get(requirements[i].item)));
-                            } else {
-                                int toRemove = Math.min(-remaining, core.items.get(requirements[i].item));
-                                core.items.remove(requirements[i].item, toRemove);
-                            }
+                            core.items.add(requirements[i].item, Mathf.clamp(remaining, 0, core.storageCapacity - core.items.get(requirements[i].item)));
                         }
 
                         refundedItems[i] = target;
@@ -488,6 +484,7 @@ public class ConstructBlock extends Block{
                     write.f(accumulator[i]);
                     write.f(totalAccumulator[i]);
                     write.i(itemsLeft[i]);
+                    write.i(refundedItems[i]);
                 }
             }
         }
@@ -504,11 +501,13 @@ public class ConstructBlock extends Block{
                 accumulator = new float[acsize];
                 totalAccumulator = new float[acsize];
                 itemsLeft = new int[acsize];
+                refundedItems = new int[acsize];
                 for(int i = 0; i < acsize; i++){
                     accumulator[i] = read.f();
                     totalAccumulator[i] = read.f();
                     if(revision >= 1){
                         itemsLeft[i] = read.i();
+                        refundedItems[i] = read.i();
                     }
                 }
             }


### PR DESCRIPTION
- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

I get the amount obtained in the process through 
```
refundedItems[i] += accepting;
```
Because itemsLeft[i] = totalCost[i] - usedItems[i] + refundedItems[i]
So I get usedItems[i], and then I get the total amount that should be given to you, that is, totalRefundItems[i] = usedItems[i] * deconstructMultiplier, and then I use totalRefundItems[i - refundedItems[i] to get the most accurate amount of compensation.

But even so, I found other problems. For example, if deconstructMultiplier = 2, I spent 7 coppers to build it, and refundedItems[i] = 15, it gave me one more, which means that I can't give it, but I have to reduce it by one.