### PR TITLE
feat: Auto-unlock Erekir tech tree on startup

### DIFF
--- a/core/src/mindustry/ClientLauncher.java
+++ b/core/src/mindustry/ClientLauncher.java
@@ -20,6 +20,9 @@ import mindustry.maps.*;
 import mindustry.mod.*;
 import mindustry.net.*;
 import mindustry.ui.*;
+import mindustry.content.Planets;
+import mindustry.content.ErekirTechTree;
+import mindustry.io.SaveIO;
 
 import static arc.Core.*;
 import static mindustry.Vars.*;
@@ -180,7 +183,11 @@ public abstract class ClientLauncher extends ApplicationCore implements Platform
 
         assets.load(schematics);
 
-        assets.loadRun("contentinit", ContentLoader.class, () -> content.init(), () -> content.load());
+        assets.loadRun("contentinit", ContentLoader.class, () -> content.init(), () -> {
+            content.load();
+            ErekirTechTree.unlockAllRecursive(Planets.erekir.techTree);
+            SaveIO.save(Vars.saveDirectory.child("erekir_unlocked.msav"));
+        });
         assets.loadRun("baseparts", BaseRegistry.class, () -> {}, () -> bases.load());
     }
 

--- a/core/src/mindustry/content/ErekirTechTree.java
+++ b/core/src/mindustry/content/ErekirTechTree.java
@@ -7,6 +7,7 @@ import mindustry.game.Objectives.*;
 import mindustry.type.*;
 import mindustry.type.unit.*;
 import mindustry.world.blocks.defense.turrets.*;
+import mindustry.content.TechTree.TechNode;
 
 import static mindustry.Vars.*;
 import static mindustry.content.Blocks.*;
@@ -466,5 +467,17 @@ public class ErekirTechTree{
                 });
             });
         });
+    }
+
+    public static void unlockAllRecursive(TechNode node){
+        if(node == null){
+            return;
+        }
+
+        node.content.unlock();
+
+        for(TechNode child : node.children){
+            unlockAllRecursive(child);
+        }
     }
 }


### PR DESCRIPTION
This implements a feature that automatically unlocks all research items in the Erekir tech tree when the game starts.

Changes:
- I added a recursive function `unlockAllRecursive` to `ErekirTechTree.java` to unlock a given tech node and all its children.
- I modified `ClientLauncher.java` to call this function for the Erekir tech tree root after content loading.
- I added a call to `SaveIO.save()` in `ClientLauncher.java` to save the game state to a new file named `erekir_unlocked.msav` after the tech tree is unlocked.

This allows you to start with all Erekir research completed by default, with the progress saved to a dedicated save file.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [ ] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
