### PR TITLE
Improve server control and logging of the DOS blacklist

### DIFF
--- a/core/src/mindustry/net/Administration.java
+++ b/core/src/mindustry/net/Administration.java
@@ -91,6 +91,10 @@ public class Administration{
         dosBlacklist.add(address);
     }
 
+    public synchronized void unBlacklistDos(String address){
+        dosBlacklist.remove(address);
+    }
+
     public synchronized boolean isDosBlacklisted(String address){
         return dosBlacklist.contains(address);
     }

--- a/core/src/mindustry/net/ArcNetProvider.java
+++ b/core/src/mindustry/net/ArcNetProvider.java
@@ -113,7 +113,7 @@ public class ArcNetProvider implements NetProvider{
 
                 //kill connections above the limit to prevent spam
                 if((playerLimitCache > 0 && server.getConnections().length > playerLimitCache) || netServer.admins.isDosBlacklisted(ip)){
-                    Log.info(String.format("Closing connection %s - IP marked as a potential DOS attack.", ip));
+                    Log.info("Closing connection @ - IP marked as a potential DOS attack.", ip);
 
                     connection.close(DcReason.closed);
                     return;

--- a/core/src/mindustry/net/ArcNetProvider.java
+++ b/core/src/mindustry/net/ArcNetProvider.java
@@ -113,6 +113,8 @@ public class ArcNetProvider implements NetProvider{
 
                 //kill connections above the limit to prevent spam
                 if((playerLimitCache > 0 && server.getConnections().length > playerLimitCache) || netServer.admins.isDosBlacklisted(ip)){
+                    Log.info(String.format("Closing connection %s - IP marked as a potential DOS attack.", ip));
+
                     connection.close(DcReason.closed);
                     return;
                 }

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -1054,6 +1054,35 @@ public class ServerControl implements ApplicationListener{
             }
         });
 
+        handler.register("dos-ban", "[add/remove] [ip]", "Add or remove a DOS ban.", args -> {
+            if (args.length == 0){
+                info("DOS bans: @", netServer.admins.dosBlacklist.isEmpty() ? "<none>" : "");
+
+                netServer.admins.dosBlacklist.forEach(address -> {
+                    info("&lw\t" + address);
+                });
+                return;
+            } else if (args.length == 1) {
+                err("Expected either zero or two parameters, but only got one parameter.");
+                return;
+            }
+
+            String action = args[0].toLowerCase();
+            String ip = args[1];
+
+            if (action.equals("add")){
+                netServer.admins.blacklistDos(ip);
+                info("Dos banned: @", ip);
+                return;
+            } else if (action.equals("remove")){
+                netServer.admins.unBlacklistDos(ip);
+                info("Removed dos ban: @", ip);
+                return;
+            }
+
+            err("Unrecognized action: @", action);
+        });
+
         mods.eachClass(p -> p.registerServerCommands(handler));
     }
 

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -666,7 +666,7 @@ public class ServerControl implements ApplicationListener{
             if(arg.length == 0){
                 info("Subnets banned: @", netServer.admins.getSubnetBans().isEmpty() ? "<none>" : "");
                 for(String subnet : netServer.admins.getSubnetBans()){
-                    info("&lw  " + subnet);
+                    info("&lw\t" + subnet);
                 }
             }else if(arg.length == 1){
                 err("You must provide a subnet to add or remove.");

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -1054,27 +1054,27 @@ public class ServerControl implements ApplicationListener{
             }
         });
 
-        handler.register("dos-ban", "[add/remove] [ip]", "Add or remove a DOS ban.", args -> {
-            if (args.length == 0){
+        handler.register("dos-ban", "[add/remove] [ip]", "Add or remove a DOS ban.", arg -> {
+            if(arg.length == 0){
                 info("DOS bans: @", netServer.admins.dosBlacklist.isEmpty() ? "<none>" : "");
 
                 netServer.admins.dosBlacklist.forEach(address -> {
                     info("&lw\t" + address);
                 });
                 return;
-            } else if (args.length == 1) {
+            }else if(arg.length == 1){
                 err("Expected either zero or two parameters, but only got one parameter.");
                 return;
             }
 
-            String action = args[0].toLowerCase();
-            String ip = args[1];
+            String action = arg[0].toLowerCase();
+            String ip = arg[1];
 
-            if (action.equals("add")){
+            if(action.equals("add")){
                 netServer.admins.blacklistDos(ip);
                 info("Dos banned: @", ip);
                 return;
-            } else if (action.equals("remove")){
+            }else if(action.equals("remove")){
                 netServer.admins.unBlacklistDos(ip);
                 info("Removed dos ban: @", ip);
                 return;


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

## Added
- A method to remove a DOS blacklisted IP.
- A command to add, remove, and list DOS blacklisted IPs.
- A line to log when a connection is being kicked for being a DOS blacklisted IP.

## Changes
- Switched the double-spaces in the subnet-ban command's listing to instead use a tab. This is better for accessibility and customization. 

## Justifications
- Some mods will accidentally trigger a DOS blacklist. The server only logs the trigger, but it doesn't log anything when the player is kicked for having an IP that is on the DOS blacklist. This can cause confusion for server owners/admins that are trying to resolve a connection issue.
- There is no built-in way to correct this issue other than by running Javascript. The Javascript that is necessary to correct this issue can be confusing to certain individuals, and running unknown Javascript code can pose a significant risk to those that aren't familiar with programming and security.
- While a lot of IDEs encourage using spaces instead of actual tabs (from my knowledge) -- this can cause issues for accessibility. Some individuals may rely on the tab character (denoted by `\t`) to be able to properly read text and information on a screen. Using spaces instead of the tab character can make it harder for an individual that relies on the tab character to be able to access all of the features of the headless Mindustry server. Additionally, the length of tabs can be customized on a local level, so having this level of customization can potentially benefit individuals that would want to customize the length of their tabs (even if they don't need it for accessibility).