### PR TITLE
True placement efficiency percentages text in ThermalGenerator

### DIFF
--- a/core/src/mindustry/world/blocks/power/ThermalGenerator.java
+++ b/core/src/mindustry/world/blocks/power/ThermalGenerator.java
@@ -61,7 +61,7 @@ public class ThermalGenerator extends PowerGenerator{
         super.drawPlace(x, y, rotation, valid);
 
         if(displayEfficiency){
-            drawPlaceText(Core.bundle.formatFloat("bar.efficiency", sumAttribute(attribute, x, y) * 100, 1), x, y, valid);
+            drawPlaceText(Core.bundle.formatFloat("bar.efficiency", sumAttribute(attribute, x, y) * 100 * displayEfficiencyScale, 1), x, y, valid);
         }
     }
 


### PR DESCRIPTION
in thermal generator efficiency percentages are displayed incorrectly when placed and do not show real efficiency other than the total intesity of the attribute