### PR TITLE
Fix BuildTower drawing another turret sprite below block

### DIFF
--- a/core/assets/contributors
+++ b/core/assets/contributors
@@ -187,3 +187,4 @@ Iniquit
 DSFdsfWxp
 Someone's Shadow
 buj
+nullevoy

--- a/core/src/mindustry/world/blocks/defense/BuildTurret.java
+++ b/core/src/mindustry/world/blocks/defense/BuildTurret.java
@@ -220,8 +220,6 @@ public class BuildTurret extends BaseTurret{
 
         @Override
         public void draw(){
-            super.draw();
-
             Draw.rect(baseRegion, x, y);
             Draw.color();
 


### PR DESCRIPTION
fixes the following:

<img width="614" height="438" alt="image" src="https://github.com/user-attachments/assets/db458662-8841-43f8-9f8f-a5eb0a7a62e6" />

(also adds contributor since I apparently never did that)

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
