### PR TITLE
Zero wait yields

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -1172,7 +1172,7 @@ public class LExecutor{
                 exec.yield = true;
                 // Start the next wait afresh ('value' might have been modified remotely by a different processor)
                 curTime = 0f;
-            }if(curTime >= value.num()){
+            }else if(curTime >= value.num()){
                 curTime = 0f;
             }else{
                 //skip back to self.


### PR DESCRIPTION
Modifies the wait instruction to yield execution when the argument is zero (or less).

Currently, when the argument is zero, `wait` doesn't yield. When the argument is above zero, the instruction gets executed at least twice (first time to yield, and second time on the next tick to detect he wait has elapsed). There currently isn't a way to yield and immediately execute the next instruction on the next tick. For microprocessors with 2 IPT, this additional wait execution is particularly costly, making processor synchronization code less efficient and reliable.

If there's a concern this change might break backwards compatibility, an alternative would be to yield only when the value is above zero, but very small (say, less than 10<sup>-10</sup>), or negative.

Test code:

```
set p ""
set w 0
set :t @tick
wait w
print p
wait w
print p
wait w
print p
wait w
print p
wait w
print p
wait w
print p
wait w
print p
wait w
print p
wait w
print p
wait w
print p
op sub :t @tick :t
print :t
printflush message1
```

Before the change, or with a very small value of `w`, this outputs ~15. After the change with `w` zero, it outputs ~10 (the `print` and the `wait` are executed on each tick).

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
