### PR TITLE
Unit stance no longer affects SectorDamage sum regen per second

### DIFF
--- a/core/src/mindustry/maps/SectorDamage.java
+++ b/core/src/mindustry/maps/SectorDamage.java
@@ -338,9 +338,7 @@ public class SectorDamage{
                 sumHealth += unit.health*healthMult + unit.shield;
                 sumDps += unit.type.dpsEstimate;
                 sumRps += unit.type.weapons.sumf(w -> w.shotsPerSec() * (w.bullet.healPercent/100f * 20f + w.bullet.healAmount));
-                if(unit.controller() instanceof CommandAI ai && ai.command == UnitCommand.rebuildCommand){
-                    sumRps += unit.type.buildSpeed * 20f;
-                }
+                sumRps += unit.type.buildSpeed * 20f;
             }else{
                 float bossMult = unit.isBoss() ? 3f : 1f;
                 curEnemyDps += unit.type.dpsEstimate * unit.damageMultiplier() * bossMult;


### PR DESCRIPTION
Units capable of building contribute more to sector AFK regen calculations if they are set to the rebuild stance. I propose making them contribute to AFK calculations as if they were always set to rebuild. This would be more intuitive, as right now, the player has no way of knowing that they have to set units to rebuild before leaving. 

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
