### PR TITLE
scale most consumers with timescale

### DIFF
--- a/core/src/mindustry/world/blocks/defense/ForceProjector.java
+++ b/core/src/mindustry/world/blocks/defense/ForceProjector.java
@@ -207,7 +207,7 @@ public class ForceProjector extends Block{
 
             phaseHeat = Mathf.lerpDelta(phaseHeat, Mathf.num(phaseValid), 0.1f);
 
-            if(phaseValid && !broken && timer(timerUse, phaseUseTime) && efficiency > 0){
+            if(phaseValid && !broken && timer(timerUse, phaseUseTime / timeScale) && efficiency > 0){
                 consume();
             }
 

--- a/core/src/mindustry/world/blocks/defense/MendProjector.java
+++ b/core/src/mindustry/world/blocks/defense/MendProjector.java
@@ -98,7 +98,7 @@ public class MendProjector extends Block{
 
             phaseHeat = Mathf.lerpDelta(phaseHeat, optionalEfficiency, 0.1f);
 
-            if(optionalEfficiency > 0 && timer(timerUse, useTime) && canHeal){
+            if(optionalEfficiency > 0 && timer(timerUse, useTime / timeScale) && canHeal){
                 consume();
             }
 

--- a/core/src/mindustry/world/blocks/defense/RegenProjector.java
+++ b/core/src/mindustry/world/blocks/defense/RegenProjector.java
@@ -139,7 +139,7 @@ public class RegenProjector extends Block{
             anyTargets = targets.contains(b -> b.damaged());
 
             if(efficiency > 0){
-                if((optionalTimer += Time.delta * optionalEfficiency) >= optionalUseTime){
+                if((optionalTimer += edelta() * optionalEfficiency) >= optionalUseTime){
                     consume();
                     optionalTimer = 0f;
                 }

--- a/core/src/mindustry/world/blocks/production/WallCrafter.java
+++ b/core/src/mindustry/world/blocks/production/WallCrafter.java
@@ -204,7 +204,7 @@ public class WallCrafter extends Block{
                 }
             }, null) * Mathf.lerp(1f, liquidBoostIntensity, hasLiquidBooster ? optionalEfficiency : 0f) * (itemValid ? itemBoostIntensity : 1f);
 
-            if(itemValid && eff * efficiency > 0 && timer(timerUse, boostItemUseTime)){
+            if(itemValid && eff * efficiency > 0 && timer(timerUse, boostItemUseTime / timeScale)){
                 consume();
             }
 


### PR DESCRIPTION
<img width="777" height="107" alt="image" src="https://github.com/user-attachments/assets/97ece4b9-8bfd-4ba4-98a6-56099850055a" />
Phased mender under odd consumes 0.06 phase/s, perfectly balanced

### Before:
<img width="726" height="862" alt="image" src="https://github.com/user-attachments/assets/3de59ffe-afae-49a2-800b-17ff7af521c6" />

### After:
<img width="679" height="453" alt="image" src="https://github.com/user-attachments/assets/288397b0-027c-4620-a4f9-4b9659802f71" />

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

<img width="639" height="92" alt="image" src="https://github.com/user-attachments/assets/3c4590fb-1ff7-4ae2-be68-674b4bf8d0b6" />
