### PR TITLE
Implement popup id system so that popups don't flicker.

### DIFF
--- a/core/src/mindustry/core/UI.java
+++ b/core/src/mindustry/core/UI.java
@@ -85,6 +85,9 @@ public class UI implements ApplicationListener, Loadable{
 
     private @Nullable Element lastAnnouncement;
 
+    /** Maps popups to ids so that they can be removed or updated by id. */
+    private final ObjectMap<String, Table> popups = new ObjectMap<>();
+
     public UI(){
         Fonts.loadFonts();
     }
@@ -394,14 +397,21 @@ public class UI implements ApplicationListener, Loadable{
     }
 
     /** Shows a label at some position on the screen. Does not fade. */
-    public void showInfoPopup(String info, float duration, int align, int top, int left, int bottom, int right){
+    public void showInfoPopup(String info, @Nullable String id, float duration, int align, int top, int left, int bottom, int right){
         Table table = new Table();
+        if(id != null){
+            Table old = popups.put(id, table);
+            if (old != null) old.remove();
+        }
         table.setFillParent(true);
         table.touchable = Touchable.disabled;
         table.update(() -> {
-            if(state.isMenu()) table.remove();
+            if(state.isMenu()){
+                table.remove();
+                if(id != null) popups.remove(id);
+            }
         });
-        table.actions(Actions.delay(duration), Actions.remove());
+        table.actions(Actions.delay(duration), Actions.remove(), Actions.run(() -> { if(id != null) popups.remove(id); }));
         table.align(align).table(Styles.black3, t -> t.margin(4).add(info).style(Styles.outlineLabel)).pad(top, left, bottom, right);
         Core.scene.add(table);
     }

--- a/core/src/mindustry/ui/Menus.java
+++ b/core/src/mindustry/ui/Menus.java
@@ -122,10 +122,29 @@ public class Menus{
     }
 
     @Remote(variants = Variant.both, unreliable = true)
-    public static void infoPopup(String message, float duration, int align, int top, int left, int bottom, int right){
+    public static void infoPopup(String message, @Nullable String id, float duration, int align, int top, int left, int bottom, int right){
         if(message == null) return;
 
-        ui.showInfoPopup(message, duration, align, top, left, bottom, right);
+        ui.showInfoPopup(message, id, duration, align, top, left, bottom, right);
+    }
+
+    @Remote(variants = Variant.both)
+    public static void infoPopupReliable(String message, @Nullable String id, float duration, int align, int top, int left, int bottom, int right){
+        infoPopup(message, id, duration, align, top, left, bottom, right);
+    }
+
+    /** @deprecated Prefer variants with ids to stop flickering popups. */
+    @Deprecated
+    @Remote(variants = Variant.both, unreliable = true)
+    public static void infoPopup(String message, float duration, int align, int top, int left, int bottom, int right){
+        infoPopup(message, null, duration, align, top, left, bottom, right);
+    }
+
+    /** @deprecated Prefer variants with ids to stop flickering popups. */
+    @Deprecated
+    @Remote(variants = Variant.both)
+    public static void infoPopupReliable(String message, float duration, int align, int top, int left, int bottom, int right){
+        infoPopup(message, duration, align, top, left, bottom, right);
     }
 
     @Remote(variants = Variant.both, unreliable = true)
@@ -133,13 +152,6 @@ public class Menus{
         if(message == null) return;
 
         ui.showLabel(message, duration, worldx, worldy);
-    }
-
-    @Remote(variants = Variant.both)
-    public static void infoPopupReliable(String message, float duration, int align, int top, int left, int bottom, int right){
-        if(message == null) return;
-
-        ui.showInfoPopup(message, duration, align, top, left, bottom, right);
     }
 
     @Remote(variants = Variant.both)


### PR DESCRIPTION
Adds ids to popups, this way a popup can have a longer duration and be updated rather than having to send a fresh popup every second which causes flickering.

**Open to any feedback on these points:**
- This is probably worth adding to labels too. Should we use the same map or create a new map for those?
- Would integer ids be preferred over string ids?
- The popups clear after game over so that's not anything to worry about.
- Perhaps it would be worth allowing null popup text which would allow us to clear popups with ids?
- Should we actually be deprecating the old methods or are they worth keeping forever do to the number of plugins that actually make use of the old system?




- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
