### PR TITLE
Sensor operating on incorrect tile of a tileable display

### DIFF
--- a/core/src/mindustry/world/blocks/logic/LogicDisplay.java
+++ b/core/src/mindustry/world/blocks/logic/LogicDisplay.java
@@ -73,6 +73,8 @@ public class LogicDisplay extends Block{
     }
 
     public class LogicDisplayBuild extends Building{
+        //The root display (bottom left corner of display for tileable displays)
+        public LogicDisplayBuild rootDisplay = this;
         public @Nullable FrameBuffer buffer;
         public float color = Color.whiteFloatBits;
         public float stroke = 1f;
@@ -107,16 +109,12 @@ public class LogicDisplay extends Block{
             Draw.blend();
         }
 
-        public LogicDisplayBuild rootDisplay(){
-            return this;
-        }
-
         @Override
         public double sense(LAccess sensor){
             return switch(sensor){
                 case displayWidth, displayHeight -> displaySize;
-                case bufferSize -> rootDisplay().commands.size;
-                case operations -> rootDisplay().operations;
+                case bufferSize -> rootDisplay.commands.size;
+                case operations -> rootDisplay.operations;
                 default -> super.sense(sensor);
             };
         }

--- a/core/src/mindustry/world/blocks/logic/TileableLogicDisplay.java
+++ b/core/src/mindustry/world/blocks/logic/TileableLogicDisplay.java
@@ -118,19 +118,12 @@ public class TileableLogicDisplay extends LogicDisplay{
     }
 
     public class TileableLogicDisplayBuild extends LogicDisplayBuild{
-        //bottom left corner of display
-        public TileableLogicDisplayBuild rootDisplay = this;
         //size of display area
         public int tilesWidth = 1, tilesHeight = 1, originX, originY;
         public @Nullable Seq<MergeBuffer> prevBuffers;
 
         public int bits = 0;
         public boolean needsUpdate = false;
-
-        @Override
-        public LogicDisplayBuild rootDisplay(){
-            return rootDisplay;
-        }
 
         @Override
         public double sense(LAccess sensor){


### PR DESCRIPTION
The sensor instruction operates on the linked tile of a tileable display, not on the root tile, giving wrong results.

~~I've created a method returning the root display, primarily so that, in case a new sensable property gets added, there would be just one place to fix. If you prefer to handle it in TileableLogicDisplay.sense without a new method being added, it can be easily done.~~

I've just moved the rootDisplay up to LogicDisplayBuild. It seems more in line with Mindustry coding style.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
