### PR TITLE
Editor copy paste (revisited)

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -607,6 +607,10 @@ toolmode.select = Select
 toolmode.select.description = Select tiles to copy.
 toolmode.paste = Paste
 toolmode.paste.description = Paste copied tiles.
+toolmode.flipx = Flip Horizontally
+toolmode.flipx.description = Flip the selection horizontally.
+toolmode.flipy = Flip Vertically
+toolmode.flipy.description = Flip the selection vertically.
 #unused
 toolmode.underliquid = Under Liquids
 toolmode.underliquid.description = Draw floors under liquid tiles.

--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -603,6 +603,10 @@ toolmode.fillcliffs = Fill Cliffs
 toolmode.fillcliffs.description = Turns walls into cliffs.
 toolmode.drawteams = Draw Teams
 toolmode.drawteams.description = Draw teams instead of blocks.
+toolmode.select = Select
+toolmode.select.description = Select tiles to copy.
+toolmode.paste = Paste
+toolmode.paste.description = Paste copied tiles.
 #unused
 toolmode.underliquid = Under Liquids
 toolmode.underliquid.description = Draw floors under liquid tiles.

--- a/core/src/mindustry/editor/EditorTool.java
+++ b/core/src/mindustry/editor/EditorTool.java
@@ -302,7 +302,7 @@ public enum EditorTool{
             }
         }
     },
-    copy(KeyCode.c, "select", "paste");
+    copy(KeyCode.c, "select", "paste", "flipx", "flipy");
 
     public static final EditorTool[] all = values();
 

--- a/core/src/mindustry/editor/EditorTool.java
+++ b/core/src/mindustry/editor/EditorTool.java
@@ -302,17 +302,7 @@ public enum EditorTool{
             }
         }
     },
-    copy(KeyCode.c, "select", "paste"){
-        @Override
-        public void modeChanged(int newMode) {
-            if(newMode == 1) {
-                ui.editor.pasteSelection();
-                newMode = -1;
-            }
-
-            super.modeChanged(newMode);
-        }
-    };
+    copy(KeyCode.c, "select", "paste");
 
     public static final EditorTool[] all = values();
 
@@ -348,8 +338,4 @@ public enum EditorTool{
     public void touched(int x, int y){}
 
     public void touchedLine(int x1, int y1, int x2, int y2){}
-
-	public void modeChanged(int newMode){
-        mode = newMode;
-    }
 }

--- a/core/src/mindustry/editor/EditorTool.java
+++ b/core/src/mindustry/editor/EditorTool.java
@@ -302,7 +302,17 @@ public enum EditorTool{
             }
         }
     },
-    copy(KeyCode.c);
+    copy(KeyCode.c, "select", "paste"){
+        @Override
+        public void modeChanged(int newMode) {
+            if(newMode == 1) {
+                ui.editor.pasteSelection();
+                newMode = -1;
+            }
+
+            super.modeChanged(newMode);
+        }
+    };
 
     public static final EditorTool[] all = values();
 
@@ -338,4 +348,8 @@ public enum EditorTool{
     public void touched(int x, int y){}
 
     public void touchedLine(int x1, int y1, int x2, int y2){}
+
+	public void modeChanged(int newMode){
+        mode = newMode;
+    }
 }

--- a/core/src/mindustry/editor/EditorTool.java
+++ b/core/src/mindustry/editor/EditorTool.java
@@ -301,7 +301,8 @@ public enum EditorTool{
                 editor.drawBlocks(x, y, tile -> Mathf.chance(chance));
             }
         }
-    };
+    },
+    copy(KeyCode.c);
 
     public static final EditorTool[] all = values();
 

--- a/core/src/mindustry/editor/MapEditorDialog.java
+++ b/core/src/mindustry/editor/MapEditorDialog.java
@@ -576,7 +576,13 @@ public class MapEditorDialog extends Dialog implements Disposable{
                                     b.row();
                                     b.add(Core.bundle.get("toolmode." + name + ".description")).color(Color.lightGray).left();
                                 }, () -> {
-                                    tool.modeChanged((tool.mode == mode ? -1 : mode));
+                                    int newMode = tool.mode == mode ? -1 : mode;
+                                    if(tool == EditorTool.copy && newMode == 1){
+                                        //paste upon pressing this, anything else would not make sense on mubile
+                                        view.pasteSelection();
+                                        newMode = -1;
+                                    }
+                                    tool.mode = newMode;
                                     table.remove();
                                 }).update(b -> b.setChecked(tool.mode == mode));
                                 table.row();
@@ -774,17 +780,13 @@ public class MapEditorDialog extends Dialog implements Disposable{
             }
 
             if(Core.input.keyTap(KeyCode.v)){
-                pasteSelection();
+                view.pasteSelection();
             }
 
             if(Core.input.keyTap(KeyCode.g)){
                 view.setGrid(!view.isGrid());
             }
         }
