### PR TITLE
Fix the disparity between acccumulator increase and time waited in WaitI

### DIFF
--- a/core/src/mindustry/world/blocks/logic/LogicBlock.java
+++ b/core/src/mindustry/world/blocks/logic/LogicBlock.java
@@ -523,8 +523,6 @@ public class LogicBlock extends Block{
             if(state.rules.disableWorldProcessors && privileged) return;
 
             if(enabled && executor.initialized()){
-                accumulator += edelta() * ipt;
-
                 if(accumulator > maxInstructionScale * ipt) accumulator = maxInstructionScale * ipt;
 
                 while(accumulator >= 1f){
@@ -535,6 +533,10 @@ public class LogicBlock extends Block{
                     }
                     accumulator --;
                 }
+
+                // Do not move in front of the loop, otherwise the curTime accumulated in WaitI
+                // may get out of sync with the accumulator increase.
+                accumulator += edelta() * ipt;
             }
         }
 


### PR DESCRIPTION
When the wait instruction waits, the accumulator is supposed to increase by the amount corresponding to the time waited (this provides execution atomicity - see #11568), but it doesn't. As a consequence, the atomicity of a code following `wait n` is not guaranteed. (I've closed the previous PR attempting to fix the issue. I've identified the underlying cause and this PR addresses the cause directly.)

Currently, the game behaves like this: let's say that a tick-long wait instruction is executed towards the end of a regular, one-tick long frame update. The accumulator is therefore (almost) zero, but the total time waited in `WaitI` (`curTime`) gets increased by a tick duration. For some reason, the next frame is shorter (this may happen anytime, and does happen when the focus is lost or the window is resized, for example). The wait is satisfied, because the last execution already accumulated enough wait time, but the accumulator, which was almost zero, does not get a full tick's worth of increase, because the current frame (and corresponding delta time) is shorter.

Fundamentally, the time waited in `WaitI` is equal to the duration of the previous frame, but the resulting accumulator increase gets spent in the current frame. This PR moves the accumulator increase below the execution loop, so that he accumulator increase gets spent in the next frame. This way, the accumulator increase and the `WaitI.curTime` increase are in sync.

Also note that on a map load, both the accumulator and `WaitI.curTime` get reset to zero. The `wait` execution essentially restarts, bringing the accumulator to the expected value as well. No special handling is therefore needed for map reloads, which is great.

The only scenario where the atomicity mechanism fails is when the processor's `efficiency * timeScale` drops below 1. This may happen to a hyperprocesor not having enough cryofluid. I find quite apt that a code running on a hyperprocessor with insufficient cryo may fail in this way and would like to keep it.

I've created test schematics for this that I'm running in the game, at various FPS (from 10 to 2000 or more). With this fix, there are no atomicity failures (not even when resizing the window), whereas before the failures were easy to trigger, and happened a lot spuriously on higher FPS.

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.