### PR TITLE
idk remove inconsistency when client/server outdated

### DIFF
--- a/core/src/mindustry/ui/dialogs/JoinDialog.java
+++ b/core/src/mindustry/ui/dialogs/JoinDialog.java
@@ -740,10 +740,10 @@ public class JoinDialog extends BaseDialog{
             return Core.bundle.get("server.outdated");
         }else if(host.version < Version.build && Version.build != -1){
             return Core.bundle.get("server.outdated") + "\n" +
-            Core.bundle.format("server.version", host.version, "");
+            Core.bundle.format("server.version", host.version, host.versionType);
         }else if(host.version > Version.build && Version.build != -1){
             return Core.bundle.get("server.outdated.client") + "\n" +
-            Core.bundle.format("server.version", host.version, "");
+            Core.bundle.format("server.version", host.version, host.versionType);
         }else if(host.version == Version.build && Version.type.equals(host.versionType)){
             //not important
             return "";


### PR DESCRIPTION
So, previously, when the server/client were outdated, it just didn't show the version type...
dont know why that was done so heres a pr

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
