### PR TITLE
scale forcefield/shield abilities with healthmultiplier gamerule

### DIFF
--- a/core/src/mindustry/entities/abilities/ForceFieldAbility.java
+++ b/core/src/mindustry/entities/abilities/ForceFieldAbility.java
@@ -12,7 +12,6 @@ import mindustry.*;
 import mindustry.content.*;
 import mindustry.gen.*;
 import mindustry.graphics.*;
-import mindustry.type.*;
 import mindustry.ui.*;
 
 import static mindustry.Vars.*;

--- a/core/src/mindustry/entities/abilities/ForceFieldAbility.java
+++ b/core/src/mindustry/entities/abilities/ForceFieldAbility.java
@@ -12,6 +12,7 @@ import mindustry.*;
 import mindustry.content.*;
 import mindustry.gen.*;
 import mindustry.graphics.*;
+import mindustry.type.*;
 import mindustry.ui.*;
 
 import static mindustry.Vars.*;
@@ -34,6 +35,7 @@ public class ForceFieldAbility extends Ability{
     protected float radiusScale, alpha;
     protected boolean wasBroken = true;
 
+    private float scaledMax = max;
     private static float realRad;
     private static Unit paramUnit;
     private static ForceFieldAbility paramField;
@@ -78,6 +80,9 @@ public class ForceFieldAbility extends Ability{
 
     @Override
     public void update(Unit unit){
+
+        //gamerules can change during gameplay
+        scaledMax = max * Vars.state.rules.unitHealth(unit.team);
         if(unit.shield <= 0f && !wasBroken){
             unit.shield -= cooldown * regen;
 
@@ -86,8 +91,10 @@ public class ForceFieldAbility extends Ability{
 
         wasBroken = unit.shield <= 0f;
 
-        if(unit.shield < max){
+        if(unit.shield < scaledMax){
             unit.shield += Time.delta * regen;
+        }else{
+            unit.shield = scaledMax;
         }
 
         alpha = Math.max(alpha - Time.delta/10f, 0f);
@@ -136,12 +143,12 @@ public class ForceFieldAbility extends Ability{
 
     @Override
     public void displayBars(Unit unit, Table bars){
-        bars.add(new Bar("stat.shieldhealth", Pal.accent, () -> unit.shield / max)).row();
+        bars.add(new Bar("stat.shieldhealth", Pal.accent, () -> unit.shield / scaledMax)).row();
     }
 
     @Override
     public void created(Unit unit){
-        unit.shield = max;
+        unit.shield = scaledMax;
     }
 
     public void checkRadius(Unit unit){

--- a/core/src/mindustry/entities/abilities/ShieldArcAbility.java
+++ b/core/src/mindustry/entities/abilities/ShieldArcAbility.java
@@ -136,7 +136,7 @@ public class ShieldArcAbility extends Ability{
     public boolean pushUnits = true;
 
     /** State. */
-    protected float widthScale, alpha;
+    protected float widthScale, alpha, scaledMax = max;
 
     @Override
     public void addStats(Table t){
@@ -153,8 +153,12 @@ public class ShieldArcAbility extends Ability{
     @Override
     public void update(Unit unit){
 
-        if(data < max){
+        //gamerules can change during gameplay
+        scaledMax = max * Vars.state.rules.unitHealth(unit.team);
+        if(data < scaledMax){
             data += Time.delta * regen;
+        }else{
+            data = scaledMax;
         }
 
         boolean active = data > 0 && (unit.isShooting || !whenShooting);
@@ -176,7 +180,7 @@ public class ShieldArcAbility extends Ability{
 
     @Override
     public void created(Unit unit){
-        data = max;
+        data = scaledMax;
     }
 
     @Override
@@ -208,6 +212,6 @@ public class ShieldArcAbility extends Ability{
 
     @Override
     public void displayBars(Unit unit, Table bars){
-        bars.add(new Bar("stat.shieldhealth", Pal.accent, () -> data / max)).row();
+        bars.add(new Bar("stat.shieldhealth", Pal.accent, () -> data / scaledMax)).row();
     }
 }


### PR DESCRIPTION
Not scaling makes units like oct or quasar really useless when it s >1 (low survivability compared to other units), and also very tanky the other way around


https://github.com/user-attachments/assets/04f27aaa-4ec2-4ae7-9bba-895d15d5e171


If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
