### PR TITLE
shale 1.6→2 oil attribute

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -573,7 +573,7 @@ public class Blocks{
 
         shale = new Floor("shale"){{
             variants = 3;
-            attributes.set(Attribute.oil, 1.6f);
+            attributes.set(Attribute.oil, 2f);
         }};
 
         moss = new Floor("moss"){{


### PR DESCRIPTION
Despite a previous buff from 1 to 1.6 oil attribute, shale is incompetent and unable to compete with dark sand. 1.5 oil/s is not worth the requirement for an external sand input. It's gotten to the point where people will use **_light sand_** over shale for plastanium production in maps where shale appears in patches surrounding titanium ores. This results in shale only being a good option when the map author forces it to be (the same argument can be made even for salt. it's not a good argument to use against this change).

This change makes oil extractor output 30 oil/s on 9 tiles of shale, perfect for 2 plastanium compressors or 5 coal centrifuges. This is +6 oil/s compare to current shale oilex and +7.5 oil/s compared to dark sand oilex

![Screenshot_2025-11-28-10-52-48-66_13f989b68d7412e5a177fb13b36ac66f](https://github.com/user-attachments/assets/6f1caf42-7c5a-4c7c-9259-570847f0c941)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
