### PR TITLE
Allow any version to join hidden steam lobbies

### DIFF
--- a/desktop/src/mindustry/desktop/steam/SNet.java
+++ b/desktop/src/mindustry/desktop/steam/SNet.java
@@ -270,9 +270,10 @@ public class SNet implements SteamNetworkingCallback, SteamMatchmakingCallback, 
         }
 
         int version = Strings.parseInt(smat.getLobbyData(steamIDLobby, "version"), -1);
+        boolean hidden = smat.getLobbyData(steamIDLobby, "hidden").equals("true");
 
         //check version
-        if(version != Version.build){
+        if(version != Version.build && !hidden){
             ui.loadfrag.hide();
             ui.showInfo("[scarlet]" + (version > Version.build ? KickReason.clientOutdated : KickReason.serverOutdated) + "\n[]" +
                 Core.bundle.format("server.versions", Version.build, version));


### PR DESCRIPTION
The primary use case for hidden lobbies is steam verification servers. These aren't typically version sensitive as they only handle a couple packets before sending the user to a different server. It's annoying to bump the version every time the game updates so why not just ignore it?

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
