### PR TITLE
bugfix: lancer does not scale correctly under odd and booster

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -3557,7 +3557,7 @@ public class Blocks{
         }};
 
         lancer = new PowerTurret("lancer"){{
-            requirements(Category.turret, with(Items.copper, 60, Items.lead, 70, Items.silicon, 60, Items.titanium, 30));
+            requirements(Category.turret, with(Items.copper, 80, Items.lead, 90, Items.silicon, 80, Items.titanium, 40));
             range = 165f;
 
             shoot.firstShotDelay = 40f;
@@ -3577,7 +3577,7 @@ public class Blocks{
             coolant = consumeCoolant(0.2f);
             chargeSound = Sounds.chargeLancer;
 
-            consumePower(6f);
+            consumePower(8f);
 
             shootType = new LaserBulletType(140){{
                 colors = new Color[]{Pal.lancerLaser.cpy().a(0.4f), Pal.lancerLaser, Color.white};

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -3557,7 +3557,7 @@ public class Blocks{
         }};
 
         lancer = new PowerTurret("lancer"){{
-            requirements(Category.turret, with(Items.copper, 80, Items.lead, 90, Items.silicon, 80, Items.titanium, 40));
+            requirements(Category.turret, with(Items.copper, 60, Items.lead, 70, Items.silicon, 60, Items.titanium, 30));
             range = 165f;
 
             shoot.firstShotDelay = 40f;
@@ -3577,7 +3577,7 @@ public class Blocks{
             coolant = consumeCoolant(0.2f);
             chargeSound = Sounds.chargeLancer;
 
-            consumePower(8f);
+            consumePower(6f);
 
             shootType = new LaserBulletType(140){{
                 colors = new Color[]{Pal.lancerLaser.cpy().a(0.4f), Pal.lancerLaser, Color.white};

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -742,7 +742,7 @@ public class Turret extends ReloadTurret{
                 int barrel = barrelCounter;
 
                 if(delay > 0f){
-                    Time.run(delay, () -> {
+                    Time.run(delay / timeScale, () -> {
                         //hack: make sure the barrel is the same as what it was when the bullet was queued to fire
                         int prev = barrelCounter;
                         barrelCounter = barrel;

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -75,6 +75,8 @@ public class Turret extends ReloadTurret{
     public float minWarmup = 0f;
     /** If true, this turret will accurately target moving targets with respect to shoot.firstShotDelay. */
     public boolean accurateDelay = true;
+    /** Whether shoot.firstShotDelay should be affected (reduced) by timescale */
+    public boolean shotDelayTimescale = true;
     /** If false, this turret can't move while charging. */
     public boolean moveWhileCharging = true;
     /** If false, this turret can't reload while charging */
@@ -432,7 +434,7 @@ public class Turret extends ReloadTurret{
 
             //when delay is accurate, assume unit has moved by chargeTime already
             if(accurateDelay && !moveWhileCharging && pos instanceof Hitboxc h){
-                offset.set(h.deltaX(), h.deltaY()).scl(shoot.firstShotDelay / Time.delta);
+                offset.set(h.deltaX(), h.deltaY()).scl(shoot.firstShotDelay / (shotDelayTimescale ? delta() : Time.delta));
             }
 
             if(predictTarget && bullet.speed >= 0.01f){
@@ -491,7 +493,7 @@ public class Turret extends ReloadTurret{
                 }
             }
             heat = Mathf.approachDelta(heat, 0, 1 / cooldownTime);
-            charge = charging() ? Mathf.approachDelta(charge, 1, 1 / shoot.firstShotDelay) : 0;
+            charge = charging() ? Mathf.approachDelta(charge, 1, (1 / shoot.firstShotDelay) * (shotDelayTimescale ? timeScale : 1f)) : 0;
 
             unit.tile(this);
             unit.rotation(rotation);
@@ -742,7 +744,7 @@ public class Turret extends ReloadTurret{
                 int barrel = barrelCounter;
 
                 if(delay > 0f){
-                    Time.run(delay / timeScale, () -> {
+                    Time.run((shotDelayTimescale ? delay / timeScale : delay), () -> {
                         //hack: make sure the barrel is the same as what it was when the bullet was queued to fire
                         int prev = barrelCounter;
                         barrelCounter = barrel;


### PR DESCRIPTION
<img width="663" height="172" alt="image" src="https://github.com/user-attachments/assets/bd987f67-9df1-4ed8-9ab7-37e88dbcb3e6" />

More incentives to boost your lancers instead of spamming them, otherwise you end up with half the expected dps with cryo and odd

### Before
<img width="801" height="463" alt="image" src="https://github.com/user-attachments/assets/b606798d-0f47-4100-909f-3add6e0957d7" />

### After
<img width="939" height="278" alt="image" src="https://github.com/user-attachments/assets/f7cf0e4d-3a3d-46e6-a8d1-e13815af5636" />

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
