### PR TITLE
added color mappings for Items and Liquids

### DIFF
--- a/core/src/mindustry/ClientLauncher.java
+++ b/core/src/mindustry/ClientLauncher.java
@@ -11,6 +11,7 @@ import arc.math.*;
 import arc.util.*;
 import mindustry.ai.*;
 import mindustry.audio.*;
+import mindustry.content.*;
 import mindustry.core.*;
 import mindustry.ctype.*;
 import mindustry.game.EventType.*;
@@ -191,6 +192,45 @@ public abstract class ClientLauncher extends ApplicationCore implements Platform
 
         assets.loadRun("contentinit", ContentLoader.class, () -> content.init(), () -> content.load());
         assets.loadRun("baseparts", BaseRegistry.class, () -> {}, () -> bases.load());
+        
+        //add item/liquid color mappings
+        Events.on(ContentInitEvent.class, e -> {
+            Colors.put("COPPER", Items.copper.color);
+            Colors.put("LEAD", Items.lead.color);
+            Colors.put("METAGLASS", Items.metaglass.color);
+            Colors.put("GRAPHITE", Items.graphite.color);
+            Colors.put("SAND", Items.sand.color);
+            Colors.put("COAL", Items.coal.color);
+            Colors.put("TITANIUM", Items.titanium.color);
+            Colors.put("THORIUM", Items.thorium.color);
+            Colors.put("SCRAP", Items.scrap.color);
+            Colors.put("SILICON", Items.silicon.color);
+            Colors.put("PLASTANIUM", Items.plastanium.color);
+            Colors.put("PHASE", Items.phaseFabric.color);
+            Colors.put("SURGE", Items.surgeAlloy.color);
+            Colors.put("SPOREPOD", Items.sporePod.color);
+            Colors.put("BLAST", Items.blastCompound.color);
+            Colors.put("PYRATITE", Items.pyratite.color);
+
+            Colors.put("BERYLLIUM", Items.beryllium.color);
+            Colors.put("TUNGSTEN", Items.tungsten.color);
+            Colors.put("OXIDE", Items.oxide.color);
+            Colors.put("CARBIDE", Items.carbide.color);
+
+            Colors.put("WATER", Liquids.water.color);
+            Colors.put("SLAG", Liquids.slag.color);
+            Colors.put("OIL", Liquids.oil.color);
+            Colors.put("CRYOFLUID", Liquids.cryofluid.color);
+
+            Colors.put("NEOPLASM", Liquids.neoplasm.color);
+            Colors.put("ARKYCITE", Liquids.arkycite.color);
+            Colors.put("OZONE", Liquids.ozone.color);
+            Colors.put("HYDROGEN", Liquids.hydrogen.color);
+            Colors.put("NITROGEN", Liquids.nitrogen.color);
+            Colors.put("CYANOGEN", Liquids.cyanogen.color);
+
+            Colors.getColors().copy().each((key, val) -> Colors.put(key.toLowerCase().replace("_", ""), val));
+        });
     }
 
     @Override


### PR DESCRIPTION
Added colors for all Items and Liquids. This will allow prettier and more consistent ingame printing and drawing. I also suggest slightly tweaking the colors in the future for better visuals.

<img width="764" height="687" alt="obraz" src="https://github.com/user-attachments/assets/ec8265bc-51bc-4427-b4ed-52b0f9924e6d" />

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
