### PR TITLE
Size selection always move opposite to the cursor

### DIFF
--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1685,13 +1685,16 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
             float z = Draw.z();
             Draw.z(Layer.endPixeled);
             font.getData().setScale(1 / renderer.camerascale);
-            int width = (int)((result.x2 - result.x) / 8);
-            int height = (int)((result.y2 - result.y) / 8);
+
+            int width = (int)((result.x2 - result.x) / tilesize);
+            int height = (int)((result.y2 - result.y) / tilesize);
             int area = width * height;
+            float offset = 5f / renderer.camerascale * tilesize;
 
             font.draw(width + "x" + height + " (" + area + ")",
-            input.mouseWorldX() + 5 * (4 / renderer.camerascale),
-            input.mouseWorldY() - 5 * (4 / renderer.camerascale));
+                input.mouseWorldX() + (input.mouseWorldX() > x1 * tilesize ? offset : -offset),
+                input.mouseWorldY() + (input.mouseWorldY() > y1 * tilesize ? offset : -offset));
+
             font.setColor(Color.white);
             font.getData().setScale(1);
             font.setUseIntegerPositions(ints);


### PR DESCRIPTION
Since at least one user mentioned it cannot be viewed under your finger

https://github.com/user-attachments/assets/cccd6bc5-72ca-4a53-8660-6dd7285b3da4



If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
