### PR TITLE
Translation: Update bundle_hu.properties

### DIFF
--- a/core/assets/bundles/bundle_hu.properties
+++ b/core/assets/bundles/bundle_hu.properties
@@ -850,7 +850,7 @@ difficulty.normal = Normál
 difficulty.hard = Nehéz
 difficulty.eradication = Irtózatos
 
-difficulty.enemyHealthMultiplier = Ellenség életpontja: {0}
+difficulty.enemyHealthMultiplier = Ellenség életpontjai: {0}
 difficulty.enemySpawnMultiplier = Ellenségek száma: {0}
 difficulty.waveTimeMultiplier = Hullámidőzítő: {0}
 difficulty.nomodifiers = [lightgray](Nincsenek módosítók)


### PR DESCRIPTION
Updated various terms to use 'életpont' instead of 'életerő' for consistency in the Hungarian localization for the word health.

Follow the changes of the english bundle minimum game version: 147 -> 154

Fix typo