### PR TITLE
Added descentSpeed to UnitType.java

### DIFF
--- a/core/src/mindustry/ai/types/GroundAI.java
+++ b/core/src/mindustry/ai/types/GroundAI.java
@@ -55,7 +55,7 @@ public class GroundAI extends AIController{
         }
 
         if(unit.type.canBoost && unit.elevation > 0.001f && !unit.onSolid()){
-            unit.elevation = Mathf.approachDelta(unit.elevation, 0f, unit.type.riseSpeed);
+            unit.elevation = Mathf.approachDelta(unit.elevation, 0f, unit.type.descentSpeed);
         }
 
         faceTarget();

--- a/core/src/mindustry/ai/types/HugAI.java
+++ b/core/src/mindustry/ai/types/HugAI.java
@@ -54,7 +54,7 @@ public class HugAI extends AIController{
         }
 
         if(unit.type.canBoost && unit.elevation > 0.001f && !unit.onSolid()){
-            unit.elevation = Mathf.approachDelta(unit.elevation, 0f, unit.type.riseSpeed);
+            unit.elevation = Mathf.approachDelta(unit.elevation, 0f, unit.type.descentSpeed);
         }
 
         faceTarget();

--- a/core/src/mindustry/ai/types/LogicAI.java
+++ b/core/src/mindustry/ai/types/LogicAI.java
@@ -109,7 +109,8 @@ public class LogicAI extends AIController{
         }
 
         if(unit.type.canBoost && !unit.type.flying){
-            unit.elevation = Mathf.approachDelta(unit.elevation, Mathf.num(boost || unit.onSolid() || (unit.isFlying() && !unit.canLand())), unit.type.riseSpeed);
+            boolean shouldBoost = boost || unit.onSolid() || (unit.isFlying() && !unit.canLand());
+            unit.elevation = Mathf.approachDelta(unit.elevation, Mathf.num(shouldBoost), shouldBoost ? unit.type.riseSpeed : unit.type.descentSpeed);
         }
 
         //look where moving if there's nothing to aim at

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -397,7 +397,7 @@ public class UnitTypes{
             health = 320f;
             buildSpeed = 0.5f;
             armor = 4f;
-            riseSpeed = 0.07f;
+            riseSpeed = descentSpeed = 0.07f;
 
             mineTier = 2;
             mineSpeed = 3f;
@@ -453,7 +453,7 @@ public class UnitTypes{
             canBoost = true;
             armor = 9f;
             mechLandShake = 2f;
-            riseSpeed = 0.05f;
+            riseSpeed = descentSpeed = 0.05f;
 
             mechFrontSway = 0.55f;
             ammoType = new PowerAmmoType(1500);
@@ -509,7 +509,7 @@ public class UnitTypes{
             engineOffset = 12f;
             engineSize = 6f;
             lowAltitude = true;
-            riseSpeed = 0.02f;
+            riseSpeed = descentSpeed = 0.02f;
 
             health = 8200f;
             armor = 9f;

--- a/core/src/mindustry/entities/comp/PlayerComp.java
+++ b/core/src/mindustry/entities/comp/PlayerComp.java
@@ -167,7 +167,8 @@ abstract class PlayerComp implements UnitController, Entityc, Syncc, Timerc, Dra
 
             //update some basic state to sync things
             if(unit.type.canBoost){
-                unit.elevation = Mathf.approachDelta(unit.elevation, unit.onSolid() || boosting || (unit.isFlying() && !unit.canLand()) ? 1f : 0f, unit.type.riseSpeed);
+                boolean shouldBoost = unit.onSolid() || boosting || (unit.isFlying() && !unit.canLand());
+                unit.elevation = Mathf.approachDelta(unit.elevation, shouldBoost ? 1f : 0f, shouldBoost ? unit.type.riseSpeed : unit.type.descentSpeed);
             }
         }else if((core = bestCore()) != null){
             //have a small delay before death to prevent the camera from jumping around too quickly

--- a/core/src/mindustry/entities/comp/UnitComp.java
+++ b/core/src/mindustry/entities/comp/UnitComp.java
@@ -113,7 +113,8 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
     public void updateBoosting(boolean boost){
         if(!type.canBoost || dead) return;
 
-        elevation = Mathf.approachDelta(elevation, type.canBoost ? Mathf.num(boost || onSolid() || (isFlying() && !canLand())) : 0f, type.riseSpeed);
+        boolean shouldBoost = boost || onSolid() || (isFlying() && !canLand());
+        elevation = Mathf.approachDelta(elevation, type.canBoost ? Mathf.num(shouldBoost) : 0f, shouldBoost ? type.riseSpeed : type.descentSpeed);
     }
 
     /** Move based on preferred unit movement type. */

--- a/core/src/mindustry/type/UnitType.java
+++ b/core/src/mindustry/type/UnitType.java
@@ -77,7 +77,9 @@ public class UnitType extends UnlockableContent implements Senseable{
     rippleScale = 1f,
     /** boosting rise speed as fraction */
     riseSpeed = 0.08f,
-    /** how fast this unit falls when not boosting */
+    /** boosting descent speed as fraction */
+    descentSpeed = 0.08f,
+    /** how fast this unit falls upon death */
     fallSpeed = 0.018f,
     /** how many ticks it takes this missile to accelerate to full speed */
     missileAccelTime = 0f,


### PR DESCRIPTION
### Purpose
- Mostly because riseSpeed and fallSpeed have misleading descriptions...
- Currently riseSpeed is for both boost ascent and boost descent, while fallSpeed is only for dying units...
- So I added descentSpeed to fulfill said expectations, keep riseSpeed only for ascent and fallSpeed same as is.


### Proof of Function

Descent works

https://github.com/user-attachments/assets/80370df6-92f5-4b75-b032-c5027ac7f2d1


Rise works

https://github.com/user-attachments/assets/221c6826-8b27-402d-829c-08228c8afb44


If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
