### PR TITLE
Version/revision numbers for logic

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -2618,8 +2618,9 @@ lglobal.sectionLookup = Lookup
 lglobal.@this = The logic block executing the code
 lglobal.@thisx = X coordinate of block executing the code
 lglobal.@thisy = Y coordinate of block executing the code
-lglobal.@links = Total number of blocks linked to this processors
+lglobal.@links = Total number of blocks linked to this processor
 lglobal.@ipt = Execution speed of the processor in instructions per tick (60 ticks = 1 second)
+lglobal.@version = Version number of the game
 
 lglobal.@unitCount = Total number of types of unit content in the game; used with the lookup instruction
 lglobal.@blockCount = Total number of types of block content in the game; used with the lookup instruction

--- a/core/src/mindustry/logic/GlobalVars.java
+++ b/core/src/mindustry/logic/GlobalVars.java
@@ -8,6 +8,7 @@ import arc.math.*;
 import arc.struct.*;
 import arc.util.*;
 import mindustry.*;
+import mindustry.core.Version;
 import mindustry.ctype.*;
 import mindustry.gen.*;
 import mindustry.game.*;
@@ -46,6 +47,8 @@ public class GlobalVars{
         putEntryOnly("@thisy");
         putEntryOnly("@links");
         putEntryOnly("@ipt");
+
+        putEntry("@version", (Version.build < 0 ? 999999 : Version.build) + Version.revision / 100.0);
 
         putEntryOnly("sectionGeneral");
 


### PR DESCRIPTION
Adds the `@version` built-in constants for logic. Allows checking the game/processor version from the logic code, either to refuse running on incompatible processors, or to allow choosing optimal code paths for a specific version.

Notes:
- The version number is encoded as a double value of `build + version / 100.0`. This allows comparing versions for greater/smaller with a single instruction, while allowing for up to 99 revisions (an improbable value).
- I've used `@version` instead of `@build`, as `@build` might be one day needed for something related to building in-game.
- For custom build, the `@version` is set to 999,999 instead of -1, to allow meaningful comparison of version numbers even in custom builds.
- The variable was added into the "Processor" section, as they generally determine the processor's capabilities. Maybe the "General" section would be better.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.