### PR TITLE
Fix a problem caused `RailBulletType` cannot correctly create frag bullets

### DIFF
--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -539,7 +539,7 @@ public class BulletType extends Content implements Cloneable{
     }
 
     public void hit(Bullet b, float x, float y){
-        hit(b, b.x, b.y, true);
+        hit(b, x, y, true);
     }
 
     public void hit(Bullet b, float x, float y, boolean createFrags){


### PR DESCRIPTION
this caused bullets that with `collideLine` cannot correctly create frags when hitting something, instead, it will create frag on where it is shot.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
