### PR TITLE
Serpulo nano-rebalance: conveyor and junction

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -2081,9 +2081,8 @@ public class Blocks{
         conveyor = new Conveyor("conveyor"){{
             requirements(Category.distribution, with(Items.copper, 1));
             health = 45;
-            speed = 0.03f;
-            displayedSpeed = 4.2f;
-            buildCostMultiplier = 2f;
+            speed = 0.046f;
+            displayedSpeed = 6.5f;
             researchCost = with(Items.copper, 5);
         }};
 
@@ -2113,7 +2112,7 @@ public class Blocks{
             speed = 26;
             capacity = 6;
             health = 30;
-            buildCostMultiplier = 6f;
+            buildCostMultiplier = 3f;
         }};
 
         itemBridge = new BufferedItemBridge("bridge-conveyor"){{


### PR DESCRIPTION
<img width="418" height="305" alt="Captura de pantalla 2026-03-18 171811" src="https://github.com/user-attachments/assets/348f34ea-ed14-4d35-8c9a-d61cd66c8d84" />
<img width="546" height="301" alt="Captura de pantalla 2026-03-18 172855" src="https://github.com/user-attachments/assets/aa5c516f-8984-4feb-b737-ddc95d923c77" />

.

The cost (and specially) build time increase made junction next to useless as a wiring block compared to bridges. Basic conveyors are near instantly replaced the moment there s trickle influx of copper unlike bridges, junctions and titanium conveyors. While the old junction nerf was initially done to make conveyors more fair compared junctions this was the wrong approach.

**Conveyor:** movespeed: 4.2 -> 6.5 ;  build time: 0.016s ->0.008s
**Junction:** build time: 0.15s -> 0.075s

The new conveyor speed breaks almost no schematics and provides clean ratios with factories, such as coal to 4 smelters, lead/sand to 3 glass kilns or to 4 pyra mixers.

.

<img width="634" height="85" alt="image" src="https://github.com/user-attachments/assets/4fd92a9a-4948-4f7a-9e3a-ee326486a9b9" />
<img width="272" height="46" alt="image" src="https://github.com/user-attachments/assets/ee786df6-4735-45bd-b20e-89a532b3d83a" />
<img width="773" height="349" alt="image" src="https://github.com/user-attachments/assets/dfc982d2-3c24-4c87-a676-584e87c380bf" />


If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
