### PR TITLE
Allowing multiple planets to have the same tech tree

### DIFF
--- a/core/src/mindustry/ui/dialogs/ResearchDialog.java
+++ b/core/src/mindustry/ui/dialogs/ResearchDialog.java
@@ -217,13 +217,13 @@ public class ResearchDialog extends BaseDialog{
             {
                 //first, find a planets associated with the current tech tree
                 rootPlanets.clear();
-                for (var planet : content.planets()){
-                    if (planet.techTree == lastNode)
+                for(var planet : content.planets()){
+                    if(planet.techTree == lastNode)
                         rootPlanets.add(planet);
                 }
 
                 //if there is no root, fall back to serpulo
-                if (rootPlanets.size == 0){
+                if(rootPlanets.size == 0){
                     rootPlanets.add(Planets.serpulo);
                 }
 

--- a/core/src/mindustry/ui/dialogs/ResearchDialog.java
+++ b/core/src/mindustry/ui/dialogs/ResearchDialog.java
@@ -46,6 +46,7 @@ public class ResearchDialog extends BaseDialog{
 
     public ItemSeq items;
 
+    private final Seq<Planet> rootPlanets = new Seq<>(false, 4);
     private boolean showTechSelect;
     private boolean needsRebuild;
 
@@ -214,21 +215,29 @@ public class ResearchDialog extends BaseDialog{
             ObjectMap<Sector, ItemSeq> cache = new ObjectMap<>();
 
             {
-                //first, find a planet associated with the current tech tree
-                Planet rootPlanet = lastNode.planet != null ? lastNode.planet : content.planets().find(p -> p.techTree == lastNode);
+                //first, find a planets associated with the current tech tree
+                rootPlanets.clear();
+                for (var planet : content.planets()){
+                    if (planet.techTree == lastNode)
+                        rootPlanets.add(planet);
+                }
 
                 //if there is no root, fall back to serpulo
-                if(rootPlanet == null) rootPlanet = Planets.serpulo;
+                if (rootPlanets.size == 0){
+                    rootPlanets.add(Planets.serpulo);
+                }
 
                 //add global counts of each sector
-                for(Sector sector : rootPlanet.sectors){
-                    if(sector.hasBase()){
-                        ItemSeq cached = sector.items();
-                        cache.put(sector, cached);
-                        cached.each((item, amount) -> {
-                            values[item.id] += Math.max(amount, 0);
-                            total += Math.max(amount, 0);
-                        });
+                for(Planet planet : rootPlanets){
+                    for(Sector sector : planet.sectors){
+                        if(sector.hasBase()){
+                            ItemSeq cached = sector.items();
+                            cache.put(sector, cached);
+                            cached.each((item, amount) -> {
+                                values[item.id] += Math.max(amount, 0);
+                                total += Math.max(amount, 0);
+                            });
+                        }
                     }
                 }
             }

--- a/core/src/mindustry/ui/dialogs/ResearchDialog.java
+++ b/core/src/mindustry/ui/dialogs/ResearchDialog.java
@@ -218,8 +218,9 @@ public class ResearchDialog extends BaseDialog{
                 //first, find a planets associated with the current tech tree
                 rootPlanets.clear();
                 for(var planet : content.planets()){
-                    if(planet.techTree == lastNode)
+                    if(planet.techTree == lastNode){
                         rootPlanets.add(planet);
+                    }
                 }
 
                 //if there is no root, fall back to serpulo


### PR DESCRIPTION
If multiple planets end-up having the same ``TechTree`` by any means - in ``ResearchDialog``, when fetching resources available on the planet, ``ResearchDialog`` will only take into account items from sectors of the **first** planet added during game/mod content loading.

As of right now, this impacts only mods.
To trigger this quirk in the base game you need to attach the same root ``TechNode`` to both the ``Planets.sun`` and ``Planets.serpulo``, for example, because ``sun`` is added to the ``content.planets()`` seq first. (e.g. both need to have the same ``Planet.techTree`` instance attached to them)

Other parts of the game is not impacted by the fix.
Also, I'm not sure who decided to use ``ObjectMap<Sector, ItemSeq> cache = new ObjectMap<>();`` to work with associated sectors, but he/she allowed to implement this change without any problems. Cheers!

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:
- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
