### PR TITLE
Fix tileable display not being updated when the root tile is not shown

### DIFF
--- a/core/src/mindustry/world/blocks/logic/TileableLogicDisplay.java
+++ b/core/src/mindustry/world/blocks/logic/TileableLogicDisplay.java
@@ -211,9 +211,9 @@ public class TileableLogicDisplay extends LogicDisplay{
                         prevBuffers.clear();
                     }
                 });
-
-                processCommands();
             }
+
+            rootDisplay.processCommands();
 
             float offset = 0.001f + (rootDisplay.buffer == null ? 0f : (rootDisplay.buffer.hashCode() % 1_000_000) / 1_000_000f * 0.01f);
 


### PR DESCRIPTION
The tileable display doesn't get updated (the draw commands aren't processed) when the root tile is off screen.

Testing schematics:

```
bXNjaAF4nC3OPWjdVRiA8ZN7vr/Pv6AQIjWCuhVMBClIF1FRMcU6JGBjyzW5hAvXe0NukBZpwSnUL4iCOBRcqkOhg0NpkQziB4iDEBwMUpzawUW3Igiil8cDLw+8w/s74phoSqhx/82ByC/3d7YGi88Op9uj/kURNibj3cF4d6W/LXpvXxJxczDd2Blu7w4nYyGEGfXfGIymonf29Z6oo8nWcOPE9s5kYzCdTnbEsd3haHCC7eb/B8XcnJi98t+8c+HqyodnQ28pPffk5RfX9h94YXnxr99Xn1n48pWtl16bXz8c/fxTvGe+OXXxLfGE/dhfenXp2hcLN67c+XHlvdVrnz21fvDo9/989d2ZHx7ce/fwg/nH1PsrB5/+cnvh171bzz9+9/if5/au37/19/5v96488snVu9+OPzr64/zRzbWnTz780Glx/uvTy5+LOdGb/WaWOdIjkiiiiSGWOOJJIJEkkkkhdRaJJ/EknsSTeBJP4kk8iSfxJJ7Ek3gST+JJPIWn8BSewlN4Ck/hKTyFp/AUnsJTeApP4Sk8jafxNJ7G03gaT+NpPI2n8TSextN4Gk/jaTyDZ/AMnsEzeAbP4Bk8g2fwDJ7BM3gGz+AZPItn8SyexbN4Fs/iWTyLZ/EsnsWzeBbP4lk8h+fwHJ7Dc3gOz+E5PIfn8Byew3N4Ds/hOTyP5/E8nsfzeB7P43k8j+fxPJ7H83gez+N5vIAX8AJewAt4AS/gBbyAF/ACXsALeAEv4AW8iBfxIl7Ei3gRL+JFvIgX8SJexIt4ES/iRbyEl/ASXsJLeAkv4SW8hJfwEl7CS3gJL+ElvIyX8TJexst4GS/jZbyMl/EyXsbLeBkv42W8glfwCl7BK3gFr+AVvIJX8ApewSt4Ba/gFbyKV/EqXsWreBWv4lW8ilfxKl7Fq3gVr+JVvIbX8Bpew2t4Da/hNbyG1/AaXsNreA2v4TW8Dq/D6/A6vA6vw+vwOrwOr8Pr8Dq8Dq/D6/C6mfcvzIdvjw==
```

Build the schematics and scroll the lower left corner of the display off screen. The display will stop updating. After the fix, the display still updates.

The fix ensures the draw commands stored in the root tile are processed when any of the display's tiles is redrawn. I assume this is safe, since there won't be any logic executed while the individual tiles are being drawn; after the first tile is drawn, the graphics buffer gets emptied and the display content won't change until the drawing ends. (I think that the original code might lead to inconsistent display - if the root tile wasn't the first one to be drawn, the tiles drawn before the root tile would draw the old content of the display).

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
