### PR TITLE
Setting null to counter should be a no-op

### DIFF
--- a/core/src/mindustry/logic/LVar.java
+++ b/core/src/mindustry/logic/LVar.java
@@ -103,8 +103,12 @@ public class LVar{
 
     public void set(LVar other){
         isobj = other.isobj;
-        objval = other.objval;
-        numval = other.numval;
+        // Setting a non-numeric value to @counter must preserve its numeric field
+        if(isobj){
+            objval = other.objval;
+        }else{
+            numval = other.numval;
+        }
     }
 
     public static boolean invalid(double d){


### PR DESCRIPTION
In the past, setting `null` to `@counter` (or any object value for that matter) was a no-op. Recent updates changed this behavior in such a way that setting `@counter`to `null` sets `@counter` to 0. The former behavior was used by some (e.g., a calling a null function pointer resulted in a no-op).

This PR restores the original behavior.

(Another way to fix the problem would be to create a special subclass of LVar for counter, which would make it more apparent in the code for other developers in the future, but I believe LVar not having subclasses allows for better optimization by JIT at runtime. I may be mistaken, though.)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
