### PR TITLE
Fix draw image bug with tiled displays.

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -980,7 +980,7 @@ public class LExecutor{
                     if(p1.obj() instanceof UnlockableContent u){
                         packed = (u.id << 5) | (u.getContentType().ordinal() & 31);
                     }else if(p1.obj() instanceof LogicDisplayBuild d){
-                        packed = (d.index << 5) | LogicDisplay.displayDrawType;
+                        packed = (d.rootDisplay.index << 5) | LogicDisplay.displayDrawType;
                     }
                     num1 = packed & 0x3FF;
                     num4 = packed >> 10;

--- a/core/src/mindustry/world/blocks/logic/LogicDisplay.java
+++ b/core/src/mindustry/world/blocks/logic/LogicDisplay.java
@@ -268,8 +268,10 @@ public class LogicDisplay extends Block{
             super.remove();
 
             if(index != -1){
-                displays.get(displays.size - 1).index = index;
-                displays.remove(index);
+                LogicDisplayBuild last = displays.get(displays.size - 1);
+                last.index = index;
+                displays.set(index, last);
+                displays.remove(displays.size - 1);
                 index = -1;
             }
 


### PR DESCRIPTION
Fixes two bugs related to `draw image` used with tiled displays:

1. The `draw image` command uses the display linked to the processor as the source display, not the root display. When the display linked is not the root display, incorrect frame buffer is used as a source for drawing.
2. There's a list of all displays on the map mapping displays to their indexes. When removing a display, the list is incorrectly updated, meaning that the n-th position in the list no longer contains a display with index n. This means that a wrong display may be used as a source for `draw image`.

After the fix, display indexes may change when removing a display from a map. Currently, there's a remote possibility that a `draw image` command will be contained in a processor's or display's draw buffer with a display index, and before it gets drawn on the display, the index changes, resulting in the wrong display to be used in `draw image`. (This is more probable for situations where there is a longer delay between `draw image` and `drawflush`.)

To fix this, either the indexes would have to be stable, or existing draw commands in all graphic buffers on the map would have to be fixed when a display is removed. I think the second solution is unfeasible. I can do the first one if you think it is worth the trouble (when removing a display, its position would be set to null, when adding a display, the first free position would be reused).

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
