### PR TITLE
Core units, poly, zenith bullets keep velocity but scale lifetime

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -3442,7 +3442,6 @@ public class Blocks{
                     hitEffect = Fx.hitFlameSmall;
                     despawnEffect = Fx.none;
                     status = StatusEffects.burning;
-                    keepVelocity = false;
                     hittable = false;
                 }},
                 Items.pyratite, new BulletType(4f, 30f){{

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -1176,7 +1176,7 @@ public class UnitTypes{
                     shrinkY = 0f;
                     drag = -0.003f;
                     homingRange = 60f;
-                    keepVelocity = false;
+                    scaleKeepVelocity = true;
                     splashDamageRadius = 25f;
                     splashDamage = 15f;
                     lifetime = 50f;
@@ -1411,7 +1411,7 @@ public class UnitTypes{
                     weaveMag = 4;
                     weaveScale = 4;
                     lifetime = 50f;
-                    keepVelocity = false;
+                    scaleKeepVelocity = true;
                     shootEffect = Fx.shootHeal;
                     smokeEffect = Fx.hitLaser;
                     hitEffect = despawnEffect = Fx.hitLaser;
@@ -2546,7 +2546,7 @@ public class UnitTypes{
                 shootSound = Sounds.shootAlpha;
 
                 bullet = new LaserBoltBulletType(2.5f, 11){{
-                    keepVelocity = false;
+                    scaleKeepVelocity = true;
                     width = 1.5f;
                     height = 4.5f;
                     hitEffect = despawnEffect = Fx.hitBulletColor;
@@ -2597,7 +2597,7 @@ public class UnitTypes{
                 shootSound = Sounds.shootAlpha;
 
                 bullet = new LaserBoltBulletType(3f, 11){{
-                    keepVelocity = false;
+                    scaleKeepVelocity = true;
                     width = 1.5f;
                     height = 4.5f;
                     hitEffect = despawnEffect = Fx.hitBulletColor;
@@ -2652,7 +2652,7 @@ public class UnitTypes{
                 shootSound = Sounds.shootAlpha;
 
                 bullet = new LaserBoltBulletType(3.5f, 11){{
-                    keepVelocity = false;
+                    scaleKeepVelocity = true;
                     width = 1.5f;
                     height = 5f;
                     hitEffect = despawnEffect = Fx.hitBulletColor;

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -135,6 +135,8 @@ public class BulletType extends Content implements Cloneable{
     public boolean collideTerrain = false;
     /** Whether velocity is inherited from the shooter. */
     public boolean keepVelocity = true;
+    /** If keepVelocity = true, whether to reduce lifetime proportionally to the added speed, making range consistent. */
+    public boolean scaleKeepVelocity = false;
     /** Whether to scale lifetime (not actually velocity!) to disappear at the target position. Used for artillery. */
     public boolean scaleLife;
     /** Whether this bullet can be hit by point defense. */
@@ -833,6 +835,7 @@ public class BulletType extends Content implements Cloneable{
 
         if(fragBullet != null){
             fragBullet.keepVelocity = false;
+            fragBullet.scaleKeepVelocity = false;
         }
 
         if(lightningType == null){
@@ -973,7 +976,15 @@ public class BulletType extends Content implements Cloneable{
         }
         bullet.add();
 
-        if(keepVelocity && owner instanceof Velc v) bullet.vel.add(v.vel());
+        if(keepVelocity && owner instanceof Velc v){
+            float len = bullet.vel.len();
+            bullet.vel.add(v.vel());
+
+            if(scaleKeepVelocity){
+                float newLen = bullet.vel.len();
+                if(newLen > 0f) bullet.lifetime *= len / newLen;
+            }
+        }
         return bullet;
     }
 


### PR DESCRIPTION
Ever since the rework of the serpulo core units there were many complains their bullets can no longer chase units. Range should be consistent now

https://github.com/user-attachments/assets/93f18b87-abab-47d8-93de-3b6601127d63


https://github.com/user-attachments/assets/11f0fa9d-5865-40f3-9a6f-9d6cdab3e0c7

<img width="608" height="430" alt="image" src="https://github.com/user-attachments/assets/475d75c6-d357-420d-a174-f96596213eff" />

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
