### PR TITLE
planet requirement option for patches & a few new sorts

### DIFF
--- a/core/src/mindustry/entities/UnitSorts.java
+++ b/core/src/mindustry/entities/UnitSorts.java
@@ -11,7 +11,11 @@ public class UnitSorts{
     closest = Unit::dst2,
     farthest = (u, x, y) -> -u.dst2(x, y),
     strongest = (u, x, y) -> -u.maxHealth + Mathf.dst2(u.x, u.y, x, y) / 6400f,
-    weakest = (u, x, y) -> u.maxHealth + Mathf.dst2(u.x, u.y, x, y) / 6400f;
+    weakest = (u, x, y) -> u.maxHealth + Mathf.dst2(u.x, u.y, x, y) / 6400f,
+    mostArmor = (u, x, y) -> -u.armor + Mathf.dst2(u.x, u.y, x, y) / 6400f,
+    leastArmor = (u, x, y) -> u.armor + Mathf.dst2(u.x, u.y, x, y) / 6400f,
+    mostShield = (u, x, y) -> -u.shield + Mathf.dst2(u.x, u.y, x, y) / 6400f,
+    leastShield = (u, x, y) -> u.shield + Mathf.dst2(u.x, u.y, x, y) / 6400f;
 
     public static BuildingPriorityf
 

--- a/core/src/mindustry/mod/DataPatcher.java
+++ b/core/src/mindustry/mod/DataPatcher.java
@@ -87,10 +87,19 @@ public class DataPatcher{
 
         for(String patch : patchArray){
             PatchSet set = new PatchSet(patch, new JsonValue("error"));
-            patches.add(set);
 
             try{
                 JsonValue value = parser.getJson().fromJson(null, Jval.read(patch).toString(Jformat.plain));
+                if(Vars.state.rules.planet != null && value.has("requiredPlanets")){
+                    JsonValue req = value.get("requiredPlanets");
+                    value.remove("requiredPlanets");
+
+                    String[] planets = req.isArray() ? req.asStringArray() : new String[]{ req.asString() };
+                    if(!Structs.contains(planets, Vars.state.rules.planet.name)){
+                        continue;
+                    }
+                }
+
                 set.json = value;
                 currentlyApplying = set;
                 visitStack.clear();
@@ -109,6 +118,8 @@ public class DataPatcher{
 
                 Log.err("Failed to apply patch: " + patch, e);
             }
+
+            patches.add(set);
         }
 
         afterCallbacks.each(Runnable::run);

--- a/core/src/mindustry/mod/DataPatcher.java
+++ b/core/src/mindustry/mod/DataPatcher.java
@@ -94,9 +94,12 @@ public class DataPatcher{
                     JsonValue req = value.get("requiredPlanets");
                     value.remove("requiredPlanets");
 
-                    String[] planets = req.isArray() ? req.asStringArray() : new String[]{ req.asString() };
-                    if(!Structs.contains(planets, Vars.state.rules.planet.name)){
-                        continue;
+                    //this should be ignored unless this instance is a dedicated server
+                    if(Vars.headless){
+                        String[] planets = req.isArray() ? req.asStringArray() : new String[]{req.asString()};
+                        if(!Structs.contains(planets, Vars.state.rules.planet.name)){
+                            continue;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Adds an option for patches to only load on specified planets and a few new target sorts to be used when patching turrets

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
