### PR TITLE
Ensure onNewPlan() is also called on mobile when placing schematics

### DIFF
--- a/core/src/mindustry/input/MobileInput.java
+++ b/core/src/mindustry/input/MobileInput.java
@@ -237,6 +237,7 @@ public class MobileInput extends InputHandler implements GestureListener{
                             if(validPlace(plan.x, plan.y, plan.block, plan.rotation, null, true)){
                                 BuildPlan other = getPlan(plan.x, plan.y, plan.block.size, null);
                                 BuildPlan copy = plan.copy();
+                                plan.block.onNewPlan(copy);
 
                                 if(other == null){
                                     player.unit().addBuild(copy);
@@ -691,7 +692,6 @@ public class MobileInput extends InputHandler implements GestureListener{
         }else if(mode == placing && isPlacing() && validPlace(cursor.x, cursor.y, block, rotation) && !checkOverlapPlacement(cursor.x, cursor.y, block)){
             //add to selection queue if it's a valid place position
             selectPlans.add(lastPlaced = new BuildPlan(cursor.x, cursor.y, rotation, block, block.nextConfig()));
-            block.onNewPlan(lastPlaced);
         }else if(mode == breaking && validBreak(linked.x,linked.y) && !hasPlan(linked)){
             //add to selection queue if it's a valid BREAK position
             selectPlans.add(new BuildPlan(linked.x, linked.y));


### PR DESCRIPTION
Right now, `onNewPlan()` seems to be called differently on desktop and on mobile.
On java, it seems to be called when blocks are added to the player's build queue:

https://github.com/user-attachments/assets/0528dfcc-e721-4a17-9dfd-8d62a51d64b2

On mobile, it only seems to be called when a block is placed, but not when a schematic containing the block is placed:

https://github.com/user-attachments/assets/0b4820bf-5c48-4e07-ac68-57cd9019e897

The fix ensures its called both when a block is placed and a schematic containing the block is placed:

https://github.com/user-attachments/assets/137ed687-e68f-46b6-b366-d90faedcf51e



If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
