### PR TITLE
Mass driver bullets are destroyed like the blocks with items

### DIFF
--- a/core/src/mindustry/entities/bullet/MassDriverBolt.java
+++ b/core/src/mindustry/entities/bullet/MassDriverBolt.java
@@ -3,9 +3,12 @@ package mindustry.entities.bullet;
 import arc.graphics.*;
 import arc.graphics.g2d.*;
 import arc.math.*;
+import mindustry.Vars;
 import mindustry.content.*;
+import mindustry.entities.Damage;
 import mindustry.gen.*;
 import mindustry.graphics.*;
+import mindustry.type.Item;
 import mindustry.world.blocks.distribution.MassDriver.*;
 
 import static mindustry.Vars.*;
@@ -89,5 +92,18 @@ public class MassDriverBolt extends BasicBulletType{
     public void hit(Bullet b, float hitx, float hity){
         super.hit(b, hitx, hity);
         despawned(b);
+        if(b.data() instanceof DriverBulletData data){
+            float explosiveness = 0f;
+            float flammability = 0f;
+            float power = 0f;
+            for(int i = 0; i < data.items.length; i++){
+            	Item item = content.item(i);
+                explosiveness += item.explosiveness * data.items[i];
+                flammability += item.flammability * data.items[i];
+                power += item.charge * Mathf.pow(data.items[i], 1.1f) * 25f;
+            }
+            Damage.dynamicExplosion(b.x, b.y, flammability / 10f, explosiveness / 10f, power, 1f, state.rules.damageExplosions);
+        }
     }
+    
 }

--- a/core/src/mindustry/entities/bullet/MassDriverBolt.java
+++ b/core/src/mindustry/entities/bullet/MassDriverBolt.java
@@ -3,12 +3,11 @@ package mindustry.entities.bullet;
 import arc.graphics.*;
 import arc.graphics.g2d.*;
 import arc.math.*;
-import mindustry.Vars;
 import mindustry.content.*;
-import mindustry.entities.Damage;
+import mindustry.entities.*;
 import mindustry.gen.*;
 import mindustry.graphics.*;
-import mindustry.type.Item;
+import mindustry.type.*;
 import mindustry.world.blocks.distribution.MassDriver.*;
 
 import static mindustry.Vars.*;
@@ -105,5 +104,4 @@ public class MassDriverBolt extends BasicBulletType{
             Damage.dynamicExplosion(b.x, b.y, flammability / 10f, explosiveness / 10f, power, 1f, state.rules.damageExplosions);
         }
     }
-    
 }

--- a/core/src/mindustry/world/blocks/distribution/MassDriver.java
+++ b/core/src/mindustry/world/blocks/distribution/MassDriver.java
@@ -299,7 +299,7 @@ public class MassDriver extends Block{
 
             bullet.create(this, team,
                 x + Angles.trnsx(angle, translation), y + Angles.trnsy(angle, translation),
-                angle, -1f, bulletSpeed, bulletLifetime, data);
+                angle, totalUsed/2f, bulletSpeed, bulletLifetime, data);
 
             shootEffect.at(x + Angles.trnsx(angle, translation), y + Angles.trnsy(angle, translation), angle);
             smokeEffect.at(x + Angles.trnsx(angle, translation), y + Angles.trnsy(angle, translation), angle);


### PR DESCRIPTION
When a block (for example container) with items is destroyed, an `dynamicExplosion` is created depending on the items in it
Mass driver bolt too contains an items. It would be logical that when it hits an enemy, it would also creatis an `dynamicExplosion` depending on the objects inside.
I was very upset when I realized that bolt just disappears with all my items when hitting an enemy.
***
Single:

https://github.com/user-attachments/assets/5196faf0-f147-455f-93b1-2dc9002884fc

Groups:

https://github.com/user-attachments/assets/41647a9f-726a-487e-8e59-68d700479f4e

***

Considering the amount of items and the difficulty of hitting the target, I think the damage should be higher. 
But I was afraid to make it too big, given the fact that damage wasn't before.

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
