### PR TITLE
Minke and fortress dont overrange hail, swarmer and even spectre

### DIFF
--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -176,7 +176,8 @@ public class UnitTypes{
                 bullet = new ArtilleryBulletType(2f, 20, "shell"){{
                     hitEffect = Fx.blastExplosion;
                     knockback = 0.8f;
-                    lifetime = 120f;
+                    lifetime = 120f - 35f / 2f;
+                    rangeOverride = 240f;
                     width = height = 14f;
                     collides = true;
                     collidesTiles = true;
@@ -1676,7 +1677,7 @@ public class UnitTypes{
                 ejectEffect = Fx.casing1;
                 shootSound = Sounds.shootDuo;
                 bullet = new FlakBulletType(4.2f, 3){{
-                    lifetime = 60f;
+                    lifetime = 52.5f;
                     ammoMultiplier = 4f;
                     shootEffect = Fx.shootSmall;
                     width = 6f;
@@ -1700,7 +1701,7 @@ public class UnitTypes{
                 bullet = new ArtilleryBulletType(3f, 20, "shell"){{
                     hitEffect = Fx.flakExplosion;
                     knockback = 0.8f;
-                    lifetime = 80f;
+                    lifetime = 73.5f;
                     width = height = 11f;
                     collidesTiles = false;
                     splashDamageRadius = 30f * 0.75f;


### PR DESCRIPTION
<img width="752" height="338" alt="image" src="https://github.com/user-attachments/assets/cf4502e9-b219-4eb1-92c2-28a6a7600d70" />
<img width="858" height="476" alt="image" src="https://github.com/user-attachments/assets/2abc0086-22dc-4669-bbab-5d865bc17b3d" />
<img width="1565" height="208" alt="image" src="https://github.com/user-attachments/assets/aa4b46fe-ba1c-4002-806f-e4cc848231d7" />

.

**Old** fortress -> 120 * 2 + 35 = 34,38 tiles max range, 29.5 tiles range
**New** fortress -> 102.5 * 2 + 35 = 30 tiles max range, 29.5 tiles range
**Old** minke -> 80 * 3 + 22.5 = 32.81 tiles max range, 29.5 tiles range
**New** minke -> 73.5 * 3 + 22.5 = 30.38 tiles max range, 27 tiles range



If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
