### PR TITLE
Fix wrong allowed size displayed in an error message

### DIFF
--- a/core/src/mindustry/world/blocks/logic/LogicBlock.java
+++ b/core/src/mindustry/world/blocks/logic/LogicBlock.java
@@ -729,7 +729,7 @@ public class LogicBlock extends Block{
                 if(forceEditor) state.rules.editor = true;
                 byte[] bytes = compress(code, relativeConnections());
                 if(bytes.length > maxCompressedLen){
-                    ui.showErrorMessage(Core.bundle.format("logic.error.toolong", maxByteLen, bytes.length));
+                    ui.showErrorMessage(Core.bundle.format("logic.error.toolong", maxCompressedLen, bytes.length));
                 }else{
                     configure(bytes);
                     state.rules.editor = prev;


### PR DESCRIPTION
Fixes a tiny bug: when exceeding the compressed code size limit, a wrong value for the limit was displayed in the error message.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
