### PR TITLE
RulesLoadEvent

### DIFF
--- a/core/src/mindustry/core/Control.java
+++ b/core/src/mindustry/core/Control.java
@@ -404,6 +404,7 @@ public class Control implements ApplicationListener, Loadable{
             if(playtest) state.playtestingMap = map;
             state.rules.sector = null;
             state.rules.editor = false;
+            Events.fire(new RulesLoadEvent(state.rules));
             logic.play();
             if(settings.getBool("savecreate") && !world.isInvalidMap() && !playtest){
                 control.saves.addSave(map.name() + " " + new SimpleDateFormat("MMM dd h:mm", Locale.getDefault()).format(new Date()));
@@ -543,6 +544,7 @@ public class Control implements ApplicationListener, Loadable{
                             });
                         }
                     }else{
+                        Events.fire(new RulesLoadEvent(state.rules, true));
                         state.set(State.playing);
                         reloader.end();
                     }
@@ -577,6 +579,7 @@ public class Control implements ApplicationListener, Loadable{
             beforePlay.run();
         }
 
+        Events.fire(new RulesLoadEvent(state.rules));
         logic.play();
         control.saves.saveSector(sector);
         Events.fire(new SectorLaunchEvent(sector));

--- a/core/src/mindustry/core/World.java
+++ b/core/src/mindustry/core/World.java
@@ -646,6 +646,11 @@ public class World{
             super.end();
         }
 
+        @Override
+        public boolean isMap(){
+            return true;
+        }
+
         public void applyFilters(){
             Seq<GenerateFilter> filters = map.filters();
 

--- a/core/src/mindustry/game/EventType.java
+++ b/core/src/mindustry/game/EventType.java
@@ -498,6 +498,22 @@ public class EventType{
         }
     }
 
+    /** Called when all rules of the current map are loaded. */
+    public static class RulesLoadEvent{
+        public final Rules rules;
+        public final boolean fromSave;
+
+        public RulesLoadEvent(Rules rules){
+            this.rules = rules;
+            this.fromSave = false;
+        }
+
+        public RulesLoadEvent(Rules rules, boolean fromSave){
+            this.rules = rules;
+            this.fromSave = fromSave;
+        }
+    }
+
     /**
      * Called when block building begins by placing down the ConstructBlock.
      * The tile's block will nearly always be a ConstructBlock.

--- a/core/src/mindustry/io/SaveIO.java
+++ b/core/src/mindustry/io/SaveIO.java
@@ -171,6 +171,11 @@ public class SaveIO{
 
             ver.read(stream, counter, context);
             Events.fire(new SaveLoadEvent(context.isMap()));
+
+            //this gets handled elsewhere when starting a new game or loading a sector
+            if(!context.isMap() && !state.isCampaign()){
+                Events.fire(new RulesLoadEvent(state.rules, true));
+            }
         }catch(Throwable e){
             throw new SaveException(e);
         }finally{

--- a/core/src/mindustry/maps/generators/FileMapGenerator.java
+++ b/core/src/mindustry/maps/generators/FileMapGenerator.java
@@ -78,11 +78,6 @@ public class FileMapGenerator implements WorldGenerator{
                 applyFilters();
                 //no super.end(), don't call world load event twice
             }
-
-            @Override
-            public boolean isMap(){
-                return true;
-            }
         });
         world.setGenerating(true);
 

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -427,6 +427,7 @@ public class ServerControl implements ApplicationListener{
                 try{
                     world.loadMap(result, result.applyRules(lastMode));
                     state.rules = result.applyRules(preset);
+                    Events.fire(new RulesLoadEvent(state.rules));
                     logic.play();
 
                     info("Map loaded.");
@@ -1232,6 +1233,7 @@ public class ServerControl implements ApplicationListener{
                 run.run();
 
                 state.rules = state.map.applyRules(lastMode);
+                Events.fire(new RulesLoadEvent(state.rules));
                 logic.play();
 
                 reloader.end();


### PR DESCRIPTION
New event so that mods would have a convenient way of modifying map rules right after they get loaded
Happens after WorldLoadEvent but before the game state gets set to playing

~~also fixed SaveLoadEvent considering newly started games as saves~~

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
