### PR TITLE
Make construct block not weaker than router

### DIFF
--- a/core/src/mindustry/world/blocks/ConstructBlock.java
+++ b/core/src/mindustry/world/blocks/ConstructBlock.java
@@ -40,7 +40,7 @@ public class ConstructBlock extends Block{
         super("build" + size);
         this.size = size;
         update = true;
-        health = 10;
+        health = 10 * (size * size);
         consumesTap = true;
         solidifes = true;
         generateIcons = false;


### PR DESCRIPTION
Makes construct blocks have 10 health per tile they cover, which is better than just 10

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
