### PR TITLE
Limit build progress per frame gamerule

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -1495,6 +1495,7 @@ rules.initialwavespacing = Initial Wave Spacing:[lightgray] (sec)
 rules.buildcostmultiplier = Build Cost Multiplier
 rules.buildspeedmultiplier = Build Speed Multiplier
 rules.deconstructrefundmultiplier = Deconstruct Refund Multiplier
+rules.limitbuildprogress = Limit Build Progress
 rules.waitForWaveToEnd = Waves Wait for Enemies
 rules.wavelimit = Map Ends After Wave
 rules.dropzoneradius = Drop Zone Radius:[lightgray] (tiles)

--- a/core/src/mindustry/game/Rules.java
+++ b/core/src/mindustry/game/Rules.java
@@ -104,6 +104,8 @@ public class Rules{
     public float buildCostMultiplier = 1f;
     /** Multiplier for building speed. */
     public float buildSpeedMultiplier = 1f;
+    /** Maximum block build progress that can be built per frame */
+    public float limitBuildProgress = Float.MAX_VALUE;
     /** Multiplier for percentage of materials refunded when deconstructing. */
     public float deconstructRefundMultiplier = 0.5f;
     /** Multiplier for time in timer objectives. */
@@ -283,6 +285,10 @@ public class Rules{
 
     public float buildSpeed(Team team){
         return buildSpeedMultiplier * teams.get(team).buildSpeedMultiplier;
+    }
+
+    public float limitBuildProgress(Team team){
+        return instantBuild ? Float.MAX_VALUE : limitBuildProgress / 60f;
     }
 
     public boolean isBanned(Block block){

--- a/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
+++ b/core/src/mindustry/ui/dialogs/CustomRulesDialog.java
@@ -170,6 +170,7 @@ public class CustomRulesDialog extends BaseDialog{
         check("@rules.disableworldprocessors", b -> rules.disableWorldProcessors = b, () -> rules.disableWorldProcessors);
         number("@rules.buildcostmultiplier", false, f -> rules.buildCostMultiplier = f, () -> rules.buildCostMultiplier, () -> !rules.infiniteResources);
         number("@rules.buildspeedmultiplier", f -> rules.buildSpeedMultiplier = f, () -> rules.buildSpeedMultiplier, 0.001f, 50f);
+        number("@rules.limitbuildprogress", f -> rules.limitBuildProgress = f, () -> rules.limitBuildProgress, 0f, Float.MAX_VALUE);
         number("@rules.deconstructrefundmultiplier", false, f -> rules.deconstructRefundMultiplier = f, () -> rules.deconstructRefundMultiplier, () -> !rules.infiniteResources, 0f, 1f);
         number("@rules.blockhealthmultiplier", f -> rules.blockHealthMultiplier = f, () -> rules.blockHealthMultiplier);
         number("@rules.blockdamagemultiplier", f -> rules.blockDamageMultiplier = f, () -> rules.blockDamageMultiplier);

--- a/core/src/mindustry/world/blocks/ConstructBlock.java
+++ b/core/src/mindustry/world/blocks/ConstructBlock.java
@@ -288,7 +288,7 @@ public class ConstructBlock extends Block{
 
             maxProgress = core == null || team.rules().infiniteResources ? maxProgress : checkRequired(core.items, maxProgress, true);
 
-            progress = Mathf.clamp(progress + maxProgress);
+            progress = Mathf.clamp(progress + Math.min(maxProgress, state.rules.limitBuildProgress * amount));
 
             if(progress >= 1f || state.rules.infiniteResources){
                 boolean canFinish = true;
@@ -362,7 +362,7 @@ public class ConstructBlock extends Block{
                 }
             }
 
-            progress = Mathf.clamp(progress - amount);
+            progress = Mathf.clamp(progress - Math.min(amount, state.rules.limitBuildProgress * amount));
 
             if(progress <= current.deconstructThreshold || state.rules.infiniteResources){
                 //add any leftover items that weren't obtained due to rounding errors


### PR DESCRIPTION

https://github.com/user-attachments/assets/cd92cd77-8ae6-406f-bbd7-8a9e934f2543

No more instant buildspeed thanks to 10 morbillion poly/mega. Could also be used in a formula to make buildspeed logarithmic instead of linear, but the main concern is informing the player that this exists (and it s not a bug)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
