### PR TITLE
Allow presenting command for reconstructor

### DIFF
--- a/core/src/mindustry/world/blocks/units/Reconstructor.java
+++ b/core/src/mindustry/world/blocks/units/Reconstructor.java
@@ -178,7 +178,7 @@ public class Reconstructor extends UnitBlock{
 
         public boolean canSetCommand(){
             var output = unit();
-            return output != null && output.commands.size > 1 && output.allowChangeCommands;
+            return output == null || (output.commands.size > 1 && output.allowChangeCommands);
         }
 
         @Override
@@ -195,25 +195,20 @@ public class Reconstructor extends UnitBlock{
         public void buildConfiguration(Table table){
             var unit = unit();
 
-            if(unit == null){
-                deselect();
-                return;
-            }
-
             var group = new ButtonGroup<ImageButton>();
             group.setMinCheckCount(0);
             int i = 0, columns = 4;
 
             table.background(Styles.black6);
 
-            var list = unit().commands;
+            var list = unit == null ? Vars.content.unitCommands() : unit.commands;
             for(var item : list){
                 ImageButton button = table.button(item.getIcon(), Styles.clearNoneTogglei, 40f, () -> {
                     configure(item);
                     deselect();
                 }).tooltip(item.localized()).group(group).get();
 
-                button.update(() -> button.setChecked(command == item || (command == null && unit.defaultCommand == item)));
+                button.update(() -> button.setChecked(command == item || (unit != null && command == null && unit.defaultCommand == item)));
 
                 if(++i % columns == 0){
                     table.row();


### PR DESCRIPTION
I found that players have to wait for a unit to be reconstructed before they can see what commands are available for the reconstructors. That's terribly annoying when you're eager to build a reconstructor for poly to assist your building.

The current pull request might not be the best solution, since it will show unavailable commands.


https://github.com/user-attachments/assets/22d84121-8a6f-4394-9551-d42d4eab0edc



If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
