### PR TITLE
Fix draw print edit layout

### DIFF
--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -238,8 +238,7 @@ public class LStatements{
 
                         row(s);
 
-                        s.add("align ");
-                        fields(s, "align", p1, v -> p1 = v);
+                        fields(s, "align", p1, v -> p1 = v).width(170f);
                         fieldAlignSelect(s, () -> p1, v -> {
                             p1 = v;
                             rebuild(table);


### PR DESCRIPTION
When editing the `draw print` instruction, the `align` label is shown twice:

<img width="961" height="176" alt="image" src="https://github.com/user-attachments/assets/55d6cdb1-2c1e-4848-a2e1-c507d9a6fc2f" />

Also, the field holding the alignment value is too short to display most of the predefined constants. 

This PR removes the duplicate label and widens the alignment field:

<img width="945" height="152" alt="image" src="https://github.com/user-attachments/assets/5fda6459-c45f-4b89-85fa-c8f10605ac9f" />

<img width="462" height="230" alt="image" src="https://github.com/user-attachments/assets/ca0a8cba-2539-4134-86be-cba2fb688a3d" />

The layout isn't entirety optimal In the narrow mode, but I believe being able to see the alignment value is preferable to have the x and y fields nicely packed.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
