### PR TITLE
Preserve accumulator on yield

### DIFF
--- a/core/src/mindustry/world/blocks/logic/LogicBlock.java
+++ b/core/src/mindustry/world/blocks/logic/LogicBlock.java
@@ -529,11 +529,11 @@ public class LogicBlock extends Block{
 
                 while(accumulator >= 1f){
                     executor.runOnce();
-                    accumulator --;
                     if(executor.yield){
                         executor.yield = false;
                         break;
                     }
+                    accumulator --;
                 }
             }
         }


### PR DESCRIPTION
(Yet another `wait`-related update. Didn't think of it yesterday, sorry. This one should be the last.)

This PR ensures that the accumulator doesn't decrease when an instruction yields. The motivation is to stabilize the behavior of `wait` with higher frame rates for inter-processor synchronization.

Currently, when the FPS is higher than 120, a microprocessor executing a `wait` doesn't accumulate any instructions - as soon as the accumulator reaches 1, `wait` is executed and the accumulator is decreased. Therefore, even when waiting for several ticks, there isn't a guarantee the accumulator will be nonzero. For faster processors, the same problem occurs at higher frame rates.

With this PR, `wait` (or any instruction which yields, i.e. `stop`) doesn't decrease the accumulator on wait. This guarantees that after waiting _n_ (up to 5) ticks, _n_-ticks worth of instructions will be run in the next update uninterrupted. This doesn't depend on the frame rate, allowing to use `wait` for executing uninterrupted bursts of a few instruction reliably.

Possible downside is that the `wait` instruction may now run more often when the FPS is high (on each frame, instead of only when the accumulator reaches 1). However, as the game is running on at least 120 FPS for this to ever happen, and both `wait` and `stop` are very lightweight, it really shouldn't be a performance problem.

Additionally, combined with the zero wait PR, `wait 0` now doesn't consume accumulator (unlike nonzero waits, which do consume the accumulator on their last execution). This can't be abused, as it allows to run at most one additional `wait 0` instruction per tick, if the code is carefully crafted to do so.

Test code:

```
set :i -1
wait 1
set :t @tick
op add :i :i 1
jump 3 equal :t @tick
print :i
printflush message1
```

With 60 FPS, this code print 4 on a microprocessor. With 120 or more FPS, this code prints 0 before the PR and 4 after the PR.


If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
