### PR TITLE
Fixes #11855

### DIFF
--- a/core/src/mindustry/mod/Mods.java
+++ b/core/src/mindustry/mod/Mods.java
@@ -373,7 +373,11 @@ public class Mods implements Loadable{
             regionName = baseName.contains(".") ? baseName.substring(0, baseName.indexOf(".")) : baseName;
 
             if(!prefix && !Core.atlas.has(regionName)){
-                Log.warn("Sprite '@' in mod '@' attempts to override a non-existent sprite.", regionName, mod.name);
+                Log.warn("Sprite '@' in mod '@' attempts to override a non-existent sprite. Ignoring.", regionName, mod.name);
+                continue;
+
+                // to the man who removed this: you ruined an entire 3 hours of my sleep
+		// please never make me do this again
             }
 
             //read and bleed pixmaps in parallel


### PR DESCRIPTION
A quick and simple fix for #11855: Putting back the original, safe behaviour that simply ignores the modded sprite override being added if it's clearly broken. This will inevitably break something later, but for now it fixes a few mods broken by that update.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
