### PR TITLE
Add data setting which allows clearing saves/research for only one planet & Fixed #11977

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -1030,6 +1030,13 @@ settings.clearresearch = Clear Research
 settings.clearresearch.confirm = Are you sure you want to clear all of your campaign research?
 settings.clearcampaignsaves = Clear Campaign Saves
 settings.clearcampaignsaves.confirm = Are you sure you want to clear all of your campaign saves?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Paused >
 clear = Clear
 banned = [scarlet]Banned

--- a/core/assets/bundles/bundle_be.properties
+++ b/core/assets/bundles/bundle_be.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Ачысціць Даследаванні
 settings.clearresearch.confirm = Вы сапраўды жадаеце ачысціць усе вашыя даследаванні ў кампаніі?
 settings.clearcampaignsaves = Ачысціць Захаванні Кампаніі
 settings.clearcampaignsaves.confirm = Вы сапраўды жадаеце ачысціць усе вашыя захаванні ў кампаніі?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent] <Паўза>
 clear = Ачысціць
 banned = [scarlet] Забаронена

--- a/core/assets/bundles/bundle_bg.properties
+++ b/core/assets/bundles/bundle_bg.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Изчисти проучванията
 settings.clearresearch.confirm = Сигурни ли сте, че искате да изчистите всичките си проучвания от кампанията?
 settings.clearcampaignsaves = Изчисти запазените игри в кампанията
 settings.clearcampaignsaves.confirm = Сигурни ли сте, че искате да изтриете всичките си записи от кампанията?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Играта е в пауза >
 clear = Изчисти
 banned = [scarlet]Баннат

--- a/core/assets/bundles/bundle_ca.properties
+++ b/core/assets/bundles/bundle_ca.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Esborra la recerca
 settings.clearresearch.confirm = Esteu segur que voleu esborrar tota la recerca feta en el mode campanya?
 settings.clearcampaignsaves = Esborra les desades de la campanya
 settings.clearcampaignsaves.confirm = Esteu segur que voleu esborrar totes les desades de la campanya?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< En pausa >
 clear = Esborra
 banned = [scarlet]Expulsat

--- a/core/assets/bundles/bundle_cs.properties
+++ b/core/assets/bundles/bundle_cs.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Vymazat výzkum
 settings.clearresearch.confirm = Jsi si jist, že opravdu chceš vymazat veškerý dosažený výzkum v této kampani?
 settings.clearcampaignsaves = Vymazat uložené hry kampaně
 settings.clearcampaignsaves.confirm = Jsi si jist, že opravdu chceš vymazat všechny uložené hry v této kampani?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Pozastaveno >[]
 clear = Vyčistit
 banned = [scarlet]Zakázán[]

--- a/core/assets/bundles/bundle_da.properties
+++ b/core/assets/bundles/bundle_da.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Ryd research
 settings.clearresearch.confirm = Er du sikker på, at du vil rydde alt din research?
 settings.clearcampaignsaves = Ryd kampagne-gem
 settings.clearcampaignsaves.confirm = Er du sikker på at du vil slette alt kampagne-fremskridt?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Pauset >
 clear = Ryd
 banned = [scarlet]Banlyst

--- a/core/assets/bundles/bundle_de.properties
+++ b/core/assets/bundles/bundle_de.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Erforschungen löschen
 settings.clearresearch.confirm = Möchtest du wirklich alle Erforschungen löschen?
 settings.clearcampaignsaves = Kampagne-Speicherstände löschen
 settings.clearcampaignsaves.confirm = Möchtest du wirklich alle Kampagne-Speicherstände löschen?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Pausiert >
 clear = Leeren
 banned = [scarlet]Verbannt

--- a/core/assets/bundles/bundle_es.properties
+++ b/core/assets/bundles/bundle_es.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Borrar investigaciones tecnológicas
 settings.clearresearch.confirm = ¿Quieres eliminar todo el progreso de las investigaciones tecnológicas del modo campaña?
 settings.clearcampaignsaves = Borrar datos de campaña
 settings.clearcampaignsaves.confirm = ¿Quieres borrar tus partidas guardadas en el modo campaña?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent] < Pausado >
 clear = Borrar
 banned = [scarlet]Vetado

