### PR TITLE
add save io for Ability, WeaponMount, Team and StatusEntry

### DIFF
--- a/core/src/mindustry/entities/abilities/Ability.java
+++ b/core/src/mindustry/entities/abilities/Ability.java
@@ -2,6 +2,7 @@ package mindustry.entities.abilities;
 
 import arc.*;
 import arc.scene.ui.layout.*;
+import arc.util.io.*;
 import mindustry.gen.*;
 import mindustry.type.*;
 import mindustry.ui.*;
@@ -24,6 +25,10 @@ public abstract class Ability implements Cloneable{
     public void init(UnitType type){}
 
     public void displayBars(Unit unit, Table bars){}
+
+    public void read(Reads read){}
+
+    public void write(Writes write){}
 
     public void display(Table t){
         t.table(Styles.grayPanel, a -> {

--- a/core/src/mindustry/entities/comp/StatusComp.java
+++ b/core/src/mindustry/entities/comp/StatusComp.java
@@ -60,7 +60,7 @@ abstract class StatusComp implements Posc{
 
         if(!effect.reactive){
             //otherwise, no opposites found, add direct effect
-            StatusEntry entry = Pools.obtain(StatusEntry.class, StatusEntry::new);
+            StatusEntry entry = effect.entryType.get();
             entry.damageTime = 0f;
             entry.set(effect, duration);
             applied.set(effect.id);

--- a/core/src/mindustry/entities/units/StatusEntry.java
+++ b/core/src/mindustry/entities/units/StatusEntry.java
@@ -1,5 +1,6 @@
 package mindustry.entities.units;
 
+import arc.util.io.*;
 import mindustry.type.*;
 
 public class StatusEntry{
@@ -16,4 +17,8 @@ public class StatusEntry{
         this.time = time;
         return this;
     }
+
+    public void read(Reads read){}
+
+    public void write(Writes write){}
 }

--- a/core/src/mindustry/entities/units/WeaponMount.java
+++ b/core/src/mindustry/entities/units/WeaponMount.java
@@ -1,6 +1,7 @@
 package mindustry.entities.units;
 
 import arc.util.*;
+import arc.util.io.*;
 import mindustry.audio.*;
 import mindustry.gen.*;
 import mindustry.type.*;
@@ -56,5 +57,13 @@ public class WeaponMount{
     public WeaponMount(Weapon weapon){
         this.weapon = weapon;
         this.rotation = weapon.baseRotation;
+    }
+
+    public void read(Reads read){
+
+    }
+
+    public void write(Writes write){
+
     }
 }

--- a/core/src/mindustry/game/Team.java
+++ b/core/src/mindustry/game/Team.java
@@ -5,6 +5,7 @@ import arc.graphics.*;
 import arc.math.*;
 import arc.struct.*;
 import arc.util.*;
+import arc.util.io.*;
 import mindustry.game.Rules.*;
 import mindustry.game.Teams.*;
 import mindustry.graphics.*;
@@ -155,6 +156,10 @@ public class Team implements Comparable<Team>, Senseable{
         }
         hasPalette = true;
     }
+
+    public void read(Reads read){}
+
+    public void write(Writes write){}
 
     @Override
     public int compareTo(Team team){

--- a/core/src/mindustry/io/TypeIO.java
+++ b/core/src/mindustry/io/TypeIO.java
@@ -282,6 +282,7 @@ public class TypeIO{
             writes.b((m.shoot ? 1 : 0) | (m.rotate ? 2 : 0));
             writes.f(m.aimX);
             writes.f(m.aimY);
+            m.write(writes);
         }
     }
 
@@ -297,6 +298,7 @@ public class TypeIO{
                 m.aimY = ay;
                 m.shoot = (state & 1) != 0;
                 m.rotate = (state & 2) != 0;
+                m.read(read);
             }
         }
 
@@ -317,7 +319,9 @@ public class TypeIO{
         for(int i = 0; i < len; i++){
             float data = read.f();
             if(abilities.length > i){
-                abilities[i].data = data;
+                Ability a = abilities[i];
+                a.data = data;
+                a.read(read);
             }
         }
         return abilities;
@@ -327,6 +331,7 @@ public class TypeIO{
         write.b(abilities.length);
         for(var a : abilities){
             write.f(a.data);
+            a.write(write);
         }
     }
 
@@ -932,6 +937,8 @@ public class TypeIO{
             if(entry.dragMultiplier != 1f) write.f(entry.dragMultiplier);
             if(entry.armorOverride >= 0f) write.f(entry.armorOverride);
         }
+
+        entry.write(write);
     }
 
     public static StatusEntry readStatus(Reads read){
@@ -952,6 +959,8 @@ public class TypeIO{
             if((flags & (1 << 5)) != 0) result.dragMultiplier = read.f();
             if((flags & (1 << 6)) != 0) result.armorOverride = read.f();
         }
+
+        result.read(read);
 
         return result;
     }
@@ -1003,11 +1012,15 @@ public class TypeIO{
     }
 
     public static void writeTeam(Writes write, Team team){
-        write.b(team == null ? 0 : team.id);
+        Team t = team == null ? Team.derelict : team;
+        write.b(t.id);
+        t.write(write);
     }
 
     public static Team readTeam(Reads read){
-        return Team.get(read.b());
+        Team t = Team.get(read.b());
+        t.read(read);
+        return t;
     }
 
     public static void writeAction(Writes write, AdminAction reason){

--- a/core/src/mindustry/type/StatusEffect.java
+++ b/core/src/mindustry/type/StatusEffect.java
@@ -1,5 +1,6 @@
 package mindustry.type;
 
+import arc.func.*;
 import arc.graphics.*;
 import arc.math.*;
 import arc.struct.*;
@@ -67,6 +68,8 @@ public class StatusEffect extends UnlockableContent{
     public ObjectSet<StatusEffect> affinities = new ObjectSet<>(), opposites = new ObjectSet<>();
     /** Set to false to disable outline generation. */
     public boolean outline = true;
+    /** Type of status entry to be used. */
+    public Prov<StatusEntry> entryType = StatusEntry::new;
     /** Transition handler map. */
     protected ObjectMap<StatusEffect, TransitionHandler> transitions = new ObjectMap<>();
     /** Called on init. */


### PR DESCRIPTION
this just adds read()/write() methods for Ability, WeaponMount, Team and StatusEntry

(note: check the implementation for StatusEffect and StatusEntry which might have some unintended side consequences)

the current implementation shouldn't disrupt existing saves as the methods are empty, mostly just for mods to utilize

> why Team?
no idea


If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
