### PR TITLE
Add legacy mod support

### DIFF
--- a/core/src/mindustry/mod/ModListing.java
+++ b/core/src/mindustry/mod/ModListing.java
@@ -2,8 +2,8 @@ package mindustry.mod;
 
 /** Mod listing as a data class. */
 public class ModListing{
-    public String repo, name, internalName, subtitle, author, lastUpdated, description,  minGameVersion;
-    public boolean hasScripts, hasJava, iosCompatible;
+    public String repo, name, internalName, author, lastUpdated, description, minGameVersion;
+    public boolean hasScripts, hasJava, iosCompatible, legacyCompatible;
     public String[] contentTypes = {};
     public int stars;
 

--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -1183,7 +1183,7 @@ public class Mods implements Loadable{
                 !skipModLoading() &&
                 Core.settings.getBool("mod-" + baseName + "-enabled", true) &&
                 Version.isAtLeast(meta.minGameVersion) &&
-                (meta.getMinMajor() >= minJavaModGameVersion || headless) &&
+                (meta.getMinMajor() >= minJavaModGameVersion || headless || meta.legacyCompatible) &&
                 !skipModCode &&
                 initialize
             ){
@@ -1326,7 +1326,7 @@ public class Mods implements Loadable{
 
         /** @return whether this mod is outdated, i.e. not compatible with v8. */
         public boolean isOutdated(){
-            return getMinMajor() < (isJava() ? minJavaModGameVersion : minModGameVersion);
+            return getMinMajor() < (isJava() ? minJavaModGameVersion : minModGameVersion) && !meta.legacyCompatible;
         }
 
         public int getMinMajor(){
@@ -1427,8 +1427,10 @@ public class Mods implements Loadable{
         public float texturescale = 1.0f;
         /** If true, bleeding is skipped and no content icons are generated. */
         public boolean pregenerated;
-        /** If set, load the mod content in this order by content names */
+        /** If set, load the mod content in this order by content names. */
         public String[] contentOrder;
+        /** Mod from an older major version that is compatible with the latest one as well. */
+        public boolean legacyCompatible;
 
         public String shortDescription(){
             return Strings.truncate(subtitle == null ? (description == null || description.length() > maxModSubtitleLength ? "" : description) : subtitle, maxModSubtitleLength, "...");

--- a/core/src/mindustry/ui/dialogs/ModsDialog.java
+++ b/core/src/mindustry/ui/dialogs/ModsDialog.java
@@ -544,7 +544,7 @@ public class ModsDialog extends BaseDialog{
                     "\n[lightgray]\uE809 " + mod.stars +
 
                     (!Version.isAtLeast(mod.minGameVersion) ? "\n" + Core.bundle.format("mod.requiresversion", mod.minGameVersion) :
-                    ((mod.hasJava && Strings.parseDouble(mod.minGameVersion, 0) < minJavaModGameVersion) ? "\n" + Core.bundle.get("mod.incompatiblemod") : ""));
+                    ((mod.hasJava && Strings.parseDouble(mod.minGameVersion, 0) < minJavaModGameVersion && !mod.legacyCompatible) ? "\n" + Core.bundle.get("mod.incompatiblemod") : ""));
 
                     con.add(infoText).width(358f).wrap().grow().pad(4f, 2f, 4f, 6f).top().left().labelAlign(Align.topLeft);
 


### PR DESCRIPTION
Allow mods to mark themselves as legacy compatible meaning that mods from v7 which still work in v8 can continue to use an old repo and work in both versions.

Requires: https://github.com/Anuken/MindustryMods/pull/58

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
