### PR TITLE
show constructor build speed stat

### DIFF
--- a/core/src/mindustry/world/blocks/payloads/Constructor.java
+++ b/core/src/mindustry/world/blocks/payloads/Constructor.java
@@ -43,6 +43,7 @@ public class Constructor extends BlockProducer{
         super.setStats();
 
         stats.add(Stat.output, "@x@ ~ @x@", minBlockSize, minBlockSize, maxBlockSize, maxBlockSize);
+        stats.addPercent(Stat.buildSpeed, buildSpeed);
     }
 
     @Override


### PR DESCRIPTION
No hiding build speed values when it s actually needed for ratios thx
<img width="577" height="253" alt="image" src="https://github.com/user-attachments/assets/8143b8d7-2ea4-4bf5-853c-406c278caaff" />


If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
