### PR TITLE
Weather Effects Change Vision Radius of Units in Fog

### DIFF
--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -2380,7 +2380,7 @@ public class UnitTypes{
             speed = 3f;
             rotateSpeed = 15f;
             accel = 0.1f;
-            fogRadius = 0f;
+            baseFogRadius = 0f;
             itemCapacity = 30;
             health = 150f;
             engineOffset = 6f;
@@ -2426,7 +2426,7 @@ public class UnitTypes{
             speed = 3.3f;
             rotateSpeed = 17f;
             accel = 0.1f;
-            fogRadius = 0f;
+            baseFogRadius = 0f;
             itemCapacity = 50;
             health = 170f;
             engineOffset = 6f;
@@ -2477,7 +2477,7 @@ public class UnitTypes{
             speed = 3.55f;
             rotateSpeed = 19f;
             accel = 0.11f;
-            fogRadius = 0f;
+            baseFogRadius = 0f;
             itemCapacity = 70;
             health = 220f;
             engineOffset = 6f;
@@ -3188,7 +3188,7 @@ public class UnitTypes{
             rotateSpeed = 3f;
             health = 2900;
             armor = 7f;
-            fogRadius = 40f;
+            baseFogRadius = 40f;
             stepShake = 0f;
 
             legCount = 6;
@@ -3688,7 +3688,7 @@ public class UnitTypes{
             armor = 3f;
             hitSize = 12f;
             engineSize = 0;
-            fogRadius = 25;
+            baseFogRadius = 25;
             itemCapacity = 0;
 
             setEnginesMirror(
@@ -3735,7 +3735,7 @@ public class UnitTypes{
             hitSize = 25f;
             engineSize = 4.3f;
             engineOffset = 54f / 4f;
-            fogRadius = 25;
+            baseFogRadius = 25f;
             itemCapacity = 0;
             lowAltitude = true;
 
@@ -4177,7 +4177,7 @@ public class UnitTypes{
             pickupUnits = false;
             vulnerableWithPayloads = true;
 
-            fogRadius = 0f;
+            baseFogRadius = 0f;
             targetable = false;
             hittable = false;
 
@@ -4242,7 +4242,7 @@ public class UnitTypes{
             pickupUnits = false;
             vulnerableWithPayloads = true;
 
-            fogRadius = 0f;
+            baseFogRadius = 0f;
             targetable = false;
             hittable = false;
 

--- a/core/src/mindustry/content/Weathers.java
+++ b/core/src/mindustry/content/Weathers.java
@@ -23,6 +23,7 @@ public class Weathers{
             sizeMin = 2.6f;
             density = 1200f;
             attrs.set(Attribute.light, -0.15f);
+            attrs.set(Attribute.fogVisibilityMultiplier, 0.8f);
 
             sound = Sounds.windhowl;
             soundVol = 0f;
@@ -37,6 +38,7 @@ public class Weathers{
             status = StatusEffects.wet;
             sound = Sounds.rain;
             soundVol = 0.25f;
+            attrs.set(Attribute.fogVisibilityMultiplier, 0.8f);
         }};
 
         sandstorm = new ParticleWeather("sandstorm"){{
@@ -57,6 +59,7 @@ public class Weathers{
             sound = Sounds.wind;
             soundVol = 0.8f;
             duration = 7f * Time.toMinutes;
+            attrs.set(Attribute.fogVisibilityMultiplier, 0.6f);
         }};
 
         sporestorm = new ParticleWeather("sporestorm"){{
@@ -79,6 +82,7 @@ public class Weathers{
             sound = Sounds.wind;
             soundVol = 0.7f;
             duration = 7f * Time.toMinutes;
+            attrs.set(Attribute.fogVisibilityMultiplier, 0.7f);
         }};
 
         fog = new ParticleWeather("fog"){{
@@ -100,6 +104,7 @@ public class Weathers{
             attrs.set(Attribute.light, -0.3f);
             attrs.set(Attribute.water, 0.05f);
             opacityMultiplier = 0.47f;
+            attrs.set(Attribute.fogVisibilityMultiplier, 0.5f);
         }};
 
         suspendParticles = new ParticleWeather("suspend-particles"){{

--- a/core/src/mindustry/core/Logic.java
+++ b/core/src/mindustry/core/Logic.java
@@ -18,8 +18,10 @@ import mindustry.maps.*;
 import mindustry.type.*;
 import mindustry.type.Weather.*;
 import mindustry.world.*;
+import mindustry.world.blocks.Attributes;
 import mindustry.world.blocks.storage.*;
 import mindustry.world.blocks.storage.CoreBlock.*;
+import mindustry.world.meta.Attribute;
 
 import java.util.*;
 
@@ -213,6 +215,14 @@ public class Logic implements ApplicationListener{
                 state.stats.unitsCreated++;
             }
         });
+
+        Events.on(FogWeatherEvent.class,
+                e -> {
+                    for(Unit u : Groups.unit)
+                    {
+                        u.type.updateFogRadius(e.multiplier);
+                    }
+                });
     }
 
     private void checkOverlappingPlans(Team team, Tile tile){
@@ -522,10 +532,24 @@ public class Logic implements ApplicationListener{
                     runWave();
                 }
 
+
                 //apply weather attributes
                 state.envAttrs.clear();
                 state.envAttrs.add(state.rules.attributes);
                 Groups.weather.each(w -> state.envAttrs.add(w.weather.attrs, w.opacity));
+
+                //apply fog effects
+                float fogMultiplier = 1f;
+                for(WeatherState entry : Groups.weather){
+                    // get the fog multiplier from the weather’s attributes
+                    float mult = entry.weather.attrs.get(Attribute.fogVisibilityMultiplier);
+                    if(mult != 0f)
+                    {
+                        fogMultiplier *= mult;
+                    }
+                }
+                Events.fire(new FogWeatherEvent(fogMultiplier));
+
 
                 PerfCounter.entityUpdate.begin();
                 Groups.update();

--- a/core/src/mindustry/core/Logic.java
+++ b/core/src/mindustry/core/Logic.java
@@ -363,6 +363,19 @@ public class Logic implements ApplicationListener{
         }
     }
 
+    void updateFogFromWeather(){
+        float fogMultiplier = 1f;
+
+        for(WeatherState entry : Groups.weather){
+            float mult = entry.weather.attrs.get(Attribute.fogVisibilityMultiplier);
+            if(mult != 0f){
+                fogMultiplier *= mult;
+            }
+        }
+
+        Events.fire(new FogWeatherEvent(fogMultiplier));
+    }
+
     @Remote(called = Loc.server)
     public static void sectorCapture(){
         //the sector has been conquered - waves get disabled
@@ -539,16 +552,7 @@ public class Logic implements ApplicationListener{
                 Groups.weather.each(w -> state.envAttrs.add(w.weather.attrs, w.opacity));
 
                 //apply fog effects
-                float fogMultiplier = 1f;
-                for(WeatherState entry : Groups.weather){
-                    // get the fog multiplier from the weather’s attributes
-                    float mult = entry.weather.attrs.get(Attribute.fogVisibilityMultiplier);
-                    if(mult != 0f)
-                    {
-                        fogMultiplier *= mult;
-                    }
-                }
-                Events.fire(new FogWeatherEvent(fogMultiplier));
+                updateFogFromWeather();
 
 
                 PerfCounter.entityUpdate.begin();

--- a/core/src/mindustry/game/EventType.java
+++ b/core/src/mindustry/game/EventType.java
@@ -103,6 +103,11 @@ public class EventType{
     /** Called when a game begins and the world tiles are initiated. About to updates tile proximity and sets up physics for the world(Before WorldLoadEvent) */
     public static class WorldLoadEndEvent{}
 
+    public static class FogWeatherEvent{
+        public final float multiplier;
+
+        public FogWeatherEvent(float multiplier) { this.multiplier = multiplier; }
+    }
     /** Called when a save loads custom patches. {@link #patches} can be modified in the event handler. */
     public static class ContentPatchLoadEvent{
         public final Seq<String> patches;
@@ -785,4 +790,6 @@ public class EventType{
             this.action = action;
         }
     }
+
+
 }

--- a/core/src/mindustry/type/UnitType.java
+++ b/core/src/mindustry/type/UnitType.java
@@ -144,6 +144,8 @@ public class UnitType extends UnlockableContent implements Senseable{
     softShadowScl = 1f,
     /** fog view radius in tiles. <0 for automatic radius. */
     fogRadius = -1f,
+    /** base fog radius before effected by weather */
+    baseFogRadius = -1f,
 
     /** horizontal offset of wave trail in naval units */
     waveTrailX = 4f,
@@ -640,6 +642,11 @@ public class UnitType extends UnlockableContent implements Senseable{
 
     }
 
+    public void updateFogRadius(float multiplier)
+    {
+        fogRadius = baseFogRadius * multiplier;
+    }
+
     public void killed(Unit unit){}
 
     public void landed(Unit unit){}
@@ -926,10 +933,11 @@ public class UnitType extends UnlockableContent implements Senseable{
             }
         }
 
-        if(fogRadius < 0){
+        if(baseFogRadius < 0){
             //TODO depend on range?
-            fogRadius = Math.max(58f * 3f, hitSize * 2f) / 8f;
+            baseFogRadius = Math.max(58f * 3f, hitSize * 2f) / 8f;
         }
+        fogRadius = baseFogRadius;
 
         if(!weapons.contains(w -> w.useAttackRange)){
             if(range < 0 || range == Float.MAX_VALUE) range = mineRange;

--- a/core/src/mindustry/type/UnitType.java
+++ b/core/src/mindustry/type/UnitType.java
@@ -642,8 +642,7 @@ public class UnitType extends UnlockableContent implements Senseable{
 
     }
 
-    public void updateFogRadius(float multiplier)
-    {
+    public void updateFogRadius(float multiplier){
         fogRadius = baseFogRadius * multiplier;
     }
 

--- a/core/src/mindustry/type/Weather.java
+++ b/core/src/mindustry/type/Weather.java
@@ -32,6 +32,7 @@ public class Weather extends UnlockableContent{
     public float soundVol = 0.1f, soundVolMin = 0f;
     public float soundVolOscMag = 0f, soundVolOscScl = 20f;
     public boolean hidden = false;
+    public float fogRadiusMultiplier = 1f;
 
     //internals
     public Prov<WeatherState> type = WeatherState::create;

--- a/core/src/mindustry/world/meta/Attribute.java
+++ b/core/src/mindustry/world/meta/Attribute.java
@@ -22,7 +22,9 @@ public class Attribute{
     /** Used for sand extraction. */
     sand = add("sand"),
     /** Used for erekir vents only. */
-    steam = add("steam");
+    steam = add("steam"),
+    /** used to determine how weather effects vision in fog */
+    fogVisibilityMultiplier = add("fogVisibilityMultiplier");
 
     public final int id;
     public final String name;


### PR DESCRIPTION
Implementin a feature from: https://github.com/Anuken/Mindustry-Suggestions/issues/5237

Different weathers now get a fogVisibilityMultiplier stored in their attributes. 
Then in the logic update method the attributes get combined into 1 fogMultiplier (if multiple weathers are active at once) that gets passed using a FogWeatherEvent to all the active units which calculate their new fogRadius using baseFogRadius and the multiplier. 

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
