### PR TITLE
Fix ConditionOp.strictEqual handling

### DIFF
--- a/core/src/mindustry/logic/ConditionOp.java
+++ b/core/src/mindustry/logic/ConditionOp.java
@@ -30,7 +30,7 @@ public enum ConditionOp{
 
     public boolean test(LVar va, LVar vb){
         if(this == ConditionOp.strictEqual){
-            return va.isobj == vb.isobj && ((va.isobj && va.objval == vb.objval) || (!va.isobj && va.numval == vb.numval));
+            return va.isobj == vb.isobj && ((va.isobj && Structs.eq(va.objval, vb.objval)) || (!va.isobj && va.numval == vb.numval));
         }
         if(objFunction != null && va.isobj && vb.isobj){
             //use object function if both are objects


### PR DESCRIPTION
The `jump` instrucion uses reference comparison to compare objects using `strictEqual`, while `op` instruction uses `Structs.eq` to compare objects using `strictEqual`. This fix removes the disparity by switching to `Structs.eq` even for `jump` instructions.

Note that reference comparison has the downside that it treats two identical strings as different. With the availability of `read` and `write` for processor variables, different instances of the same string may easily occur in a processor, leading to incorrect comparison of strings using `strictEqual` in a `jump` instruction.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
