### PR TITLE
Label ids, deletable labels & popups

### DIFF
--- a/core/src/mindustry/ai/RtsAI.java
+++ b/core/src/mindustry/ai/RtsAI.java
@@ -160,7 +160,7 @@ public class RtsAI{
         ay /= units.size;
 
         if(debug){
-            Vars.ui.showLabel("Squad: " + units.size, 2f, ax, ay);
+            Vars.ui.showLabel("Squad: " + units.size, -1, 2f, ax, ay);
         }
 
         Building defend = null;
@@ -192,7 +192,7 @@ public class RtsAI{
                 defend = best;
 
                 if(debug){
-                    Vars.ui.showLabel("Defend, dst = " + (int)(best.dst(ax, ay)), 8f, best.x, best.y);
+                    Vars.ui.showLabel("Defend, dst = " + (int)(best.dst(ax, ay)), -1, 8f, best.x, best.y);
                 }
 
                 if(best instanceof CoreBuild){

--- a/core/src/mindustry/core/UI.java
+++ b/core/src/mindustry/core/UI.java
@@ -399,8 +399,8 @@ public class UI implements ApplicationListener, Loadable{
     }
 
     /** Shows a label at some position on the screen. Does not fade. */
-    public void showInfoPopup(String info, @Nullable String id, float duration, int align, int top, int left, int bottom, int right){
-        if(info == null){ // null info allows deletion of old labels provided they have ids
+    public void showInfoPopup(@Nullable String info, @Nullable String id, float duration, int align, int top, int left, int bottom, int right){
+        if(info == null){ // null info allows deletion of old popups provided they have ids
             var table = popups.remove(id);
             if(table != null) table.remove();
             return;
@@ -424,7 +424,7 @@ public class UI implements ApplicationListener, Loadable{
     }
 
     /** Shows a label in the world. This label is behind everything. Does not fade. */
-    public void showLabel(String info, int id, float duration, float worldx, float worldy){
+    public void showLabel(@Nullable String info, int id, float duration, float worldx, float worldy){
         if(info == null){ // null info allows deletion of old labels provided they have ids
             var table = labels.remove(id);
             if(table != null) table.remove();

--- a/core/src/mindustry/core/UI.java
+++ b/core/src/mindustry/core/UI.java
@@ -87,6 +87,8 @@ public class UI implements ApplicationListener, Loadable{
 
     /** Maps popups to ids so that they can be removed or updated by id. */
     private final ObjectMap<String, Table> popups = new ObjectMap<>();
+    /** Maps labels to ids so that they can be removed or updated by id. */
+    private final IntMap<Table> labels = new IntMap<>();
 
     public UI(){
         Fonts.loadFonts();
@@ -398,10 +400,15 @@ public class UI implements ApplicationListener, Loadable{
 
     /** Shows a label at some position on the screen. Does not fade. */
     public void showInfoPopup(String info, @Nullable String id, float duration, int align, int top, int left, int bottom, int right){
+        if(info == null){ // null info allows deletion of old labels provided they have ids
+            var table = popups.remove(id);
+            if(table != null) table.remove();
+            return;
+        }
         Table table = new Table();
         if(id != null){
             Table old = popups.put(id, table);
-            if (old != null) old.remove();
+            if(old != null) old.remove();
         }
         table.setFillParent(true);
         table.touchable = Touchable.disabled;
@@ -417,15 +424,27 @@ public class UI implements ApplicationListener, Loadable{
     }
 
     /** Shows a label in the world. This label is behind everything. Does not fade. */
-    public void showLabel(String info, float duration, float worldx, float worldy){
+    public void showLabel(String info, int id, float duration, float worldx, float worldy){
+        if(info == null){ // null info allows deletion of old labels provided they have ids
+            var table = labels.remove(id);
+            if(table != null) table.remove();
+            return;
+        }
         var table = new Table(Styles.black3).margin(4);
+        if(id != -1){
+            Table old = labels.put(id, table);
+            if(old != null) old.remove();
+        }
         table.touchable = Touchable.disabled;
         table.update(() -> {
-            if(state.isMenu()) table.remove();
+            if(state.isMenu()){
+                table.remove();
+                if(id != -1) labels.remove(id);
+            }
             Vec2 v = Core.camera.project(worldx, worldy);
             table.setPosition(v.x, v.y, Align.center);
         });
-        table.actions(Actions.delay(duration), Actions.remove());
+        table.actions(Actions.delay(duration), Actions.remove(), Actions.run(() -> { if(id != -1) labels.remove(id); }));
         table.add(info).style(Styles.outlineLabel);
         table.pack();
         table.act(0f);

--- a/core/src/mindustry/ui/Menus.java
+++ b/core/src/mindustry/ui/Menus.java
@@ -148,15 +148,29 @@ public class Menus{
     }
 
     @Remote(variants = Variant.both, unreliable = true)
-    public static void label(String message, float duration, float worldx, float worldy){
+    public static void label(String message, int id, float duration, float worldx, float worldy){
         if(message == null) return;
 
-        ui.showLabel(message, duration, worldx, worldy);
+        ui.showLabel(message, id, duration, worldx, worldy);
     }
 
     @Remote(variants = Variant.both)
+    public static void labelReliable(String message, int id, float duration, float worldx, float worldy){
+        label(message, id, duration, worldx, worldy);
+    }
+
+    /** @deprecated Prefer variants with ids to stop flickering labels. */
+    @Deprecated
+    @Remote(variants = Variant.both, unreliable = true)
+    public static void label(String message, float duration, float worldx, float worldy){
+        label(message, -1, duration, worldx, worldy);
+    }
+
+    /** @deprecated Prefer variants with ids to stop flickering labels. */
+    @Deprecated
+    @Remote(variants = Variant.both)
     public static void labelReliable(String message, float duration, float worldx, float worldy){
-        label(message, duration, worldx, worldy);
+        label(message, -1, duration, worldx, worldy);
     }
 
     @Remote(variants = Variant.both)

--- a/core/src/mindustry/ui/Menus.java
+++ b/core/src/mindustry/ui/Menus.java
@@ -122,54 +122,54 @@ public class Menus{
     }
 
     @Remote(variants = Variant.both, unreliable = true)
-    public static void infoPopup(String message, @Nullable String id, float duration, int align, int top, int left, int bottom, int right){
+    public static void infoPopup(@Nullable String message, @Nullable String id, float duration, int align, int top, int left, int bottom, int right){
         if(message == null) return;
 
         ui.showInfoPopup(message, id, duration, align, top, left, bottom, right);
     }
 
     @Remote(variants = Variant.both)
-    public static void infoPopupReliable(String message, @Nullable String id, float duration, int align, int top, int left, int bottom, int right){
+    public static void infoPopupReliable(@Nullable String message, @Nullable String id, float duration, int align, int top, int left, int bottom, int right){
         infoPopup(message, id, duration, align, top, left, bottom, right);
     }
 
     /** @deprecated Prefer variants with ids to stop flickering popups. */
     @Deprecated
     @Remote(variants = Variant.both, unreliable = true)
-    public static void infoPopup(String message, float duration, int align, int top, int left, int bottom, int right){
+    public static void infoPopup(@Nullable String message, float duration, int align, int top, int left, int bottom, int right){
         infoPopup(message, null, duration, align, top, left, bottom, right);
     }
 
     /** @deprecated Prefer variants with ids to stop flickering popups. */
     @Deprecated
     @Remote(variants = Variant.both)
-    public static void infoPopupReliable(String message, float duration, int align, int top, int left, int bottom, int right){
+    public static void infoPopupReliable(@Nullable String message, float duration, int align, int top, int left, int bottom, int right){
         infoPopup(message, duration, align, top, left, bottom, right);
     }
 
     @Remote(variants = Variant.both, unreliable = true)
-    public static void label(String message, int id, float duration, float worldx, float worldy){
+    public static void label(@Nullable String message, int id, float duration, float worldx, float worldy){
         if(message == null) return;
 
         ui.showLabel(message, id, duration, worldx, worldy);
     }
 
     @Remote(variants = Variant.both)
-    public static void labelReliable(String message, int id, float duration, float worldx, float worldy){
+    public static void labelReliable(@Nullable String message, int id, float duration, float worldx, float worldy){
         label(message, id, duration, worldx, worldy);
     }
 
     /** @deprecated Prefer variants with ids to stop flickering labels. */
     @Deprecated
     @Remote(variants = Variant.both, unreliable = true)
-    public static void label(String message, float duration, float worldx, float worldy){
+    public static void label(@Nullable String message, float duration, float worldx, float worldy){
         label(message, -1, duration, worldx, worldy);
     }
 
     /** @deprecated Prefer variants with ids to stop flickering labels. */
     @Deprecated
     @Remote(variants = Variant.both)
-    public static void labelReliable(String message, float duration, float worldx, float worldy){
+    public static void labelReliable(@Nullable String message, float duration, float worldx, float worldy){
         label(message, -1, duration, worldx, worldy);
     }
 


### PR DESCRIPTION
Labels can make use of ids now as well, these ones are integers since labels are often tied to tiles and it makes sense to be able to use `tile.pos()` for the id and `tile.x * 8`, `tile.y * 8` for the position.
Additionally, both labels and popups can now be passed a null string to delete existing popups with matching ids.


- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