--- a/core/assets/bundles/bundle_et.properties
+++ b/core/assets/bundles/bundle_et.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Clear Research
 settings.clearresearch.confirm = Are you sure you want to clear all of your campaign research?
 settings.clearcampaignsaves = Clear Campaign Saves
 settings.clearcampaignsaves.confirm = Are you sure you want to clear all of your campaign saves?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Paus >
 clear = Clear
 banned = [scarlet]Banned

--- a/core/assets/bundles/bundle_eu.properties
+++ b/core/assets/bundles/bundle_eu.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Ikerketa ezabatu
 settings.clearresearch.confirm = Ziur zaude zure kanpainaren ikerketa guztia ezabatu nahi duzula?
 settings.clearcampaignsaves = Ezabatu kanpainan gordetako partidak
 settings.clearcampaignsaves.confirm = Ziur zaude zure kanpaina guztiak ezabatu nahi dituzula?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Pausatuta >
 clear = Garbitu
 banned = [scarlet]Debekatuta

--- a/core/assets/bundles/bundle_fi.properties
+++ b/core/assets/bundles/bundle_fi.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Poista tutkimukset
 settings.clearresearch.confirm = Oletko varma, että haluat tyhjentää kaikki tutkimuksesi polussa?
 settings.clearcampaignsaves = Poista kampanjatallennukset
 settings.clearcampaignsaves.confirm = Oletko varma, että haluat poistaa kaikki kampanjatallennuksesi?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Pysäytetty >
 clear = Tyhjä
 banned = [scarlet]Kielletty

--- a/core/assets/bundles/bundle_fil.properties
+++ b/core/assets/bundles/bundle_fil.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = I-Clear Research
 settings.clearresearch.confirm = Sigurado ka bang gusto mong i-clear ang lahat ng iyong campaign research?
 settings.clearcampaignsaves = Tanggalin ang mga Campaign Save
 settings.clearcampaignsaves.confirm = Sigurado ka bang gusto mong i-clear ang lahat ng iyong mga campaign save?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Paused >
 clear = Clear
 banned = [scarlet]Pinagbabawalan!

--- a/core/assets/bundles/bundle_fr.properties
+++ b/core/assets/bundles/bundle_fr.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Supprimer la Recherche
 settings.clearresearch.confirm = Êtes-vous sûr de vouloir supprimer toutes les recherches de la campagne ?
 settings.clearcampaignsaves = Supprimer la Campagne
 settings.clearcampaignsaves.confirm = Êtes-vous sûr de vouloir supprimer toutes les sauvegardes de la campagne ?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Pause >
 clear = Effacer
 banned = [scarlet]Banni

--- a/core/assets/bundles/bundle_hu.properties
+++ b/core/assets/bundles/bundle_hu.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Fejlesztések törlése
 settings.clearresearch.confirm = Biztosan törlöd az összes fejlesztést?
 settings.clearcampaignsaves = Hadjáratmentések törlése
 settings.clearcampaignsaves.confirm = Biztosan törlöd az összes hadjáratmentést?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Szünet >
 clear = Törlés
 banned = [scarlet]Kitiltva

--- a/core/assets/bundles/bundle_id_ID.properties
+++ b/core/assets/bundles/bundle_id_ID.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Bersihkan Riset Kampanye
 settings.clearresearch.confirm = Apakah Anda yakin ingin membersihkan semua riset kampanye?
 settings.clearcampaignsaves = Bersihkan Simpanan Kampanye
 settings.clearcampaignsaves.confirm = Apakah Anda yakin ingin membersihkan semua simpanan kampanye?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Jeda >
 clear = Kosongkan
 banned = [scarlet]Dilarang

--- a/core/assets/bundles/bundle_it.properties
+++ b/core/assets/bundles/bundle_it.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Elimina Scoperte
 settings.clearresearch.confirm = Sei sicuro di voler eliminare le scoperte della modalità campagna?
 settings.clearcampaignsaves = Elimina Salvataggi Campagna
 settings.clearcampaignsaves.confirm = Sei sicuro di voler eliminare tutti i salvataggi della modalità campagna?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< In Pausa >
 clear = Pulisci
 banned = [scarlet]Bandito

--- a/core/assets/bundles/bundle_ja.properties
+++ b/core/assets/bundles/bundle_ja.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = 研究リセット
 settings.clearresearch.confirm = キャンペーンの研究をすべて削除してもよろしいですか？
 settings.clearcampaignsaves = キャンペーンのリセット
 settings.clearcampaignsaves.confirm = キャンペーンのセーブデータをすべて削除してもよろしいですか？
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< ポーズ >
 clear = 消去
 banned = [scarlet]使用禁止

