### PR TITLE
Rebuilds belt path when switching to diagonal placement mode.

### DIFF
--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -705,7 +705,7 @@ public class DesktopInput extends InputHandler{
             }
         }
 
-        if((cursorX != lastLineX || cursorY != lastLineY) && isPlacing() && mode == placing){
+        if(isPlacing() && mode == placing && (cursorX != lastLineX || cursorY != lastLineY || Core.input.keyTap(Binding.diagonalPlacement) || Core.input.keyRelease(Binding.diagonalPlacement))){
             updateLine(selectX, selectY);
             lastLineX = cursorX;
             lastLineY = cursorY;


### PR DESCRIPTION
As of right now, belt paths only being rebuilt if you press 'left control' (Binding.diagonalPlacement) **and** move your mouse to another tile (on the video, I'm tapping/releasing left control frequently)
Current behavior: https://github.com/user-attachments/assets/df51839a-13c3-4a76-9eea-a4ced85c9bbd

This request changes this condition, so that rebuilding will also happen when 'left control' is either tapped or released as well.
Updated behavior: https://github.com/user-attachments/assets/41ba83cc-02d8-45f8-8b4e-8221001b80f0
Just so you don't need to move your mouse back and forth when you already selected a tile, and need to switch between modes.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:
- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
