### PR TITLE
Refuse duplicate labels

### DIFF
--- a/core/src/mindustry/logic/LParser.java
+++ b/core/src/mindustry/logic/LParser.java
@@ -118,7 +118,11 @@ public class LParser{
                 if(jumpLocations.size >= maxJumps){
                     error("Too many jump locations. Max jumps: " + maxJumps);
                 }
-                jumpLocations.put(tokens[0].substring(0, tokens[0].length() - 1), line);
+                String label = tokens[0].substring(0, tokens[0].length() - 1);
+                if(jumpLocations.containsKey(label)){
+                    error("Jump label already defined: \"" + label + "\".");
+                }
+                jumpLocations.put(label, line);
             }else{
                 boolean wasJump;
                 String jumpLoc = null;


### PR DESCRIPTION
The parser currently doesn't recognize duplicate labels in pasted mlog code, redirecting all jumps to such a label to the last occurrence of the label in the source code.

This PR adds a check to refuse code with duplicate labels. The first offending label is reported in the error message:

```
someLabel:
print "first"
someLabel:
print "second"
```

<img width="603" height="210" alt="image" src="https://github.com/user-attachments/assets/165c0538-eb25-45f2-bf5b-7b0152fe6534" />



If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
