### PR TITLE
Bugfix: Keepvel dont increase range when kiting (moving backwards)

### DIFF
--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -2639,7 +2639,7 @@ public class UnitTypes{
 
             weapons.add(new Weapon("small-mount-weapon"){{
                 top = false;
-                reload = 1f;
+                reload = 15f;
                 x = 1f;
                 y = 2f;
                 shoot = new ShootSpread(){{

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -2639,7 +2639,7 @@ public class UnitTypes{
 
             weapons.add(new Weapon("small-mount-weapon"){{
                 top = false;
-                reload = 15f;
+                reload = 1f;
                 x = 1f;
                 y = 2f;
                 shoot = new ShootSpread(){{

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -978,7 +978,8 @@ public class BulletType extends Content implements Cloneable{
 
         if(keepVelocity && owner instanceof Velc v){
             float len = bullet.vel.len();
-            bullet.vel.add(v.vel());
+            //only add velocity, never substract
+            if(v.vel().dot(bullet.vel) / len > 0f) bullet.vel.add(v.vel());
 
             if(scaleKeepVelocity){
                 float newLen = bullet.vel.len();

--- a/core/src/mindustry/entities/bullet/BulletType.java
+++ b/core/src/mindustry/entities/bullet/BulletType.java
@@ -978,12 +978,12 @@ public class BulletType extends Content implements Cloneable{
 
         if(keepVelocity && owner instanceof Velc v){
             float len = bullet.vel.len();
-            //only add velocity, never substract
-            if(v.vel().dot(bullet.vel) / len > 0f) bullet.vel.add(v.vel());
+            bullet.vel.add(v.vel());
 
             if(scaleKeepVelocity){
                 float newLen = bullet.vel.len();
-                if(newLen > 0f) bullet.lifetime *= len / newLen;
+                //only reduce lifetime, never add
+                if(newLen > 0f) bullet.lifetime *= Math.min(1f, len / newLen);
             }
         }
         return bullet;


### PR DESCRIPTION
### Old
<img width="1167" height="155" alt="image" src="https://github.com/user-attachments/assets/c2814d6e-f830-4699-83b3-6a3f900662b7" />

### New
<img width="1156" height="224" alt="image" src="https://github.com/user-attachments/assets/3f7aa9ec-6f0a-4c66-8968-77935a6a0881" />

<img width="552" height="98" alt="image" src="https://github.com/user-attachments/assets/6074a5e9-1637-451e-9ff5-d79e97d3ccee" />

.

For the chaser (moving forwards)
<img width="690" height="263" alt="image" src="https://github.com/user-attachments/assets/cf8e09db-530e-419a-b717-c1a9ab2bb581" />



If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
