### PR TITLE
Core unit Homing

### DIFF
--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -2561,6 +2561,7 @@ public class UnitTypes{
 
                     lifetime = 60f;
                     buildingDamageMultiplier = 0.01f;
+                    homingPower = 0.02f;
                 }};
             }});
         }};
@@ -2611,6 +2612,7 @@ public class UnitTypes{
 
                     lifetime = 60f;
                     buildingDamageMultiplier = 0.01f;
+                    homingPower = 0.03f;
                 }};
             }});
         }};


### PR DESCRIPTION
Alpha and Beta should have slight homing;

- Earlygame punishment when doing mistakes shouldn't be met with missing half the shots while dodging against t1s.
- This reliability tweak is more QoL than anything, doesn't change current dynamics. (Their dps also becomes guaranteed while moving at low speeds instead of only when stationary.)
- Consistent with Gamma, where serpulo core units have a weak, uncheesable and easy to use starting weapon.
- Duo keeps its superiority with better range and bullet velocity vs alpha.
- Helps PC users shorten the aiming skill gap needed vs mobile users and their autoaim toggle. (Having a skill gap here is borderline bad design; the skill aspect should be further tied to its genres, AKA tower defense, factory building, rts, etc)
Practical Effect:

Current dynamic: 

https://github.com/user-attachments/assets/eb9079bf-de32-4f35-b0c9-6a3e699a433d

Slight homing dynamic:


https://github.com/user-attachments/assets/8e936b52-f2ef-487c-a671-6c679397c013


Overall, this extremely small change brings noticeable QoL and consistency across core units.


- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.