### PR TITLE
Clear buffer on drawflush

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -989,8 +989,8 @@ public class LExecutor{
         public void run(LExecutor exec){
             if(target.building() instanceof LogicDisplayBuild d && d.isValid() && (d.team == exec.team || exec.privileged)){
                 d.flushCommands(exec.graphicsBuffer);
-                exec.graphicsBuffer.clear();
             }
+            exec.graphicsBuffer.clear();
         }
     }
 


### PR DESCRIPTION
Currently, when executing `drawflush` with an invalid display, the processor's graphics buffer isn't cleared. This means that executing `drawflush null` also doesn't clear the buffer, and there isn't any way to clear the buffer without drawing it, which may be problematic when using several processors to draw on a single display. There also isn't a way to determine that `drawflush` didn't succeed. This behavior was introduced with tileable displays.

For comparison, `printflush` does clear the text buffer even when the message block passed in is not valid.

This PR restores the behavior to the state before tileable displays were implemented, i.e. the graphics buffer is cleared even when the display passed in is not valid.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
