### PR TITLE
Fix server ping never timing out when out of range gamemode ordinal

### DIFF
--- a/core/src/mindustry/net/NetworkIO.java
+++ b/core/src/mindustry/net/NetworkIO.java
@@ -130,7 +130,8 @@ public class NetworkIO{
         int version = buffer.getInt();
         String vertype = readString(buffer);
 
-        Gamemode gamemode = Gamemode.all[buffer.get()];
+        byte mode = buffer.get();
+        Gamemode gamemode = Gamemode.all[mode < Gamemode.all.length ? mode : 0];
         int limit = buffer.getInt();
 
         String description = readString(buffer);


### PR DESCRIPTION
I recently did some testing with server pings, and found this issue.
I'm not sure if this should throw an error or do what it currently does, but its going to be nice if any gamemodes get added in the future.


If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
