### PR TITLE
Make Jumps to self yield

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -1149,7 +1149,7 @@ public class LExecutor{
         public void run(LExecutor exec){
             if(address != -1 && op.test(value, compare)){
                 //No possible way to change result of condition in the same tick, so this should be safe.
-                if(address + 1 == exec.counter.numval) exec.yield = true;
+                if(address + 1 == (int)exec.counter.numval) exec.yield = true;
                 exec.counter.numval = address;
             }
         }


### PR DESCRIPTION
So, since there is no way for the condition of a jump condition which jumps to itself to change within the same tick, it can safely yield. (if there is ANY way for it to change, this pr breaks some stuff prob)
This is going to make busy-waits (jump 0 lessThan @tick 123) less impactful on performance (yay, million ipt busy waits are less performance eating now :))
Very minor pr to increase performance a little bit :)

raaa i just cleaned up my master branch and now i did a commit to master again

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
