### PR TITLE
Small Impact Reactor re-balance

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -2610,14 +2610,14 @@ public class Blocks{
             size = 4;
             health = 900;
             powerProduction = 130f;
-            itemDuration = 140f;
+            itemDuration = 150f;
             ambientSound = Sounds.pulse;
             ambientSoundVolume = 0.07f;
-            liquidCapacity = 80f;
+            liquidCapacity = 160f;
 
             consumePower(25f);
             consumeItem(Items.blastCompound);
-            consumeLiquid(Liquids.cryofluid, 0.25f);
+            consumeLiquid(Liquids.cryofluid, 14.75f / 60f);
         }};
 
         //erekir


### PR DESCRIPTION
In the last few years the impact reactor has barely been used due to its complex fuel production and cryofluid usage compared to thorium reactors. 
This PR reduces cryofluid usage by 0.25/s and blast by 0.03/s

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
