### PR TITLE
Fix Inconsistency between Mobile and Desktop for configuring messages

### DIFF
--- a/core/src/mindustry/world/blocks/logic/MessageBlock.java
+++ b/core/src/mindustry/world/blocks/logic/MessageBlock.java
@@ -107,13 +107,13 @@ public class MessageBlock extends Block{
         public void buildConfiguration(Table table){
             table.button(Icon.pencil, Styles.cleari, () -> {
                 if(mobile){
-                    var contents = this.message.toString();
+                    var contents = message;
                     Core.input.getTextInput(new TextInput(){{
-                        text = contents;
+                        text = contents.toString();
                         multiline = true;
                         maxLength = maxTextLength;
                         accepted = str -> {
-                            if(!str.equals(text)) configure(str);
+                            if(!str.contentEquals(contents)) configure(str);
                         };
                     }});
                 }else{
@@ -136,7 +136,7 @@ public class MessageBlock extends Block{
                     dialog.cont.row();
                     dialog.cont.label(() -> a.getText().length() + " / " + maxTextLength).color(Color.lightGray);
                     dialog.buttons.button("@ok", () -> {
-                        if(!a.getText().equals(message.toString())) configure(a.getText());
+                        if(!a.getText().contentEquals(message)) configure(a.getText());
                         dialog.hide();
                     }).size(130f, 60f);
                     dialog.update(() -> {


### PR DESCRIPTION
This fixes a small inconsistency between desktop and mobile, and so i went with the desktop behavior due to it allowing to configure a message without changing any text (for example with a proc constantly changing the text) and still having the config be done if there is a mismatch

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
Unfortunately, i didn't figure out how to compile for mobile (and sadly Input::getTextInput doesnt work on desktop) so i cannot check the last check (compiles for desktop which is my reason to check the 2nd check)