### PR TITLE
Do not log every single connect in a DDOS

### DIFF
--- a/core/src/mindustry/net/ArcNetProvider.java
+++ b/core/src/mindustry/net/ArcNetProvider.java
@@ -113,8 +113,6 @@ public class ArcNetProvider implements NetProvider{
 
                 //kill connections above the limit to prevent spam
                 if((playerLimitCache > 0 && server.getConnections().length > playerLimitCache) || netServer.admins.isDosBlacklisted(ip)){
-                    Log.info("Closing connection @ - IP marked as a potential DOS attack.", ip);
-
                     connection.close(DcReason.closed);
                     return;
                 }


### PR DESCRIPTION
This log message was added in #10904. It is useful to help players who are falsely dosblacklisted, but it is not worth the massive amounts of console spam (and possibly lag) that it causes in a real DDoS attack.

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