--- a/core/assets/bundles/bundle_ko.properties
+++ b/core/assets/bundles/bundle_ko.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = 연구 초기화
 settings.clearresearch.confirm = 정말로 모든 연구를 삭제하시겠습니까?
 settings.clearcampaignsaves = 캠페인 맵 초기화
 settings.clearcampaignsaves.confirm = 정말로 캠페인을 초기화하시겠습니까?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< 일시정지 >[]
 clear = 초기화
 banned = [scarlet]금지됨

--- a/core/assets/bundles/bundle_lt.properties
+++ b/core/assets/bundles/bundle_lt.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Clear Research
 settings.clearresearch.confirm = Are you sure you want to clear all of your campaign research?
 settings.clearcampaignsaves = Clear Campaign Saves
 settings.clearcampaignsaves.confirm = Are you sure you want to clear all of your campaign saves?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Sustabdyta >
 clear = Išvalyti
 banned = [scarlet]Užblokuota

--- a/core/assets/bundles/bundle_nl.properties
+++ b/core/assets/bundles/bundle_nl.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Wis Onderzoek
 settings.clearresearch.confirm = Weet je zeker dat je al je onderzoek wilt verwijderen?
 settings.clearcampaignsaves = Wis Veldtocht Saves
 settings.clearcampaignsaves.confirm = Weet je zeker dat je al je veldtocht saves wilt verwijderen?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Gepauzeerd >
 clear = Wis
 banned = [scarlet]Verbannen

--- a/core/assets/bundles/bundle_nl_BE.properties
+++ b/core/assets/bundles/bundle_nl_BE.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Clear Research
 settings.clearresearch.confirm = Are you sure you want to clear all of your campaign research?
 settings.clearcampaignsaves = Clear Campaign Saves
 settings.clearcampaignsaves.confirm = Are you sure you want to clear all of your campaign saves?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Paused >
 clear = Clear
 banned = [scarlet]Banned

--- a/core/assets/bundles/bundle_pl.properties
+++ b/core/assets/bundles/bundle_pl.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Usuń Postęp Drzewa Technologicznego
 settings.clearresearch.confirm = Czy jesteś pewny, że chcesz usunąć cały postęp drzewa technologicznego?
 settings.clearcampaignsaves = Usuń Zapisy Kampanii
 settings.clearcampaignsaves.confirm = Czy jesteś pewny, że chcesz usunąć wszystkie zapisy kampanii?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Wstrzymano >
 clear = Wyczyść
 banned = [scarlet]Zbanowano

--- a/core/assets/bundles/bundle_pt_BR.properties
+++ b/core/assets/bundles/bundle_pt_BR.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Apagar Pesquisas
 settings.clearresearch.confirm = Você tem certeza que quer apagar todas as suas pesquisas da campanha?
 settings.clearcampaignsaves = Apagar Saves da Campanha
 settings.clearcampaignsaves.confirm = Você tem certeza que quer apagar todos os seus saves da campanha?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = Pausado
 clear = Limpo
 banned = [scarlet]BANIDO

--- a/core/assets/bundles/bundle_pt_PT.properties
+++ b/core/assets/bundles/bundle_pt_PT.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Limpar Pesquisa
 settings.clearresearch.confirm = Tens a certeza que queres apagar toda a tua pesquisa na campanha?
 settings.clearcampaignsaves = Limpar Saves da Campanha
 settings.clearcampaignsaves.confirm = Tens a certeza que queres limpar todos os teus saves da campanha?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = < Pausado >
 clear = Limpar
 banned = [scarlet]Banido

--- a/core/assets/bundles/bundle_ro.properties
+++ b/core/assets/bundles/bundle_ro.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Șterge Tehnologiile Cercetate
 settings.clearresearch.confirm = Sigur vrei să ștergi toate tehnologiile cercetate în campanie?
 settings.clearcampaignsaves = Șterge Salvările din Campanie
 settings.clearcampaignsaves.confirm = Sigur vrei să ștergi toate salvările din campanie?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Pauză >
 clear = Curăță
 banned = [scarlet]Interzis

