### PR TITLE
Gracefully handle string value size exceeding 65535 bytes

### DIFF
--- a/core/src/mindustry/logic/LParser.java
+++ b/core/src/mindustry/logic/LParser.java
@@ -37,17 +37,22 @@ public class LParser{
 
     String string(){
         int from = pos;
+        int utflen = 0;
 
         while(++pos < chars.length){
-            var c = chars[pos];
+            char c = chars[pos];
             if(c == '\n'){
                 error("Missing closing quote \" before end of line.");
             }else if(c == '"'){
                 break;
             }
+
+            // See ByteBufferOutput.writeUTF()
+            utflen += c != 0 && c <= 0x7F ? 1 : c <= 0x7FF ? 2 : 3;
         }
 
         if(pos >= chars.length || chars[pos] != '"') error("Missing closing quote \" before end of file.");
+        if(utflen > 65535) error("String value too long.");
 
         return new String(chars, from, ++pos - from);
     }


### PR DESCRIPTION
The possibility to read individual characters from a string means that potentially very large string can be used in mlog, providing a way to encode large amounts of data efficiently. When storing string variable values in a map file, the `ByteBufferOutput.writeUTF()` method is used. This method imposes a limit on the maximum size of the string value to 65,535 bytes (when encoded using UTF-8). When a processor contains string variables larger than this, an error occurs when saving a map.

This PR implements a specific validation in `LParser` - when a string value exceeding the limit is found, the parse fails. This prevents the error during the map save. I believe it prevents similar, potentially exploitable errors in a multiplayer game as well.

When used in a `read` instruction and not assigned to a variable, strings larger than 64 KB wouldn't cause any errors (I presume, I haven't tested this). This PR might therefore cause the game to refuse a code which could otherwise be run without problems. Perhaps a special handling could be implemented for this case, but I don't think the hassle is worth it - 64 KB ought to be enough for anybody ;)

(Note: there's an additional limit of 100 KB applied to the entire code size. However, this limit is evaluated on code constructed from `LStatement` instances in the game and can't be therefore evaluated in `LParser`, as the code size may change, even increase, after reformatting (by supplying missing instruction arguments). When this limit is exceeded, the code simply isn't saved in the processor, without any message. I don't think it is ideal, but also probably not worth fixing.)

The PR has been tested using this code (expressed in Mindcode - mlog is too large for GitHub):

```
#set target = 8m;

const a = "0123456789ABCDEF"; // 16
const b = a + a; // 32
const c = b + b; // 64
const d = c + c; // 128
const e = d + d; // 256
const f = e + e; // 512
const g = f + f; // 1024
const h = g + g; // 2048
const i = h + h; // 4096
const j = i + i; // 8192
const k = j + j; // 16384
const l = k + k; // 32768

volatile var m = a + b + c + d + e + f + g + h + i + j + k + l + "0123456789ABCDE";
print(strlen(m));
printflush(message1);
```

The string takes 65535 bytes, and the program can be pasted into a processor. After adding a single character to the string, the limit is exceeded and an error message is displayed:

<img width="431" height="185" alt="image" src="https://github.com/user-attachments/assets/c837db42-08a6-4dde-bf63-a2711d424dd2" />


If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
