### PR TITLE
Save and restore accumulator on load

### DIFF
--- a/core/src/mindustry/world/blocks/logic/LogicBlock.java
+++ b/core/src/mindustry/world/blocks/logic/LogicBlock.java
@@ -764,6 +764,8 @@ public class LogicBlock extends Block{
                 write.s(waitIndices.get(i));
                 write.f(waitValues.get(i));
             }
+
+            write.f(accumulator);
         }
 
         @Override
@@ -823,6 +825,8 @@ public class LogicBlock extends Block{
                     waitIndices.add(index);
                     waitValues.add(value);
                 }
+
+                accumulator = read.f();
             }
 
             loadBlock = () -> updateCode(code, false, asm -> {
@@ -843,7 +847,7 @@ public class LogicBlock extends Block{
                     }
                 }
 
-                //wait times can only be applied once the instructions are loaded an exist
+                //wait times can only be applied once the instructions are loaded and exist
                 for(int i = 0; i < waitIndices.size; i++){
                     int waitIndex = waitIndices.get(i);
                     if(waitIndex >= 0 && waitIndex < asm.instructions.length && asm.instructions[waitIndex] instanceof WaitI wait){


### PR DESCRIPTION
A recent commit (6ad8d06) saves the waited time for individual wait instructions. This PR adds the accumulator to the save file too, so that the accumulator will match the time waited even after map load, which is important for atomic execution of a block of code based on waits.

I haven't bumped the LogicBlock's revision number, so any map saved after 6ad8d06, but before this PR, would be invalid. Let me know if I should bump the revision number instead.

I couldn't test the PR, because the I get some build errors I'm struggling to fix. Looks like a problem connected to switching to Gradle 9. I'll try to test the feature using the GitHub build.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
