### PR TITLE
Fixes the multiple reload shots ( https://github.com/Anuken/Mindustry/issues/11636 )

### DIFF
--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -715,8 +715,8 @@ public class Turret extends ReloadTurret{
         protected void capReload(){
             //cap reload for visual reasons, need to store the excess reload to keep the firerate consistent
             if(canReload() && reloadCounter >= reload){
-                reloadShots += (int)(reloadCounter / reload);
                 excessReload += reloadCounter % reload;
+                reloadShots = (int)(excessReload / reload);
             }
             reloadCounter = Math.min(reloadCounter, reload);
             reloadShots = Math.min(reloadShots, 5);
@@ -738,11 +738,13 @@ public class Turret extends ReloadTurret{
             if(reloadShots > 0 && !charging() && shootWarmup >= minWarmup){
                 BulletType type = peekAmmo();
 
-                shoot(type);
-
+                while(reloadShots > 0){
+                    shoot(type);
+                    reloadShots--;
+                }
+                
                 reloadCounter = excessReload;
                 excessReload = 0;
-                reloadShots--;
             }
         }
 

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -721,7 +721,8 @@ public class Turret extends ReloadTurret{
             reloadCounter = Math.min(reloadCounter, reload);
             reloadShots = Math.min(reloadShots, 5);
 
-            if(!wasShooting){
+            //if it isn't constantly firing, do not keep excess reload
+            if(!wasShooting || shootWarmup < minWarmup){
                 reloadShots = 0;
                 excessReload = 0;
             }

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -284,6 +284,8 @@ public class Turret extends ReloadTurret{
         public @Nullable float[] curRecoils;
         public float shootWarmup, charge, warmupHold = 0f;
         public int totalShots, barrelCounter;
+        public float excessReload = 0;
+        public int reloadShots = 0;
         public boolean logicShooting = false;
         public @Nullable Posc target;
         public Vec2 targetPos = new Vec2();
@@ -496,8 +498,6 @@ public class Turret extends ReloadTurret{
                 shootWarmup = Mathf.lerpDelta(shootWarmup, warmupTarget, shootWarmupSpeed * (warmupTarget > 0 ? efficiency : 1f));
             }
 
-            wasShooting = false;
-
             curRecoil = Mathf.approachDelta(curRecoil, 0, 1 / recoilTime);
             if(recoils > 0){
                 if(curRecoils == null) curRecoils = new float[recoils];
@@ -530,7 +530,10 @@ public class Turret extends ReloadTurret{
             if(reloadWhileCharging || !charging()){
                 updateReload();
                 updateCooling();
+                capReload();
             }
+
+            wasShooting = false;
 
             if(state.rules.fog){
                 float newRange = hasAmmo() ? peekAmmo().rangeChange : 0f;
@@ -698,11 +701,30 @@ public class Turret extends ReloadTurret{
             return queuedBullets > 0 && shoot.firstShotDelay > 0;
         }
 
-        protected void updateReload(){
-            reloadCounter += delta() * ammoReloadMultiplier() * baseReloadSpeed();
+        @Override
+        protected boolean canReload(){
+            //keep reloading as the turret keeps shooting
+            return reloadShots < 1 || wasShooting;
+        }
 
-            //cap reload for visual reasons
+        protected void updateReload(){
+            if(!canReload()) return;
+            reloadCounter += delta() * ammoReloadMultiplier() * baseReloadSpeed();
+        }
+
+        protected void capReload(){
+            //cap reload for visual reasons, need to store the excess reload to keep the firerate consistent
+            if(canReload() && reloadCounter >= reload){
+                reloadShots += (int)(reloadCounter / reload);
+                excessReload += reloadCounter % reload;
+            }
             reloadCounter = Math.min(reloadCounter, reload);
+            reloadShots = Math.min(reloadShots, 5);
+
+            if(!wasShooting){
+                reloadShots = 0;
+                excessReload = 0;
+            }
         }
 
         @Override
@@ -712,12 +734,14 @@ public class Turret extends ReloadTurret{
 
         protected void updateShooting(){
 
-            if(reloadCounter >= reload && !charging() && shootWarmup >= minWarmup){
+            if(reloadShots > 0 && !charging() && shootWarmup >= minWarmup){
                 BulletType type = peekAmmo();
 
                 shoot(type);
 
-                reloadCounter %= reload;
+                reloadCounter = excessReload;
+                excessReload = 0;
+                reloadShots--;
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/Anuken/Mindustry/issues/11636 , without reversion.

### Proof of it being fixed

#### Broken Behavior (caused by charging or clicking multiple times)
https://github.com/user-attachments/assets/67c847d3-8e2c-4b76-a50e-41c1c4212b89

#### Fixed Behavior

https://github.com/user-attachments/assets/84f1ea59-80a5-4577-a658-c97c45950521

### So... what happened?

- Basically, there is a failsafe system where the turret will fire multiple shots, 
- if the excessReload generated would've been extremely high, (this was mostly done out of just in case, which is questionable),
- and reload Shots tracks the number of shots it should fire immediately when this happens.

```
        protected void capReload(){
            //cap reload for visual reasons, need to store the excess reload to keep the firerate consistent
            if(canReload() && reloadCounter >= reload){
                reloadShots += (int)(reloadCounter / reload);
                excessReload += reloadCounter % reload;
            }
            reloadCounter = Math.min(reloadCounter, reload);
            reloadShots = Math.min(reloadShots, 5);

            //if it isn't constantly firing, do not keep excess reload
            if(!wasShooting || shootWarmup < minWarmup){
                reloadShots = 0;
                excessReload = 0;
            }
```
This updated line `!wasShooting || shootWarmup < minWarmup` didn't consider that the turret can also not fire if the turret is currently warming up (my bad).

It now does, and it should work.

### Notes

- I'm still thinking if the implementation I did before was okay, maintable, etc., 
- I guess it was merged and it did have this only bug... 
  - Theoretically, `wasShooting` tracks already if the turret doesn't constantly fire, 
  - the `!charging()` already prevents turrets that are charging like lancer to pile up reload, 
  - and the `shootWarmup < minWarmup` now prevents warmup conditions... 
- completing the list in `if(reloadShots > 0 && !charging() && shootWarmup >= minWarmup){` at `updateShooting()`

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [n/a] I have ensured that any new features in this PR function correctly in-game, if applicable.
