### PR TITLE
Add cache bust to steam ban list.

### DIFF
--- a/core/src/mindustry/net/SteamAdmin.java
+++ b/core/src/mindustry/net/SteamAdmin.java
@@ -3,6 +3,7 @@ package mindustry.net;
 import arc.*;
 import arc.struct.*;
 import arc.util.*;
+import arc.util.serialization.*;
 import mindustry.*;
 import mindustry.gen.*;
 import mindustry.io.*;
@@ -14,9 +15,28 @@ public class SteamAdmin{
     private static final float checkInterval = 60f * 5f;
 
     public static void fetch(){
+        fetch(false);
+    }
+
+    public static void fetch(boolean cacheBust){
         if(!Vars.steam) return;
 
-        fetch(Vars.steamBansURLs[0], () -> fetch(Vars.steamBansURLs[1], () -> {}));
+        if(cacheBust){ //specific commit avoids the 5 minute cache on the /master/ ref
+            Http.get(Vars.ghApi + "/repos/Anuken/MindustrySteamBans/commits?path=data.json&per_page=1").submit(res -> { //fetch latest commit from api
+                try{
+                    fetchImpl(Vars.steamBansURLs[0].replace("master", Jval.read(res.getResultAsString()).asArray().first().getString("sha")));
+                }catch(Exception e){
+                    Log.err("Failed to fetch latest commit", e);
+                    fetchImpl(Vars.steamBansURLs[0]);
+                }
+            });
+        }else{
+            fetchImpl(Vars.steamBansURLs[0]);
+        }
+    }
+
+    private static void fetchImpl(String githubURL){
+        fetch(githubURL, () -> fetch(Vars.steamBansURLs[1], () -> {}));
         if(!scheduled){
             scheduled = true;
             Timer.schedule(SteamAdmin::fetch, checkInterval, checkInterval);

--- a/desktop/src/mindustry/desktop/steam/SNet.java
+++ b/desktop/src/mindustry/desktop/steam/SNet.java
@@ -309,8 +309,8 @@ public class SNet implements SteamNetworkingCallback, SteamMatchmakingCallback, 
 
     @Override
     public void onLobbyChatUpdate(SteamID lobby, SteamID who, SteamID changer, ChatMemberStateChange change){
-        Log.info("lobby @: @ caused @'s change: @", lobby.getAccountID(), who.getAccountID(), changer.getAccountID(), change);
-        if(change == ChatMemberStateChange.Entered && SteamAdmin.isAdmin("steam:" + who.getAccountID())) SteamAdmin.fetch(); //fetch on admin join
+        Log.info("lobby @: @ caused @'s change: @", lobby.getAccountID(), changer.getAccountID(), who.getAccountID(), change);
+        if(change == ChatMemberStateChange.Entered && SteamAdmin.isAdmin("steam:" + who.getAccountID())) SteamAdmin.fetch(true); //fetch on admin join
         if(change == ChatMemberStateChange.Disconnected || change == ChatMemberStateChange.Left){
             if(net.client()){
                 //host left, leave as well


### PR DESCRIPTION
Github caches raws for a few minutes. This is not ideal when we want to refresh it immediately.  The fix is to use the api to grab the latest commit then grab the raw file from that commit, bypassing the 5 minute cache on the /master/ ref.


- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