--- a/core/assets/bundles/bundle_ru.properties
+++ b/core/assets/bundles/bundle_ru.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Сбросить исследования
 settings.clearresearch.confirm = Вы уверены, что хотите сбросить все ваши исследования кампании?
 settings.clearcampaignsaves = Очистить сохранения кампании
 settings.clearcampaignsaves.confirm = Вы уверены, что хотите очистить все ваши сохранения кампании?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Пауза >
 clear = Очистить
 banned = [scarlet]Запрещено

--- a/core/assets/bundles/bundle_sr.properties
+++ b/core/assets/bundles/bundle_sr.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Očisti Izučavanja
 settings.clearresearch.confirm = Da li ste sigurni da želite obrisati sva izučavanja unutar kampanje?
 settings.clearcampaignsaves = Očisti Snimke Kampanje
 settings.clearcampaignsaves.confirm = Da li ste sigurni da želite obrisati sve snimke u kampanji?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Pauzirano >
 clear = Očisti
 banned = [scarlet]Nedozvoljeno

--- a/core/assets/bundles/bundle_sv.properties
+++ b/core/assets/bundles/bundle_sv.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Clear Research
 settings.clearresearch.confirm = Are you sure you want to clear all of your campaign research?
 settings.clearcampaignsaves = Clear Campaign Saves
 settings.clearcampaignsaves.confirm = Are you sure you want to clear all of your campaign saves?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Pausat >
 clear = Clear
 banned = [scarlet]Banned

--- a/core/assets/bundles/bundle_th.properties
+++ b/core/assets/bundles/bundle_th.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = เคลียร์การวิจัย
 settings.clearresearch.confirm = แน่ใจที่จะเคลียร์การวิจัยหรือไม่?
 settings.clearcampaignsaves = ลบเซฟแคมเปญ
 settings.clearcampaignsaves.confirm = แน่ใจว่าจะลบเซฟแคมเปญหรือไม่?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< หยุดชั่วคราว >
 clear = เคลียร์
 banned = [scarlet]ถูกแบน

--- a/core/assets/bundles/bundle_tk.properties
+++ b/core/assets/bundles/bundle_tk.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Clear Research
 settings.clearresearch.confirm = Are you sure you want to clear all of your campaign research?
 settings.clearcampaignsaves = Clear Campaign Saves
 settings.clearcampaignsaves.confirm = Are you sure you want to clear all of your campaign saves?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = Duraklatildi
 clear = Clear
 banned = [scarlet]Banned

--- a/core/assets/bundles/bundle_tr.properties
+++ b/core/assets/bundles/bundle_tr.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Araştırma Verisini Sil
 settings.clearresearch.confirm = Mücadele modundaki yaptığınız tüm araştırmaları sıfırlamak istediğinize emin misiniz?
 settings.clearcampaignsaves = Mücadele Kayıt Verisini Sil
 settings.clearcampaignsaves.confirm = Mücadele modundaki oynadığınız tüm sektörleri sıfırlamak istediğinize emin misiniz?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]<Durduruldu>
 clear = Temizle
 banned = [scarlet]Yasaklı

--- a/core/assets/bundles/bundle_uk_UA.properties
+++ b/core/assets/bundles/bundle_uk_UA.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Очистити дослідження
 settings.clearresearch.confirm = Ви справді хочете очистити дослідження кампанії?
 settings.clearcampaignsaves = Очистити збереження в кампанії
 settings.clearcampaignsaves.confirm = Ви справді хочете очистити всі збереження в кампанії?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Пауза >
 clear = Очистити
 banned = [scarlet]Заблоковано

--- a/core/assets/bundles/bundle_vi.properties
+++ b/core/assets/bundles/bundle_vi.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = Xóa nghiên cứu
 settings.clearresearch.confirm = Bạn có chắc muốn xóa tất cả nghiên cứu từ chiến dịch?
 settings.clearcampaignsaves = Xóa bản lưu chiến dịch
 settings.clearcampaignsaves.confirm = Bạn có chắc muốn xóa toàn bộ bản lưu chiến dịch?
+settings.clearplanetdata = Clear Planet Data
+settings.planetselect = Planet: {0}
+settings.clearplanetresearch = Clear Planet Research
+settings.clearplanetresearch.confirm = Are you sure you want to clear {0}'s research?
+settings.clearplanetcampaignsaves = Clear Planet Campaign Saves
+settings.clearplanetcampaignsaves.confirm = Are you sure you want to clear {0}'s campaign saves?
+
 paused = [accent]< Tạm dừng >
 clear = Xóa
 banned = [scarlet]Bị cấm

