### PR TITLE
Tiled display optimizations and fixes

### DIFF
--- a/core/src/mindustry/world/blocks/logic/TileableLogicDisplay.java
+++ b/core/src/mindustry/world/blocks/logic/TileableLogicDisplay.java
@@ -170,6 +170,7 @@ public class TileableLogicDisplay extends LogicDisplay{
             //don't even bother processing anything when displays are off.
             if(!Vars.renderer.drawDisplays) {
                 Draw.rect(backRegion, x, y);
+                Draw.rect(tileRegion[TileBitmask.values[bits]], x, y);
                 return;
             }
 

--- a/core/src/mindustry/world/blocks/logic/TileableLogicDisplay.java
+++ b/core/src/mindustry/world/blocks/logic/TileableLogicDisplay.java
@@ -82,10 +82,12 @@ public class TileableLogicDisplay extends LogicDisplay{
         }
 
         int tilesWidth = topX - botX + 1, tilesHeight = topY - botY + 1;
+        boolean rectangular = tilesWidth * tilesHeight == displays.size;
 
         //the new root display has been assigned
         for(var member : displays){
             member.needsUpdate = false;
+            member.rectangular = rectangular;
             member.rootDisplay = root;
             member.tilesWidth = tilesWidth;
             member.tilesHeight = tilesHeight;
@@ -124,7 +126,12 @@ public class TileableLogicDisplay extends LogicDisplay{
         public @Nullable Seq<MergeBuffer> prevBuffers;
 
         public int bits = 0;
-        public boolean needsUpdate = false;
+        public boolean needsUpdate = false, rectangular = false;
+        public long frameId = -1;
+
+        //some JVM may allocate a new instance of Runnable each time the lambda is constructed in the code
+        private final Runnable drawFull = this::drawFull;
+        private final Runnable drawTile = this::drawTile;
 
         @Override
         public double sense(LAccess sensor){
@@ -159,83 +166,94 @@ public class TileableLogicDisplay extends LogicDisplay{
         }
 
         @Override
-        public void getBufferRegion(TextureRegion region){
-            if(buffer != null){
-                region.set(buffer.getTexture(), 0, buffer.getTexture().height - frameSize*2, buffer.getTexture().width - frameSize*2, -(buffer.getTexture().height - frameSize*2));
-            }
-        }
-
-        @Override
         public void draw(){
-            //TODO if this is called before draw() on the root display is called, it will wipe it
-            if(needsUpdate){
-                needsUpdate = false;
-                linkDisplays(this);
+            //don't even bother processing anything when displays are off.
+            if(!Vars.renderer.drawDisplays) {
+                Draw.rect(backRegion, x, y);
+                return;
             }
 
-            Draw.rect(backRegion, x, y);
+            TileableLogicDisplayBuild root = (TileableLogicDisplayBuild)rootDisplay;
 
-            //don't even bother processing anything when displays are off.
-            if(!Vars.renderer.drawDisplays) return;
-
-            if(isRoot()){
+            if(root.buffer == null && tilesWidth <= maxDisplayDimensions && tilesHeight <= maxDisplayDimensions){
                 Draw.draw(Draw.z(), () -> {
-                    if(buffer == null && tilesWidth <= maxDisplayDimensions && tilesHeight <= maxDisplayDimensions){
-                        buffer = new FrameBuffer(32 * tilesWidth, 32 * tilesHeight);
+                    if(root.buffer == null){
+                        root.buffer = new FrameBuffer(32 * tilesWidth - 2 * frameSize, 32 * tilesHeight - 2 * frameSize);
 
                         Tmp.m1.set(Draw.proj());
                         Tmp.m2.set(Draw.trans());
-                        Draw.proj(0, 0, buffer.getWidth(), buffer.getHeight());
+                        Draw.proj(0, 0, root.buffer.getWidth(), root.buffer.getHeight());
 
                         //clear the buffer - some OSs leave garbage in it
-                        buffer.begin(Pal.darkerMetal);
-                        if(prevBuffers != null){
-                            for(var other : prevBuffers){
-                                Draw.rect(Draw.wrap(other.buffer.getTexture()), (other.x - originX) * 32 + other.buffer.getWidth()/2f, (other.y - originY) * 32 + other.buffer.getHeight()/2f, other.buffer.getWidth(), -other.buffer.getHeight());
+                        root.buffer.begin(Pal.darkerMetal);
+                        if(root.prevBuffers != null){
+                            for(var other : root.prevBuffers){
+                                Draw.rect(Draw.wrap(other.buffer.getTexture()), (other.x - originX) * 32 + other.buffer.getWidth() / 2f, (other.y - originY) * 32 + other.buffer.getHeight() / 2f, other.buffer.getWidth(), -other.buffer.getHeight());
                                 Draw.flush();
                             }
                         }
 
-                        buffer.end();
+                        root.buffer.end();
                         Draw.proj(Tmp.m1);
                         Draw.trans(Tmp.m2);
                         Draw.reset();
                     }
 
-                    if(prevBuffers != null){
-                        for(var other : prevBuffers){
+                    if(root.prevBuffers != null){
+                        for(var other : root.prevBuffers){
                             if(!other.buffer.isDisposed()){
                                 other.buffer.dispose();
                             }
                         }
-                        prevBuffers.clear();
+                        root.prevBuffers.clear();
                     }
                 });
             }
 
-            rootDisplay.processCommands();
+            root.processCommands();
 
-            float offset = 0.001f + (rootDisplay.buffer == null ? 0f : (rootDisplay.buffer.hashCode() % 1_000_000) / 1_000_000f * 0.01f);
+            float offset = 0.001f + (root.buffer == null ? 0f : (root.buffer.hashCode() % 1_000_000) / 1_000_000f * 0.01f);
 
             Draw.z(Layer.block + offset);
 
-            //TODO: for square regions, this can be optimized to draw only one thing
-            Draw.blend(Blending.disabled);
-            Draw.draw(Draw.z(), () -> {
-                if(rootDisplay.buffer != null){
-
-                    int rtx = (tile.x - originX), rty = (tile.y - originY);
-
-                    // Offset the region to account for display frame (6 pixels)
-                    Tmp.tr1.set(rootDisplay.buffer.getTexture(), rtx * 32 - frameSize, rty * 32 - frameSize, 32, 32);
-                    Draw.rect(Tmp.tr1, x, y, tilesize, -tilesize);
+            if(rectangular && root.buffer != null){
+                //the first tile to be processed in this frame draws the entire buffer at once
+                if(root.frameId != Core.graphics.getFrameId()){
+                    root.frameId = Core.graphics.getFrameId();
+                    Draw.blend(Blending.disabled);
+                    Draw.draw(Draw.z(), drawFull);
+                    Draw.blend();
                 }
-            });
-            Draw.blend();
+            }else{
+                Draw.blend(Blending.disabled);
+                Draw.draw(Draw.z(), drawTile);
+                Draw.blend();
+            }
 
-            Draw.z(Layer.block + 0.02f);
+            if(bits != 255){
+                Draw.z(Layer.block + 0.02f);
+                Draw.rect(tileRegion[TileBitmask.values[bits]], x, y);
+            }
+        }
 
-            Draw.rect(tileRegion[TileBitmask.values[bits]], x, y);
+        private void drawFull() {
+            if(rootDisplay.buffer != null){
+                float cx = x + tilesize * (tilesWidth - 1 - 2 * (tile.x - originX)) / 2f, cy = y + tilesize * (tilesHeight - 1 - 2 * (tile.y - originY)) / 2f;
+                Draw.rect(Draw.wrap(rootDisplay.buffer.getTexture()), cx, cy,
+                rootDisplay.buffer.getWidth() * scaleFactor * Draw.scl, -rootDisplay.buffer.getHeight() * scaleFactor * Draw.scl);
+            }
+        }
+
+        private void drawTile() {
+            if(rootDisplay.buffer != null){
+                int rtx = (tile.x - originX), rty = (tile.y - originY);
+
+                // Offset the region to account for the display frame (6 pixels)
+                Tmp.tr1.set(rootDisplay.buffer.getTexture(), rtx * 32 - frameSize, rty * 32 - frameSize, 32, 32);
+                Draw.rect(Tmp.tr1, x, y, tilesize, -tilesize);
+            }else{
+                Draw.rect(backRegion, x, y);
+            }
         }
 
         @Override
@@ -253,6 +271,13 @@ public class TileableLogicDisplay extends LogicDisplay{
                 if(other != null && other.block() == block && other.team() == team){
                     other.build.onProximityUpdate();
                 }
+            }
+        }
+
+        public void updateTile() {
+            if(needsUpdate){
+                needsUpdate = false;
+                linkDisplays(this);
             }
         }
 


### PR DESCRIPTION
PR implementing some optimization and small bug fixes related to tiled displays. These changes were made:

* The call to the `linkDisplays()` method has been moved from `draw()` to`updateTile()`. This decouples the display reconfiguration from drawing and ensures the reconfiguration is finished by the time the `draw()` method on any of the display's tiles is called, which is important for the rectangular draw optimization. It also fixes a bug where the reconfiguration doesn't happen when the root tile is off-screen, and ensures the content of the old buffer is never lost when reconfiguring.
* When the shape of the tiled display is rectangular, the content is drawn in a single drawing operation instead of being drawn tile-by-tile. The drawing is performed when the first tile of the merged display is being drawn (it can't be done from the root tile, because the display wouldn't get drawn when the root tile is off-screen). To detect the display has been already drawn in the current frame, the `frameId` counter is used.
* The `backRegion` texture is not drawn unless necessary (either when the displays are turned off in the settings, or when the merged display size exceeds the 16x16 limit).
* The frame texture is not drawn for interior tiles, which do not contain any frame.
* The lambdas embedded within `Draw.draw()` calls in the code have been refactored into methods, and their references are stored in class members. This addresses the problem that - on at least some JVMs - a new `Runnable` instance was created each time the lambda was used in `Draw.draw()`, meaning _lots_ of allocations were made. At high FPS with many tiled displays on the screen, the allocations were easily in the range of a megabyte per second or more (as seen on the memory usage displayed in-game).

**Results**

The PR has been tested on several platforms, on a map containing 25 16x16 displays, all shown on the screen at once. (Determining the difference for a single 16x16 display just by looking at the FPS displayed on screen is not very reliable due to inherent instability of the FPS rate) On several platforms, the speedup has been significant (comparing current BE to this PR): 

* from ~650 to ~1700 FPS (GeForce RTX 3060)
* from ~130 to ~560 FPS (tested by another user, I don't have the specs)
* from ~52 to ~70 FPS on an Android phone

I also have an old PC with a simple graphics adapter, and there the FPS was about 12 for both versions. I haven't encountered a platform where the new version would perform worse.

When a tile is removed from each display, making them non-rectangular and therefore rendering the main optimization ineffective, there's still a benefit from the remaining optimizations. On my main system, the FPS increased from ~650 to ~1300 (again, comparing current BE to this PR).

**Additional notes**

* I also tried to optimize drawing the display frame of rectangular displays by pre-drawing it in a `FrameBuffer` instance and drawing the frame for the entire merged display in one operation. Turns out this never actually performed better when tested several systems. My guess is that drawing textures is simply much faster than drawing a frame buffer. Perhaps textures could be made for each possible frame length and the frame for the entire display could be draw using just four texture operations, but I don't think it is even worth trying.
* When a tiled display is split into two or more separate parts, the contents of the parts not connected to the original root tile is lost. This is not a new behavior, but it probably could be somehow fixed by updating the `linkDisplays` method. Is it worth trying to implement this? Currently, the content of displays is fully preserved only when merging separate displays into one, but not when splitting.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
