### PR TITLE
Random ping servers order

### DIFF
--- a/core/src/mindustry/net/ServerGroup.java
+++ b/core/src/mindustry/net/ServerGroup.java
@@ -39,4 +39,9 @@ public class ServerGroup{
     String key(){
         return "server-" + (name.isEmpty() ? addresses.length == 0 ? "" : addresses[0] : name);
     }
+    
+    @Override
+    public String toString(){
+    	return name;
+    }
 }

--- a/core/src/mindustry/ui/dialogs/JoinDialog.java
+++ b/core/src/mindustry/ui/dialogs/JoinDialog.java
@@ -407,6 +407,9 @@ public class JoinDialog extends BaseDialog{
         //otherwise use the cached list + the extra servers that may have been included by mods
         var servers = fetchedServers ? defaultServers : tmpServers.clear().addAll(cachedServers).addAll(defaultServers);
         
+        //The system delays sending pings ~100ms
+        //when there are multiple asynchronous calls
+        //so shuffle to every server has a chance to be on top
         servers.shuffle();
         for(int i = 0; i < servers.size; i ++){
             ServerGroup group = servers.get(i);

--- a/core/src/mindustry/ui/dialogs/JoinDialog.java
+++ b/core/src/mindustry/ui/dialogs/JoinDialog.java
@@ -406,9 +406,10 @@ public class JoinDialog extends BaseDialog{
         //if the servers have been fetched, use the fetched list
         //otherwise use the cached list + the extra servers that may have been included by mods
         var servers = fetchedServers ? defaultServers : tmpServers.clear().addAll(cachedServers).addAll(defaultServers);
-
+        
+        servers.shuffle();
         for(int i = 0; i < servers.size; i ++){
-            ServerGroup group = servers.get((i + servers.size/2) % servers.size);
+            ServerGroup group = servers.get(i);
             boolean hidden = group.hidden();
             if(hidden && !showHidden){
                 continue;

--- a/core/src/mindustry/ui/dialogs/JoinDialog.java
+++ b/core/src/mindustry/ui/dialogs/JoinDialog.java
@@ -407,10 +407,6 @@ public class JoinDialog extends BaseDialog{
         //otherwise use the cached list + the extra servers that may have been included by mods
         var servers = fetchedServers ? defaultServers : tmpServers.clear().addAll(cachedServers).addAll(defaultServers);
         
-        //The system delays sending pings ~100ms
-        //when there are multiple asynchronous calls
-        //so shuffle to every server has a chance to be on top
-        servers.shuffle();
         for(int i = 0; i < servers.size; i ++){
             ServerGroup group = servers.get(i);
             boolean hidden = group.hidden();
@@ -698,6 +694,12 @@ public class JoinDialog extends BaseDialog{
 
             String text = result.getResultAsString();
             Seq<ServerGroup> servers = parseServerString(text);
+            
+            //The system delays sending pings >100ms
+            //when there are multiple asynchronous calls
+            //so shuffle to every server has a chance to be on top
+            servers.shuffle();
+            
             //modify default servers on main thread
             Core.app.post(() -> {
                 if(fetchedServers) return;


### PR DESCRIPTION
# Problem
System delays ping-server-info packets **sending**

### Example:
```
[I] #0 Ping: 46.149.69.116:5555 at ...:05:02,782 <--- first ping because pinned 
...
[I] #95 Ping: 46.149.69.116:5555 at ...:05:02,840
```
Wireshark:
```
line |
1    | #0 Ping: send
2    | #0 Ping: recived
3    | #⁣95 Ping: send
4    | #⁣95 Ping: recived
```
<img width="544" height="99" alt="packets" src="https://github.com/user-attachments/assets/c620a19d-c27b-4a95-92d4-50288f17404a" />

### Example 2:
Opened once:
<img width="587" height="260" alt="изображение" src="https://github.com/user-attachments/assets/0384e4d9-4349-42a0-bc3c-63dda0474590" />
<img width="608" height="283" alt="изображение" src="https://github.com/user-attachments/assets/23926194-2f7f-4a35-b660-c0ede8af1f81" />

## How problem working
Old implementation iterate server list in order: `center -> end -> start -> center`
Server from `center->` of server list pinged first and always has correct small ping 
(`io, MAL, MDN, TWS, Fish, LMSS, Snow, 404ru, ...` for now)
Servers from end of list delayed ping by system:
```
[Time start]
sending
system delay
sending to global
recive
[Time end]
```
This also explains why many players always have `io`, `MAL`, `404ru` and other at top of list and `charophyceae` at the bottom

## Why random
Regardless of the current/further  implementations this will give all servers a ~same chance
(but ​​ping will still play a role)

### Some about #8246 
A can add suffle ones per launch (when fetching serverlist) if "different order every time you refresh" a problem

## Other ideas:

### 1. Ordered sending from single channel, single thread to recive
I tried to implement this in another branch:
- Ping more correct
- Sending delay
- Problems with sorting:
  - Inserting better ping befre added elements?
  - Wait for loading all servers?

### 2. Limit async ping per second

*** 
_PS: owners of `io`, `mal`, `404ru` you are currently at top but it means that you will end up at the bottom when new servers are added because the center will shift_

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
