### PR TITLE
Fix logic block link removal failing when multiple links point to same building

### DIFF
--- a/core/src/mindustry/world/blocks/logic/LogicBlock.java
+++ b/core/src/mindustry/world/blocks/logic/LogicBlock.java
@@ -86,16 +86,21 @@ public class LogicBlock extends Block{
             var lbuild = world.build(pos);
             int x = lbuild.tileX(), y = lbuild.tileY();
 
-            LogicLink link = entity.links.find(l -> l.x == x && l.y == y);
+            //find all links pointing to the target building
+            Seq<LogicLink> toRemove = entity.links.select(link -> {
+                Building lb = world.build(link.x, link.y);
+                return lb == lbuild;
+            });
 
-            if(link != null){
-                entity.links.remove(link);
+            if(!toRemove.isEmpty()){
+                //if links already exist, remove all links pointing to this building
+                entity.links.removeAll(toRemove);
                 //disable when unlinking
                 if(lbuild.block.autoResetEnabled && lbuild.lastDisabler == entity){
                     lbuild.enabled = true;
                 }
             }else{
-                entity.links.remove(l -> world.build(l.x, l.y) == lbuild);
+                //add link
                 entity.links.add(new LogicLink(x, y, entity.findLinkName(lbuild.block), true));
             }
 


### PR DESCRIPTION
**Description:** 
<img width="548" height="334" alt="PixPin_2026-03-30_14-27-51" src="https://github.com/user-attachments/assets/69b9b3ea-b58e-4be4-acd2-3a2d1ca53baf" />
Fixed a bug where clicking a logic block to remove links would not fully remove all links when multiple link coordinates pointed to the same target building. Users had to click twice to completely remove the links.
The issue occurred because the previous implementation only removed one link at a time. Now, when removing links, all links pointing to the target building are properly identified and removed in a single operation.

**Changes:**
Modified the link removal logic to find and remove all links pointing to the target building at once
This ensures that clicking a linked building once will completely remove all associations, regardless of how many link entries exist