--- a/core/assets/bundles/bundle_zh_CN.properties
+++ b/core/assets/bundles/bundle_zh_CN.properties
@@ -1028,6 +1028,13 @@ settings.clearresearch = 清除研究进度
 settings.clearresearch.confirm = 确认要清除战役研究进度吗？
 settings.clearcampaignsaves = 清除战役进度
 settings.clearcampaignsaves.confirm = 确认要清除所有战役进度吗？
+settings.clearplanetdata = 清除星球数据
+settings.planetselect = 星球: {0}
+settings.clearplanetresearch = 清除星球研究进度
+settings.clearplanetresearch.confirm = 确认要清除{0}的研究进度吗？
+settings.clearplanetcampaignsaves = 清除星球战役进度
+settings.clearplanetcampaignsaves.confirm = 确认要清除{0}的战役进度吗？
+
 paused = [accent]< 暂停 >
 clear = 清除
 banned = [scarlet]禁用

--- a/core/assets/bundles/bundle_zh_TW.properties
+++ b/core/assets/bundles/bundle_zh_TW.properties
@@ -625,15 +625,15 @@ toolmode.fillteams = 填充團隊
 toolmode.fillteams.description = 填充團隊而非方塊。
 toolmode.fillerase = 清除相同
 toolmode.fillerase.description = 清除相同種類的方塊。
-toolmode.fillcliffs = Fill Cliffs
-toolmode.fillcliffs.description = Turns walls into cliffs.
+toolmode.fillcliffs = 填充懸崖
+toolmode.fillcliffs.description = 將牆壁轉換為懸崖。
 toolmode.drawteams = 繪製團隊
 toolmode.drawteams.description = 繪製團隊而非方塊。
 #unused
 toolmode.underliquid = 水下地形
 toolmode.underliquid.description = 繪製液體下的地形
-toolmode.fillunderliquid = Fill Under Liquids
-toolmode.fillunderliquid.description = Fill floors under liquid tiles.
+toolmode.fillunderliquid = 填充水下地形
+toolmode.fillunderliquid.description = 填充液體下的地形
 
 filters.empty = [lightgray]沒有過濾器！使用下面的按鈕新增一個。
 
@@ -1028,6 +1028,13 @@ settings.clearresearch = 清除研究
 settings.clearresearch.confirm = 您確定要清除所有研究？
 settings.clearcampaignsaves = 清除戰役紀錄
 settings.clearcampaignsaves.confirm = 您確定要清除所有戰役紀錄？
+settings.clearplanetdata = 清除行星資料
+settings.planetselect = 行星: {0}
+settings.clearplanetresearch = 清除行星研究
+settings.clearplanetresearch.confirm = 您確定要清除{0}的研究？
+settings.clearplanetcampaignsaves = 清除行星戰役紀錄
+settings.clearplanetcampaignsaves.confirm = 您確定要清除{0}的戰役紀錄？
+
 paused = [accent]（已暫停）
 clear = 清除
 banned = [scarlet]已被封鎖

--- a/core/src/mindustry/service/GameService.java
+++ b/core/src/mindustry/service/GameService.java
@@ -115,7 +115,7 @@ public class GameService{
             installMod.complete();
         }
 
