### PR TITLE
No timeout on drop to air

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -451,7 +451,7 @@ public class LExecutor{
                         }
                     }
                     case itemDrop -> {
-                        if(!exec.timeoutDone(unit, LogicAI.transferDelay)) return;
+                        if(p1.obj() != Blocks.air && !exec.timeoutDone(unit, LogicAI.transferDelay)) return;
 
                         //clear item when dropping to @air
                         if(p1.obj() == Blocks.air){
@@ -459,7 +459,6 @@ public class LExecutor{
                             if(!net.client()){
                                 unit.clearItem();
                             }
-                            exec.updateTimeout(unit);
                         }else{
                             Building build = p1.building();
                             int dropped = Math.min(unit.stack.amount, p2.numi());


### PR DESCRIPTION
Removes the timeout when dropping items to air. Spamming drop to air should not be a problem, because after the first one the state won't actually change. Not sure if there are other reasons for the timeout apart from a fast item transfer between nearby blocks - if there are, I guess this won't be possible to accept.

Again, inspired by the logic jam: it is difficult to use logic to mine an exact amount of items, e.g. when feeding a block using a unit. Just mining until the desired amount is reached often leads to an additional item being held, which then often incurs the timeout just to get rid of it.

A nicer alternative would be to add support for mining an exact amount of items, but that would require change to the instruction (a new parameter) and would be actually more complicated, since mining - unike itemDrop and itemTake - isn't instantaneous.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
