### PR TITLE
Add unitSot and add to only ripple

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -3987,6 +3987,7 @@ public class Blocks{
 
             scaledHealth = 130;
             shootSound = Sounds.artillery;
+            unitSort = UnitSorts.grouped;
         }};
 
         cyclone = new ItemTurret("cyclone"){{

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -3978,7 +3978,6 @@ public class Blocks{
             ammoUseEffect = Fx.casing3Double;
             ammoPerShot = 2;
             velocityRnd = 0.2f;
-            scaleLifetimeOffset = 1f / 9f;
             recoil = 6f;
             shake = 2f;
             range = 290f;

--- a/core/src/mindustry/entities/UnitSorts.java
+++ b/core/src/mindustry/entities/UnitSorts.java
@@ -11,7 +11,25 @@ public class UnitSorts{
     closest = Unit::dst2,
     farthest = (u, x, y) -> -u.dst2(x, y),
     strongest = (u, x, y) -> -u.maxHealth + Mathf.dst2(u.x, u.y, x, y) / 6400f,
-    weakest = (u, x, y) -> u.maxHealth + Mathf.dst2(u.x, u.y, x, y) / 6400f;
+    weakest = (u, x, y) -> u.maxHealth + Mathf.dst2(u.x, u.y, x, y) / 6400f,
+    //Fires at roughly the center of a unit cluster.
+    grouped = (u, x, y) -> {
+        int[] count = {0};
+        float[] avgX = {0f}, avgY = {0f};
+        Groups.unit.each(other -> {
+            if (other.team != u.team && u.dst2(other) <  120) {
+                count[0]++;
+                avgX[0] += other.x;
+                avgY[0] += other.y;
+                }
+            });
+        //No cluster.
+        if (count[0] == 0) return Float.MAX_VALUE;
+        avgX[0] /= count[0];
+        avgY[0] /= count[0];
+        float distToClusterCenter = Mathf.dst2(u.x, u.y, avgX[0], avgY[0]);
+        return distToClusterCenter - count[0] * 100f;
+    };
 
     public static BuildingPriorityf
 

--- a/core/src/mindustry/entities/UnitSorts.java
+++ b/core/src/mindustry/entities/UnitSorts.java
@@ -15,20 +15,12 @@ public class UnitSorts{
     //Fires at roughly the center of a unit cluster.
     grouped = (u, x, y) -> {
         int[] count = {0};
-        float[] avgX = {0f}, avgY = {0f};
-        Groups.unit.each(other -> {
-            if (other.team != u.team && u.dst2(other) <  120) {
+        Groups.unit.intersect(u.x - 140, u.y - 140, 140 * 2f, 140 * 2f, other -> {
+            if (other.team != u.team && u.dst2(other) <= 140) {
                 count[0]++;
-                avgX[0] += other.x;
-                avgY[0] += other.y;
-                }
-            });
-        //No cluster.
-        if (count[0] == 0) return Float.MAX_VALUE;
-        avgX[0] /= count[0];
-        avgY[0] /= count[0];
-        float distToClusterCenter = Mathf.dst2(u.x, u.y, avgX[0], avgY[0]);
-        return distToClusterCenter - count[0] * 100f;
+            }
+        });
+        return -count[0] + Mathf.dst2(u.x, u.y, x, y) / 12800f;
     };
 
     public static BuildingPriorityf

--- a/core/src/mindustry/entities/UnitSorts.java
+++ b/core/src/mindustry/entities/UnitSorts.java
@@ -23,7 +23,7 @@ public class UnitSorts{
                 count.set(0, count.get(0) + 1);
             }
         });
-        return count.get(0) + Mathf.dst2(u.x, u.y, x, y) / 6400f;
+        return -count.get(0) + Mathf.dst2(u.x, u.y, x, y) / 10000f;
     };
 
     public static BuildingPriorityf

--- a/core/src/mindustry/entities/UnitSorts.java
+++ b/core/src/mindustry/entities/UnitSorts.java
@@ -1,11 +1,13 @@
 package mindustry.entities;
 
 import arc.math.*;
+import arc.struct.IntSeq;
 import mindustry.content.*;
 import mindustry.entities.Units.*;
 import mindustry.gen.*;
 
 public class UnitSorts{
+    private static final IntSeq count = new IntSeq(1);
     public static Sortf
 
     closest = Unit::dst2,
@@ -14,13 +16,14 @@ public class UnitSorts{
     weakest = (u, x, y) -> u.maxHealth + Mathf.dst2(u.x, u.y, x, y) / 6400f,
     //Fires at roughly the center of a unit cluster.
     grouped = (u, x, y) -> {
-        int[] count = {0};
+        if (count.size < 1) count.add(0);
+        else count.set(0, 0);
         Groups.unit.intersect(u.x - 140, u.y - 140, 140 * 2f, 140 * 2f, other -> {
             if (other.team != u.team && u.dst2(other) <= 140) {
-                count[0]++;
+                count.set(0, count.get(0) + 1);
             }
         });
-        return -count[0] + Mathf.dst2(u.x, u.y, x, y) / 12800f;
+        return count.get(0) + Mathf.dst2(u.x, u.y, x, y) / 6400f;
     };
 
     public static BuildingPriorityf


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
Adds a unit sort for artillery turrets (excluding hail and titan due to balance reasons leaving only ripple) That targets the center of unit clusters for better dps efficiency.

https://github.com/user-attachments/assets/0c4f5f1c-337a-4014-a65b-310b834c26cd