-        if(Core.bundle.get("yes").equals("router")){
+        if(Core.bundle.get("ok").equals(Blocks.router.emoji()+Blocks.router.emoji())){
             routerLanguage.complete();
         }
 

--- a/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
+++ b/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
@@ -29,8 +29,6 @@ import mindustry.ui.*;
 import java.io.*;
 import java.util.zip.*;
 
-import javax.swing.Icon;
-
 import static arc.Core.*;
 import static mindustry.Vars.*;
 

--- a/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
+++ b/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
@@ -23,10 +23,13 @@ import mindustry.game.EventType.*;
 import mindustry.gen.*;
 import mindustry.graphics.*;
 import mindustry.input.*;
+import mindustry.type.Planet;
 import mindustry.ui.*;
 
 import java.io.*;
 import java.util.zip.*;
+
+import javax.swing.Icon;
 
 import static arc.Core.*;
 import static mindustry.Vars.*;
@@ -40,6 +43,8 @@ public class SettingsMenuDialog extends BaseDialog{
     private Table prefs;
     private Table menu;
     private BaseDialog dataDialog;
+    private BaseDialog planetDataDialog;
+    private Planet planet = Planets.serpulo;
     private Seq<SettingsCategory> categories = new Seq<>();
 
     public SettingsMenuDialog(){
@@ -85,6 +90,83 @@ public class SettingsMenuDialog extends BaseDialog{
         prefs.clearChildren();
         prefs.add(menu);
 
+        planetDataDialog = new BaseDialog("@settings.data");
+        planetDataDialog.addCloseButton();
+
+        planetDataDialog.cont.table(Tex.button, t -> {
+            t.defaults().size(280f, 60f).left();
+            TextButtonStyle style = Styles.flatt;
+
+            t.button(bundle.format("settings.planetselect", "[#" + planet.iconColor + "]" + planet.localizedName), Icon.planet, style, () -> {
+                BaseDialog dialog = new BaseDialog("");
+                dialog.cont.pane(p -> {
+                    p.background(Tex.button).margin(1f);
+                    int i = 0;
+
+                    for(var plan : content.planets()){
+                        if(plan.generator == null || plan.sectors.size == 0 || !plan.accessible) continue;
+
+                        p.button(plan.localizedName, Styles.flatTogglet, () -> {
+                            planet = plan;
+                            dialog.hide();
+                        }).size(110f, 45f).checked(planet == plan);
+
+                        if(++i % 4 == 0){
+                            p.row();
+                        }
+                    }
+                });
+                dialog.setFillParent(false);
+                dialog.addCloseButton();
+                dialog.show();
+            }).marginLeft(4).get().getLabel().setText(() -> bundle.format("settings.planetselect", "[#" + planet.iconColor + "]" + planet.localizedName));
+
+            t.row();
+
+            t.button("@settings.clearplanetresearch", Icon.trash, style, () -> {
+                ui.showConfirm("@confirm", bundle.format("settings.clearplanetresearch.confirm", planet.localizedName), () -> {
+                    universe.clearLoadoutInfo();
+                    for(TechNode node : TechTree.all){
+                        if(node.planet == planet) node.reset();
+                    }
+                    content.each(c -> {
+                        if(c instanceof UnlockableContent u && u.databaseTabs.contains(planet)){
+                            u.clearUnlock();
+                        }
+                    });
+                    settings.remove("unlocks");
+                });
+            }).marginLeft(4);
+
+            t.row();
+
+            t.button("@settings.clearplanetcampaignsaves", Icon.trash, style, () -> {
+                ui.showConfirm("@confirm", bundle.format("settings.clearplanetcampaignsaves.confirm", planet.localizedName), () -> {
+                    planet.clearStats();
+                    boolean any = false;
+                    for(var sec : planet.sectors){
+                        sec.clearInfo();
+                        if(sec.save != null){
+                            any = true;
+                            sec.save.delete();
+                            sec.save = null;
+                        }
+                    }
+                    if(any){
+                        planet.reloadMeshAsync();
+                    }
+
+                    for(var slot : control.saves.getSaveSlots().copy()){
+                        if(slot.isSector() && slot.getSector().planet == planet){
+                            slot.delete();
+                        }
+                    }
+                });
+            }).marginLeft(4);
+
+            t.row();
+        });
+
         dataDialog = new BaseDialog("@settings.data");
         dataDialog.addCloseButton();
 
@@ -110,6 +192,8 @@ public class SettingsMenuDialog extends BaseDialog{
             })).marginLeft(4);
 
             t.row();
+
+            t.button("@settings.clearplanetdata", Icon.trash, style, () -> planetDataDialog.show()).marginLeft(4).row();
 
             t.button("@settings.clearsaves", Icon.trash, style, () -> {
                 ui.showConfirm("@confirm", "@settings.clearsaves.confirm", () -> {


### PR DESCRIPTION
### 1. Add data setting which allows clearing saves/research for only one planet, so that players don't need to clear  research or campaign saves from both planets if they want to only do so for only one planet.
resolves https://github.com/Anuken/Mindustry-Suggestions/issues/5194

<img width="363" height="245" alt="PLANETDATA" src="https://github.com/user-attachments/assets/58a4aeb0-e9cd-44dd-b835-3065071b47fb" />

### 2. Fixed #11977 

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
