### PR TITLE
Rotation for text in Drawf.text

### DIFF
--- a/core/src/mindustry/graphics/Drawf.java
+++ b/core/src/mindustry/graphics/Drawf.java
@@ -22,14 +22,14 @@ public class Drawf{
     private static final FloatSeq points = new FloatSeq();
 
     public static void text(String text, float x, float y, Color color){
-        text(text, x, y, color, 1f, Align.center);
+        text(text, x, y, 0f, color, 1f, Align.center);
     }
 
     public static void text(String text, float x, float y, Color color, float scale){
-        text(text, x, y, color, scale, Align.center);
+        text(text, x, y, 0f, color, scale, Align.center);
     }
 
-    public static void text(String text, float x, float y, Color color, float scale, int align){
+    public static void text(String text, float x, float y, float rotation, Color color, float scale, int align){
         Font font = Fonts.outline;
         boolean ints = font.usesIntegerPositions();
         font.setUseIntegerPositions(false);
@@ -37,6 +37,11 @@ public class Drawf{
         font.setColor(color);
         font.getCache().clear();
         font.getCache().addText(text, x, y, 0f, align, false);
+        GlyphLayout layout = font.getCache().addText(text, x, y, 0f, align, false);
+        if(rotation != 0){
+            float verticalFraction = (align & Align.bottom) != 0 ? 1f : (align & Align.top) != 0 ? 0f: 0.5f;
+            font.getCache().setRotation(rotation, x, y - layout.height * verticalFraction);
+        }
         if(color.a < 1f){
             font.getCache().setAlphas(color.a);
         }

--- a/core/src/mindustry/graphics/Drawf.java
+++ b/core/src/mindustry/graphics/Drawf.java
@@ -40,7 +40,6 @@ public class Drawf{
         font.getData().setScale(0.25f / Scl.scl(1f) * scale);
         font.setColor(color);
         font.getCache().clear();
-        font.getCache().addText(text, x, y, 0f, align, false);
         GlyphLayout layout = font.getCache().addText(text, x, y, 0f, align, false);
         if(rotation != 0){
             float verticalFraction = (align & Align.bottom) != 0 ? 1f : (align & Align.top) != 0 ? 0f: 0.5f;

--- a/core/src/mindustry/graphics/Drawf.java
+++ b/core/src/mindustry/graphics/Drawf.java
@@ -29,6 +29,10 @@ public class Drawf{
         text(text, x, y, 0f, color, scale, Align.center);
     }
 
+    public static void text(String text, float x, float y, Color color, float scale, int align){
+        text(text, x, y, 0f, color, scale, align);
+    }
+
     public static void text(String text, float x, float y, float rotation, Color color, float scale, int align){
         Font font = Fonts.outline;
         boolean ints = font.usesIntegerPositions();


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

This PR is supposed to be implemented once [this](https://github.com/Anuken/Arc/pull/201) gets accepted. Please keep that in mind as there are methods used which require the addition of `getRotation` from that PR.

Text when drawn with the Drawf.text method can now use rotation as a parameter.

Centered rotation:
![NVIDIA_Overlay_DPkgralIFR](https://github.com/user-attachments/assets/dade6518-5a41-4e5a-8a56-00eaa8d42e6e)

Bottom left rotation:
![javaw_hSUDBOzmDA](https://github.com/user-attachments/assets/80ef06a0-5649-48f7-9b04-af5cb1374e0c)

Top right rotation:
![NVIDIA_Overlay_4VRNmw3uph](https://github.com/user-attachments/assets/5d2c62d7-1be4-4e91-813f-ed3349c492c3)

You get the point...

Note: the variable verticalFraction is hard-coded to ensure alignments rotate the text region as expected. Not sure how else I could've made it...
