### PR TITLE
Fast Track: Salvo Buff

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -3738,21 +3738,22 @@ public class Blocks{
         salvo = new ItemTurret("salvo"){{
             requirements(Category.turret, with(Items.copper, 100, Items.graphite, 80, Items.titanium, 50));
             ammo(
-                Items.copper,  new BasicBulletType(2.5f, 11){{
+                Items.copper,  new BasicBulletType(2.5f, 15){{
                     width = 7f;
                     height = 9f;
                     lifetime = 60f;
-                    ammoMultiplier = 2;
+                    ammoMultiplier = 4;
 
                     hitEffect = despawnEffect = Fx.hitBulletColor;
                     hitColor = backColor = trailColor = Pal.copperAmmoBack;
                     frontColor = Pal.copperAmmoFront;
                 }},
-                Items.graphite, new BasicBulletType(3.5f, 20){{
+                Items.graphite, new BasicBulletType(3.5f, 31){{
                     width = 9f;
                     height = 12f;
                     ammoMultiplier = 4;
                     lifetime = 60f;
+                    reloadMultiplier = 0.8f;
 
                     rangeChange = 4f * 8f;
 
@@ -3760,7 +3761,7 @@ public class Blocks{
                     hitColor = backColor = trailColor = Pal.graphiteAmmoBack;
                     frontColor = Pal.graphiteAmmoFront;
                 }},
-                Items.pyratite, new BasicBulletType(3.2f, 18){{
+                Items.pyratite, new BasicBulletType(3.2f, 25){{
                     width = 10f;
                     height = 12f;
                     frontColor = hitColor = Pal.lightishOrange;
@@ -3770,13 +3771,13 @@ public class Blocks{
 
                     ammoMultiplier = 5;
 
-                    splashDamage = 12f;
+                    splashDamage = 15f;
                     splashDamageRadius = 22f;
 
                     makeFire = true;
                     lifetime = 60f;
                 }},
-                Items.silicon, new BasicBulletType(3f, 15, "bullet"){{
+                Items.silicon, new BasicBulletType(3f, 23, "bullet"){{
                     width = 8f;
                     height = 10f;
                     homingPower = 0.2f;
@@ -3790,13 +3791,14 @@ public class Blocks{
                     hitColor = backColor = trailColor = Pal.siliconAmmoBack;
                     frontColor = Pal.siliconAmmoFront;
                 }},
-                Items.thorium, new BasicBulletType(4f, 29, "bullet"){{
+                Items.thorium, new BasicBulletType(4f, 28, "bullet"){{
                     width = 8f;
                     height = 13f;
                     shootEffect = Fx.shootBig;
                     smokeEffect = Fx.shootBigSmoke;
                     ammoMultiplier = 4;
                     lifetime = 60f;
+                    armorMultiplier = 0.8f;
 
                     hitEffect = despawnEffect = Fx.hitBulletColor;
                     backColor = hitColor = trailColor = Pal.thoriumAmmoBack;
@@ -3820,7 +3822,7 @@ public class Blocks{
 
             size = 2;
             range = 190f;
-            reload = 31f;
+            reload = 29f;
             consumeAmmoOnce = false;
             ammoEjectBack = 3f;
             recoil = 0f;


### PR DESCRIPTION
##### Serpulo Balancing: Fast Track 
**Implements 1 Suggestion Post:**

### [Salvo Buffs #6083](https://github.com/Anuken/Mindustry-Suggestions/issues/6083)
**_Summary Statements:_**
- Salvo underperforms to certain low-tech turrets, such as duo and hail, relative to its dps, range, and cost.
- It's ammo types needs to have clear use cases to have multiple meaningful options when using the turret.

#### Main Change
**Salvo** **(+)**
**(+)** Reload: 7.741 -> 8.275 (+6.9%)
`A minor buff done in the reload to help prevent too high anti-armor values from occurring.`

- **Copper Ammo** **(+)**
**(+)** Damage: 11 -> 15
**(+)** Ammo Multiplier: 2 -> 4
`Increasing damage as well and ammo mult, I'm giving copper salvo as a decent ammo efficient upgrade in comparison w/ the other ammo options. [B1] 566 damage per AB is nice compared to Graphite's 677, Silicon's 596, and Thorium's 726.  It also doesn't suck against copper duo anymore, but not too strong that it outclasses graphite and silicon duo in raw dps.`

- **Graphite Ammo** **(+)**
**(+)** Damage: 20 -> 31
**(-)** Reload Multiplier: 1 -> 0.8 
`The niche i gave this is being "okay" as a somewhat anti-armor ish option compared to Silicon. The main point of comparison is seen in [B3] with 9 armor. Graphite being good at range-dps would be the current niche (good coverage at the cost of some dps). Now roughly at thorium's range-dps would make it feel nice.`

- **Silicon Ammo** **(+)**
**(+)** Damage: 15 -> 23
`Straight up increase, use this as your anti low tech option if you don't have pyratite. [B1] 71 dps/tile is a really powerful option, although decays quickly as it has the same dps/tile w/ thorium at 9 armor.`

- **Thorium Ammo** **(~)**
**(~)** Damage: 29 -> 28
**(+)** Armor Piercing: 1x -> 0.8x
`Thorium Ammo, I've heard of it being decent so for the most part it is staying the same. Similar dynamic w/ Graphite vs Silicon, this is your anti-armor option. As it is an ore ammunition it can't be stronger in dps against the manufactured ammo. But! I have allowed it to have better dps against higher tech to keep its "high tech" status.`

- **Pyratite Ammo** **(+)**
**(+)** Damage: 18 -> 25
**(+)** Splash Damage: 12 -> 15
`This one is fun. This is your Crowd Control option. Keep in mind the spreadsheets at [B1 - B3] only record single target capability. Due to how the game works both the damage and splash damage are affected by armor, thus this being the "Silicon" to Thorium, as it specializes in decimating low tech. This is a steppingstone change as burning + tarred synergy will be buffed at a later date to see some further viability if needed.`


### Community Reaction

#### [A1 | 35 : 2 Current Stats Like Ratio]
<img width="693" height="570" alt="image" src="https://github.com/user-attachments/assets/8fb1179c-07ac-4757-89f8-57ae3ec3f9b4" />

- Okay, with how fast the approval was, this change deserves to be insta pr'd and not wait for a balancing train on its own.
- I'll add in some old stuff on the old ish changes (where the reload wasn't buffed)

---
### Community Reaction (No Reload Buff: Old Stats)
#### [A2 | 5 : 1 Old Stats Like Ratio]

<img width="678" height="301" alt="image" src="https://github.com/user-attachments/assets/1e6e3a75-828f-40b4-8738-7ead8a8f9ed8" />

The agaisnt was on thor salvo, but I'll work on it eventually

<img width="725" height="366" alt="image" src="https://github.com/user-attachments/assets/2c1a1b7b-5ff5-40a5-9e1b-ee7f6ce20dfb" />

---
### Notes:
First Fast Track, since I was really surprised by the positive reception. I was planning on coupling with Arc Changes and Nova Buff, but I think deserves its own pr as it seems badly needed.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:
 
- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [n/a] I have ensured that any new features in this PR function correctly in-game, if applicable.
