### PR TITLE
Bugfix: Held items turn into ghost copper when respawning

### DIFF
--- a/core/src/mindustry/input/DesktopInput.java
+++ b/core/src/mindustry/input/DesktopInput.java
@@ -435,6 +435,7 @@ public class DesktopInput extends InputHandler{
             if(Core.input.keyTap(Binding.respawn)){
                 controlledType = null;
                 recentRespawnTimer = 1f;
+                droppingItem = false;
                 Call.unitClear(player);
             }
         }

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -864,6 +864,7 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         Fx.spawn.at(player);
         player.clearUnit();
         player.checkSpawn();
+        droppingItem = false;
         player.deathTimer = Player.deathDelay + 1f; //for instant respawn
     }
 

--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -864,7 +864,6 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
         Fx.spawn.at(player);
         player.clearUnit();
         player.checkSpawn();
-        droppingItem = false;
         player.deathTimer = Player.deathDelay + 1f; //for instant respawn
     }
 

--- a/core/src/mindustry/ui/fragments/HudFragment.java
+++ b/core/src/mindustry/ui/fragments/HudFragment.java
@@ -1009,6 +1009,7 @@ public class HudFragment{
                     Call.unitClear(player);
                     control.input.recentRespawnTimer = 1f;
                     control.input.controlledType = null;
+                    control.input.droppingItem = false;
                 }
             });
 


### PR DESCRIPTION
Simple bugfix for setting the droppingItem flag correctly when respawning to avoid ghost copper.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [✔️] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [✔️ ] I have ensured that my code compiles, if applicable.
- [✔️] I have ensured that any new features in this PR function correctly in-game, if applicable.
