### PR TITLE
Fixed the issue where pop-ups left after logging out of the server could not be closed.

### DIFF
--- a/core/src/mindustry/core/UI.java
+++ b/core/src/mindustry/core/UI.java
@@ -717,7 +717,12 @@ public class UI implements ApplicationListener, Loadable{
     /** Shows a menu that hides when another followUp-menu is shown or when nothing is selected.
      * @see UI#showMenu(String, String, String[][], Intc) */
     public void showFollowUpMenu(int menuId, String title, String message, String[][] options, Intc callback) {
-        Dialog dialog = newMenuDialog(title, message, options, (option, myself) -> callback.get(option));
+        Dialog dialog = newMenuDialog(title, message, options, (option, myself) -> {
+            callback.get(option);
+            if (!state.isGame()){
+                myself.hide();
+            }
+        });
         dialog.closeOnBack(() -> {
             followUpMenus.remove(menuId);
             callback.get(-1);

--- a/core/src/mindustry/core/UI.java
+++ b/core/src/mindustry/core/UI.java
@@ -719,7 +719,7 @@ public class UI implements ApplicationListener, Loadable{
     public void showFollowUpMenu(int menuId, String title, String message, String[][] options, Intc callback) {
         Dialog dialog = newMenuDialog(title, message, options, (option, myself) -> {
             callback.get(option);
-            if (!state.isGame()){
+            if(!state.isGame()){
                 myself.hide();
             }
         });


### PR DESCRIPTION
…uld not be closed.

### Android-specific issue

When the client unexpectedly disconnects from the server (e.g., due to connection loss), leftover pop-ups stay on the screen and cannot be dismissed. These pop-ups block the interface, making the game unplayable until it is force-closed and relaunched.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