-    }
-
-    public void pasteSelection() {
-        view.pasteSelection();
     }
 
     private void tryExit(){

--- a/core/src/mindustry/editor/MapEditorDialog.java
+++ b/core/src/mindustry/editor/MapEditorDialog.java
@@ -577,11 +577,21 @@ public class MapEditorDialog extends Dialog implements Disposable{
                                     b.add(Core.bundle.get("toolmode." + name + ".description")).color(Color.lightGray).left();
                                 }, () -> {
                                     int newMode = tool.mode == mode ? -1 : mode;
+
+                                    //paste/flip upon pressing this, anything else would not make sense on mubile
                                     if(tool == EditorTool.copy && newMode == 1){
-                                        //paste upon pressing this, anything else would not make sense on mubile
                                         view.pasteSelection();
                                         newMode = -1;
                                     }
+                                    if(tool == EditorTool.copy && newMode == 2){
+                                        view.selection.flipX = !view.selection.flipX;
+                                        newMode = -1;
+                                    }
+                                    if(tool == EditorTool.copy && newMode == 3){
+                                        view.selection.flipY = !view.selection.flipY;
+                                        newMode = -1;
+                                    }
+
                                     tool.mode = newMode;
                                     table.remove();
                                 }).update(b -> b.setChecked(tool.mode == mode));
@@ -743,6 +753,14 @@ public class MapEditorDialog extends Dialog implements Disposable{
             if(!menu.isShown()){
                 menu.show();
             }
+        }
+
+        if(Core.input.keyTap(KeyCode.x)){
+            view.selection.flipY = !view.selection.flipY;
+        }
+
+        if(Core.input.keyTap(KeyCode.z)){
+            view.selection.flipX = !view.selection.flipX;
         }
 
         if(Core.input.keyTap(KeyCode.r)){

--- a/core/src/mindustry/editor/MapEditorDialog.java
+++ b/core/src/mindustry/editor/MapEditorDialog.java
@@ -650,10 +650,15 @@ public class MapEditorDialog extends Dialog implements Disposable{
 
                 tools.row();
 
+                addTool.get(EditorTool.copy);
+
+                tools.row();
+
                 tools.table(Tex.underline, t -> t.add("@editor.teams"))
                 .colspan(3).height(40).width(size * 3f + 3f).padBottom(3);
 
                 tools.row();
+
 
                 ButtonGroup<ImageButton> teamgroup = new ButtonGroup<>();
 
@@ -758,6 +763,18 @@ public class MapEditorDialog extends Dialog implements Disposable{
 
             if(Core.input.keyTap(KeyCode.s)){
                 save();
+            }
+
+            if(Core.input.keyTap(KeyCode.c)){
+                view.startSelection();
+            }
+
+            if(Core.input.keyRelease(KeyCode.c)){
+                view.endSelection();
+            }
+
+            if(Core.input.keyTap(KeyCode.v)){
+                view.pasteSelection();
             }
 
             if(Core.input.keyTap(KeyCode.g)){

--- a/core/src/mindustry/editor/MapEditorDialog.java
+++ b/core/src/mindustry/editor/MapEditorDialog.java
@@ -576,7 +576,7 @@ public class MapEditorDialog extends Dialog implements Disposable{
                                     b.row();
                                     b.add(Core.bundle.get("toolmode." + name + ".description")).color(Color.lightGray).left();
                                 }, () -> {
-                                    tool.mode = (tool.mode == mode ? -1 : mode);
+                                    tool.modeChanged((tool.mode == mode ? -1 : mode));
                                     table.remove();
                                 }).update(b -> b.setChecked(tool.mode == mode));
                                 table.row();
@@ -774,13 +774,17 @@ public class MapEditorDialog extends Dialog implements Disposable{
             }
 
             if(Core.input.keyTap(KeyCode.v)){
-                view.pasteSelection();
+                pasteSelection();
             }
 
             if(Core.input.keyTap(KeyCode.g)){
                 view.setGrid(!view.isGrid());
             }
         }
+    }
+
+    public void pasteSelection() {
+        view.pasteSelection();
     }
 
     private void tryExit(){

--- a/core/src/mindustry/editor/MapView.java
+++ b/core/src/mindustry/editor/MapView.java
@@ -15,7 +15,7 @@ import mindustry.*;
 import mindustry.graphics.*;
 import mindustry.input.*;
 import mindustry.ui.*;
-import mindustry.world.Tile;
+import mindustry.world.*;
 import mindustry.gen.*;
 
 import static mindustry.Vars.*;
@@ -401,7 +401,7 @@ public class MapView extends Element implements GestureListener{
     public void pinchStop(){
     }
 
-    public void startSelection() {
+    public void startSelection(){
         if(tool != EditorTool.copy) return;
 
         tool.mode = 0;
@@ -410,7 +410,7 @@ public class MapView extends Element implements GestureListener{
         copyStartY = p.y;
     }
 
-    public void endSelection() {
+    public void endSelection(){
         if(tool != EditorTool.copy) return;
 
         tool.mode = -1;
@@ -423,7 +423,7 @@ public class MapView extends Element implements GestureListener{
         selection.height = Math.abs(copyStartY - copyEndY) + 1;
     }
 
-    public void pasteSelection() {
+    public void pasteSelection(){
         if(tool != EditorTool.copy) return;
 
         Point2 p = project(mousex, mousey).sub(selection.width / 2, selection.height / 2);


### PR DESCRIPTION
This does not support:
- ~~rotating the selection - I have no idea how to visualize that~~
- preserving the building config beyond rotation - just copy stuff in sendbox mode

As suggested, the sampling selection is visualized as a white rectangle (if you know how to make it prettier, let me know). It has some quirks when doing overlapping pastes, but otherwise, it would not make sense.

Let me know if controls are intuitive. I am unable to judge since I implemented them (though I tried my best).

