### PR TITLE
Small canvas read/write fixes

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -615,7 +615,7 @@ public class LExecutor{
                     toVar.isobj = value.isobj;
                 }
             }else if(from instanceof CanvasBuild canvas && (exec.privileged || (from.team == exec.team))){
-		        canvas.setPixel(address, (int)(value.numval));
+		        canvas.setPixel(address, value.numi());
             }
         }
     }

--- a/core/src/mindustry/world/blocks/logic/CanvasBlock.java
+++ b/core/src/mindustry/world/blocks/logic/CanvasBlock.java
@@ -167,11 +167,11 @@ public class CanvasBlock extends Block{
             }
         }
 
-        public int getPixel(int pos){
+        public double getPixel(int pos){
             if(pos >= 0 && pos < canvasSize * canvasSize){
                 return getByte(data, pos * bitsPerPixel);
             }
-            return 0;
+            return Double.NaN;
         }
 
         public int getPixel(int x, int y){


### PR DESCRIPTION
Two small fixes regarding reading/writing from/to canvases:

1. Passing an invalid pixel index to `read` results into `null` instead of `0`, as is customary for instructions that encounter an error during execution.
2. When writing to canvas, uses `numi()` instead of `numval` to obtain a variable value to ensure proper object-to-number conversion.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
