### PR TITLE
Unloader fixed stupid bug

### DIFF
--- a/core/src/mindustry/world/blocks/storage/Unloader.java
+++ b/core/src/mindustry/world/blocks/storage/Unloader.java
@@ -97,7 +97,7 @@ public class Unloader extends Block{
         protected final Comparator<ContainerStat> comparator = (x, y) -> {
             //sort so it gives priority for blocks that can only either receive or give (not both), and then by load, and then by last use
             //highest = unload from, lowest = unload to
-            int unloadCore = Boolean.compare(!x.notStorage, !y.notStorage); //priority to containers always
+            int unloadCore = Boolean.compare(!x.notStorage, !y.notStorage); //priority to core and core containers always
             if(unloadCore != 0) return unloadCore;
             int unloadPriority = Boolean.compare(x.canUnload && !x.canLoad, y.canUnload && !y.canLoad); //priority to receive if it cannot give
             if(unloadPriority != 0) return unloadPriority;


### PR DESCRIPTION
Prioritize core/core container always regardless if factory is full. Previously it would unload from the factory if full, lowering core unloader throughput (11/s is expected).
<img width="623" height="919" alt="image" src="https://github.com/user-attachments/assets/81130271-22b7-49b2-8a98-f2072f6da90d" />
<img width="552" height="401" alt="image" src="https://github.com/user-attachments/assets/57d16df6-6618-43aa-8c3b-3da7b977516d" />
<img width="609" height="482" alt="image" src="https://github.com/user-attachments/assets/b0667bec-a83c-40bd-a857-17ed47e588ea" />


As seen in these images utilizing the corner will make the unloader unload from the factory up to 50% of the time, greatly reducing core throughput. The fix is easy but you d expect unloader behaviour to be consistent (prioritize core unloading)

### Before
<img width="611" height="362" alt="image" src="https://github.com/user-attachments/assets/69f52770-87cb-4176-be85-493c1fa4ac2b" />
<img width="1478" height="309" alt="image" src="https://github.com/user-attachments/assets/3f90c96a-53f5-41c0-9129-dfef1069f5ec" />

### After
<img width="480" height="372" alt="image" src="https://github.com/user-attachments/assets/1ad8879c-1f8f-4474-8e45-7d38613bc12a" />
<img width="1479" height="235" alt="image" src="https://github.com/user-attachments/assets/378d68d4-cfdf-4df4-91fd-37e43cd0654e" />


### Map used for testing:
<img width="1148" height="909" alt="image" src="https://github.com/user-attachments/assets/47899469-96da-4938-8fcc-df5b6606d8aa" />
Tldr, no lag increase, it s literally a boolean on a field that is only updated once on proximity



### Also content patcher qol
<img width="541" height="64" alt="image" src="https://github.com/user-attachments/assets/6528037a-e6bb-43ff-9f56-33127367fc05" />
<img width="769" height="454" alt="image" src="https://github.com/user-attachments/assets/1dc61135-84d2-4c0c-87d7-671afdfe1215" />

And a release:
https://github.com/EggleEgg/Mindustry/releases/tag/adsda


If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
