### PR TITLE
Increase operations count even on headless

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -985,9 +985,6 @@ public class LExecutor{
 
         @Override
         public void run(LExecutor exec){
-            //graphics on headless servers are useless.
-            if(Vars.headless) return;
-
             if(target.building() instanceof LogicDisplayBuild d && d.isValid() && (d.team == exec.team || exec.privileged)){
                 d.flushCommands(exec.graphicsBuffer);
                 exec.graphicsBuffer.clear();


### PR DESCRIPTION
This change is made to ensure logic is slightly more consistent on both singleplayer and multiplayer. Currently, the `operations` count of displays isn't updated on the the server, which could lead to logic not working as expected when joining a multiplayer game. For example, the following mlog code is meant to only draw to a display once.
```
sensor op display1 @operations
jump 0 notEqual op 0
draw color 116 105 96 255 0 0
draw rect 0 0 176 176 0 0
draw color 210 195 190 175 0 0
draw triangle 62 111 62 41 165 44
draw color 0 0 0 175 0 0
draw triangle -16 21 175 12 21 -16
draw color 0 0 0 175 0 0
draw triangle 175 165 -16 169 182 191
draw color 187 170 150 175 0 0
draw triangle 160 161 160 63 13 160
draw color 0 0 0 175 0 0
draw triangle 119 0 191 44 175 -16
draw color 171 157 147 175 0 0
draw triangle 154 19 16 168 19 17
draw color 0 0 0 175 0 0
draw triangle 11 1 -16 82 9 191
... A bunch more instructions here
drawflush display1
```
On singleplayer, the logic performs as expected:

https://github.com/user-attachments/assets/6e1cb67e-9663-40fa-942a-032ba1ffc152

However on multiplayer, the `@counter` variable is pretty much random:


https://github.com/user-attachments/assets/2455f660-2156-48d7-b220-b7ff2f881083

The proposed fix helps ensure that on the server side, the processor's counter will be halted at the region that does the operation count checks like in singleplayer. 

https://github.com/user-attachments/assets/15a9c7ab-0f4c-440f-aa96-03704e8da97e

I don't expect removing this check to have that any significant impact on performance, since the graphics buffer will be empty on headless. 
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:


- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
