### PR TITLE
Fixed target ore check for wall-only miners

### DIFF
--- a/core/src/mindustry/ai/types/MinerAI.java
+++ b/core/src/mindustry/ai/types/MinerAI.java
@@ -36,9 +36,9 @@ public class MinerAI extends AIController{
         if(mining){
             if(timer.get(timerTarget2, 60 * 4) || targetItem == null){
                 if(ai != null && !ai.hasStance(UnitStance.mineAuto)){
-                    targetItem = content.items().min(i -> indexer.hasOre(i) && unit.canMine(i) && ai.hasStance(ItemUnitStance.getByItem(i)), i -> core.items.get(i));
+                    targetItem = content.items().min(i -> ((unit.type.mineFloor && indexer.hasOre(i)) || (unit.type.mineWalls && indexer.hasWallOre(i))) && unit.canMine(i) && ai.hasStance(ItemUnitStance.getByItem(i)), i -> core.items.get(i));
                 }else{
-                    targetItem = unit.type.mineItems.min(i -> indexer.hasOre(i) && unit.canMine(i), i -> core.items.get(i));
+                    targetItem = unit.type.mineItems.min(i -> ((unit.type.mineFloor && indexer.hasOre(i)) || (unit.type.mineWalls && indexer.hasWallOre(i))) && unit.canMine(i), i -> core.items.get(i));
                 }
             }
 


### PR DESCRIPTION
Fixed target ore check requiring wall-only miners to check for floor ore versions when deciding whether to mine the respective ore.
Does not effect any current content directly as no wall-mining vanilla units are currently granted MinerAI in game at this time, but would allow future and modded units to successfully mine from walls.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [Y] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [Y] I have ensured that my code compiles, if applicable.
- [Y] I have ensured that any new features in this PR function correctly in-game, if applicable.
