### PR TITLE
Erekir nano-rebalance: small heat redirector buff

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -1503,7 +1503,7 @@ public class Blocks{
         }};
 
         smallHeatRedirector = new HeatConductor("small-heat-redirector"){{
-            requirements(Category.crafting, with(Items.surgeAlloy, 8, Items.graphite, 8));
+            requirements(Category.crafting, with(Items.surgeAlloy, 3, Items.graphite, 8));
 
             researchCostMultiplier = 2f;
             researchCostMultipliers.put(Items.graphite, 7f);

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -1503,12 +1503,10 @@ public class Blocks{
         }};
 
         smallHeatRedirector = new HeatConductor("small-heat-redirector"){{
-            requirements(Category.crafting, with(Items.surgeAlloy, 8, Items.graphite, 8, Items.tungsten, 6));
+            requirements(Category.crafting, with(Items.surgeAlloy, 3, Items.graphite, 8));
 
             researchCostMultiplier = 2f;
             researchCostMultipliers.put(Items.graphite, 7f);
-            hasPower = true;
-            consumesPower = outputsPower = false;
 
             group = BlockGroup.heat;
             size = 2;

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -1503,10 +1503,12 @@ public class Blocks{
         }};
 
         smallHeatRedirector = new HeatConductor("small-heat-redirector"){{
-            requirements(Category.crafting, with(Items.surgeAlloy, 3, Items.graphite, 8));
+            requirements(Category.crafting, with(Items.surgeAlloy, 8, Items.graphite, 8, Items.tungsten, 6));
 
             researchCostMultiplier = 2f;
             researchCostMultipliers.put(Items.graphite, 7f);
+            hasPower = true;
+            consumesPower = outputsPower = false;
 
             group = BlockGroup.heat;
             size = 2;


### PR DESCRIPTION
Even in circumstances where space matters that much is still is incredibly niche, and specially in campaign. It s few applications are limited (malign phase, neoplasia) thus it s fine to buff it; as it cannot beat the cost and tech convenience of the 3x3 redirector in many scenarios (oxide heat surge/carbide, slag heat, etc).
- Surge cost 8 -> 3

<img width="866" height="143" alt="image" src="https://github.com/user-attachments/assets/0061110c-12ec-4c52-9b02-63b6eaffb48b" />
<img width="736" height="86" alt="image" src="https://github.com/user-attachments/assets/789ea8a6-ae07-4b06-9194-07bd28f7f144" />

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
