### PR TITLE
Priority Nerf: Copper Salvo, 50% Armor Weakness with 5x Ammo Mult

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -3746,7 +3746,8 @@ public class Blocks{
                     width = 7f;
                     height = 9f;
                     lifetime = 60f;
-                    ammoMultiplier = 4;
+                    ammoMultiplier = 5;
+                    armorMultiplier = 1.5f;
 
                     hitEffect = despawnEffect = Fx.hitBulletColor;
                     hitColor = backColor = trailColor = Pal.copperAmmoBack;


### PR DESCRIPTION
##### Serpulo Balancing: Priority Nerf
**Implements 1 Suggestion Post:**

### [Priority Nerf: Copper Salvo's Anti Armor #6114](https://github.com/Anuken/Mindustry-Suggestions/issues/6114)
**_Summary Statement:_** Copper Salvo should be weak vs high armored units because it is simple to make. Unfortunately, the buff I did this forgot to take into account and an armor weakness application is needed.

#### Main Change
**Salvo**
**(-)** Copper Ammo, Armor Multiplier: 1x -> 1.5x or 50% Armor Weakness
`[B1] It means it has almost the same armor vulnerability as if it had 10 damage similar to duo's 9.`
**(+)** Copper Ammo, Ammo Multiplier: 4x -> 5x
`[B2] Previously it was 44 and now its 45 DPI for copper after all of the changes vs mace... its fine now...`

### Notes:

No community feedback for this one, since I do want this adressed asap, and after talking in serpulo-balancing, im keeping it because I do not want campaign balance getting screwed over by people relying on copper salvo.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [n/a] I have ensured that any new features in this PR function correctly in-game, if applicable.
