### PR TITLE
Bugfix on Landing Pad's "Redirect Launch Pads" UI

### DIFF
--- a/core/src/mindustry/world/blocks/campaign/LandingPad.java
+++ b/core/src/mindustry/world/blocks/campaign/LandingPad.java
@@ -383,19 +383,22 @@ public class LandingPad extends Block{
                     t.background(Styles.black6);
 
                     t.button(Icon.downOpen, Styles.clearNonei, 40f, () -> {
-                        if(config != null && state.isCampaign()){
-                            for(Sector sector : state.getPlanet().sectors){
-                                if(sector.hasBase() && sector != state.getSector() && sector.info.destination != state.getSector() && sector.info.hasExport(config)){
-                                    sector.info.destination = state.getSector();
-                                    sector.saveInfo();
-                                }
-                            }
-                            state.getSector().info.refreshImportRates(state.getPlanet());
+                        if(config == null || !state.isCampaign()) return;
+
+                        for(Sector sector : state.getPlanet().sectors){
+                            if(!canRedirectExports(sector)) continue;
+                            sector.info.destination = state.getSector();
+                            sector.saveInfo();
                         }
-                    }).disabled(b -> config == null || !state.isCampaign() || (!state.getPlanet().sectors.contains(s -> s.hasBase() && s.info.hasExport(config) && s.info.destination != state.getSector())))
+                        state.getSector().info.refreshImportRates(state.getPlanet());
+                    }).disabled(button -> config == null || !state.isCampaign() || (!state.getPlanet().sectors.contains(this::canRedirectExports)))
                     .tooltip("@sectors.redirect").get();
                 }).fillX().left();
             }
+        }
+
+        private boolean canRedirectExports(Sector sector){
+            return sector.hasBase() && sector != state.getSector() && sector.info.hasExport(config) && sector.info.destination != state.getSector();
         }
 
         @Override
@@ -416,14 +419,13 @@ public class LandingPad extends Block{
 
                 int sources = 0;
                 float perSecond = 0f;
-                for(var s : state.getPlanet().sectors){
-                    if(s != state.getSector() && s.hasBase() && s.info.destination == state.getSector()){
-                        float amount = s.info.getExport(config);
-                        if(amount > 0){
-                            sources ++;
-                            perSecond += s.info.getExport(config);
-                        }
-                    }
+                for(var otherSector : state.getPlanet().sectors){
+                    if(otherSector == state.getSector() || !otherSector.hasBase() || otherSector.info.destination != state.getSector()) continue;
+
+                    float amount = otherSector.info.getExport(config);
+                    if(amount <= 0) continue;
+                    sources ++;
+                    perSecond += amount;
                 }
 
                 String str = Core.bundle.format("landing.sources", sources == 0 ? Core.bundle.get("none") : sources);


### PR DESCRIPTION
- If a sector had both a launch and landing pad of the same resource, when clicking "Redirect Launch Pads" to make other sectors' launch pads to send theirs to that sector, the prompt would remain enabled due to the disable check not considering self sending that same resource, making it seem it did nothing.

Implementation details:
- Refactored some variable names and code blocks for easier reading.
- Created ``canRedirectExports`` method which determines if the provided sector's launch pads can be redirected to the player's current sector. This method is used in both the button's disabled attribute and during execution of redirecting sectors.

Testing details:
- Utilized Windows instructions for compilation and running the application;
- Used save file from Steam's "v8-beta" branch;
- Selected a sector which contained both a launch and landing pad of the same resource. Before the changes, the button would remain enabled after pressing it. After the changes, the button now remains disabled (as all other sectors were already exporting to that sector).

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
