### PR TITLE
Unloader dont die at low fps (performance friendly change)

### DIFF
--- a/core/src/mindustry/world/blocks/storage/Unloader.java
+++ b/core/src/mindustry/world/blocks/storage/Unloader.java
@@ -160,7 +160,6 @@ public class Unloader extends Block{
         public void updateTile(){
             if(((unloadTimer += delta()) < speed) || (possibleBlocks.size < 2)) return;
             Item item = null;
-            boolean any = false;
 
             if(sortItem != null){
                 if(isPossibleItem(sortItem)) item = sortItem;
@@ -192,39 +191,65 @@ public class Unloader extends Block{
                 }
 
                 possibleBlocks.sort(comparator);
+                unloadAccumulate(item);
+            }else{
+                unloadTimer = Math.min(unloadTimer, speed);
+            }
+        }
 
+        //allow dumping regardless of framerate. The expensive checks such as isPossibleItem() are still dependant on update()
+        public void unloadAccumulate(Item item){
+            if(item == null) return;
+
+            boolean any = false;
+            var pbi = possibleBlocks.items;
+            int pbs = possibleBlocks.size;
+
+            while(unloadTimer >= speed){
                 dumpingTo = null;
                 dumpingFrom = null;
 
                 //choose the building to accept the item
                 for(int i = 0; i < pbs; i++){
-                    if(pbi[i].canLoad){
-                        dumpingTo = pbi[i];
+                    var pb = pbi[i];
+                    if(pb.canLoad && pb.building.acceptItem(this, item)){
+                        dumpingTo = pb;
                         break;
                     }
                 }
 
                 //choose the building to take the item from
                 for(int i = pbs - 1; i >= 0; i--){
-                    if(pbi[i].canUnload){
-                        dumpingFrom = pbi[i];
+                    var pb = pbi[i];
+                    if(pb.canUnload && pb.building.canUnload() && pb.building.items != null && pb.building.items.has(item)){
+                        dumpingFrom = pb;
                         break;
                     }
                 }
 
+                if(dumpingFrom == null || dumpingTo == null) break;
+
+                var from = dumpingFrom.building;
+                var to = dumpingTo.building;
+
+                int fromMax = from.getMaximumAccepted(item);
+                int toMax = to.getMaximumAccepted(item);
+                dumpingFrom.loadFactor = fromMax == 0 || from.items == null ? 0f : from.items.get(item) / (float)fromMax;
+                dumpingTo.loadFactor = toMax == 0 || to.items == null ? 0f : to.items.get(item) / (float)toMax;
+
                 //trade the items
-                if(dumpingFrom != null && dumpingTo != null && (dumpingFrom.loadFactor != dumpingTo.loadFactor || !dumpingFrom.canLoad)){
-                    dumpingTo.building.handleItem(this, item);
-                    dumpingFrom.building.removeStack(item, 1);
-                    dumpingTo.lastUsed = 0;
-                    dumpingFrom.lastUsed = 0;
+                if(dumpingFrom.loadFactor != dumpingTo.loadFactor || !dumpingFrom.canLoad){
+                    to.handleItem(this, item);
+                    from.removeStack(item, 1);
+                    dumpingTo.lastUsed = dumpingFrom.lastUsed = 0;
+                    unloadTimer -= speed;
                     any = true;
+                }else{
+                    break;
                 }
             }
 
-            if(any){
-                unloadTimer %= speed;
-            }else{
+            if(!any){
                 unloadTimer = Math.min(unloadTimer, speed);
             }
         }


### PR DESCRIPTION
This approach allows unloaders to not be hard capped by fps while minimally creating lag by excluding the most expensive calls

**Why is it important?** Lategame lag with unloaders is not a matter of **if** but **when**. Whether liked it or not Serpulo revolves around unloaders, and there have been many complains around this limitation for years.

**Any downsides?** Unset unloaders now become "dumber" with low fps. This means just like before, they are limited by fps in how often they choose different item types; but unlike old their throughput is not. 60fps behavior is unchanged

Old unloader -> item type sorting & throughput affected by fps

New unloader -> only item type sorting affected by fps

<img width="769" height="96" alt="image" src="https://github.com/user-attachments/assets/4bf3e6ca-93c7-440a-a4aa-2456143eff35" />
<img width="287" height="132" alt="image" src="https://github.com/user-attachments/assets/57c2e63c-da43-471b-a9e8-31dcda725136" />
<img width="637" height="433" alt="image" src="https://github.com/user-attachments/assets/28386bd1-28b6-4025-b58c-d9edfeb52e81" />
<img width="1706" height="975" alt="image" src="https://github.com/user-attachments/assets/4866d73d-c152-45fa-ac67-cc28cb9b5e71" />


_Thanks to angels for the testing help_

### Before (1fps profiler active):

<img width="1246" height="390" alt="Captura de pantalla 2026-04-27 164323" src="https://github.com/user-attachments/assets/b7434dc5-78c6-44a1-b9b4-88a20ccdae1d" />

### Jvm monitor no profiler game set to 10fps:
<img width="742" height="443" alt="image" src="https://github.com/user-attachments/assets/24068f05-71c2-402a-9247-cb41fd9fe2a0" />

### After (1 fps profiler active):
<img width="1179" height="342" alt="image" src="https://github.com/user-attachments/assets/aeedfbb9-98c2-44c6-a6d7-aab6dfb49156" />

### Jvm monitor no profiler game set to 10fps:
<img width="735" height="432" alt="image" src="https://github.com/user-attachments/assets/c4a7afc6-1f40-4413-95dc-838780f62362" />

.

Setup for testing

<img width="1108" height="941" alt="image" src="https://github.com/user-attachments/assets/fb1b13e0-5cda-4dd5-91ec-94d916cacc9d" />


.

<img width="545" height="238" alt="image" src="https://github.com/user-attachments/assets/8257e463-9593-4d84-b0c7-9c19b29ec968" />

And a release
https://github.com/EggleEgg/Mindustry/releases/tag/423refter



If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
