### PR TITLE
Allow replacing assemblers (even if the area overlaps)

### DIFF
--- a/core/src/mindustry/world/blocks/units/UnitAssembler.java
+++ b/core/src/mindustry/world/blocks/units/UnitAssembler.java
@@ -96,11 +96,11 @@ public class UnitAssembler extends PayloadBlock{
 
     @Override
     public boolean canPlaceOn(Tile tile, Team team, int rotation){
-        //overlapping construction areas not allowed; grow by a tiny amount so edges can't overlap either.
+        //overlapping construction areas not allowed unless it s being replaced; grow by a tiny amount so edges can't overlap either.
         Rect rect = getRect(Tmp.r1, tile.worldx() + offset, tile.worldy() + offset, rotation).grow(0.1f);
         return
-            !indexer.getFlagged(team, BlockFlag.unitAssembler).contains(b -> b.block instanceof UnitAssembler assembler && assembler.getRect(Tmp.r2, b.x, b.y, b.rotation).overlaps(rect)) &&
-            !team.data().getBuildings(ConstructBlock.get(size)).contains(b -> ((ConstructBuild)b).current instanceof UnitAssembler assembler && assembler.getRect(Tmp.r2, b.x, b.y, b.rotation).overlaps(rect));
+            !indexer.getFlagged(team, BlockFlag.unitAssembler).contains(b -> b != tile.build && b.block instanceof UnitAssembler assembler && assembler.getRect(Tmp.r2, b.x, b.y, b.rotation).overlaps(rect)) &&
+            !team.data().getBuildings(ConstructBlock.get(size)).contains(b -> b != tile.build && ((ConstructBuild)b).current instanceof UnitAssembler assembler && assembler.getRect(Tmp.r2, b.x, b.y, b.rotation).overlaps(rect));
     }
 
     @Override


### PR DESCRIPTION
### New:
<img width="575" height="532" alt="image" src="https://github.com/user-attachments/assets/fccc4981-6e2f-4476-a47a-16cc9a5e07c4" />

### Old:
<img width="516" height="484" alt="image" src="https://github.com/user-attachments/assets/d1a9d6d1-1764-42f9-b2c4-fcd3b4600a19" />

.

Does not allow bypassing the area with other blocks as far as I know
<img width="951" height="729" alt="image" src="https://github.com/user-attachments/assets/6699102b-3f72-482b-9d16-78477191ec08" />



If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
