### PR TITLE
Add dedicated steam server support

### DIFF
--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -321,7 +321,7 @@ public class NetClient implements ApplicationListener{
 
     @Remote(called = Loc.client, variants = Variant.one)
     public static void connect(String ip, int port){
-        if(!steam && ip.startsWith("steam:")) return;
+        if(!steam && (ip.startsWith("steam:") || ip.startsWith("steamserver:"))) return;
         netClient.disconnectQuietly();
         logic.reset();
 

--- a/desktop/src/mindustry/desktop/steam/SNet.java
+++ b/desktop/src/mindustry/desktop/steam/SNet.java
@@ -133,6 +133,32 @@ public class SNet implements SteamNetworkingCallback, SteamMatchmakingCallback, 
             }catch(NumberFormatException e){
                 throw new IOException("Invalid Steam ID: " + lobbyname);
             }
+        }else if (ip.startsWith("steamserver:")){
+            String server = ip.substring("steamserver:".length());
+            try{
+                SteamID serverID = SteamID.createFromNativeHandle(Long.parseLong(server));
+                if(!serverID.isValid()) throw new IOException("Invalid Steam ID structure: " + server);
+
+                // Prepare for connection
+                logic.reset();
+                net.reset();
+                currentLobby = null;
+                currentServer = serverID;
+
+                // Run success
+                if(success != null) success.run();
+
+                // Connect
+                Connect con = new Connect();
+                con.addressTCP = "steam:" + currentServer.getAccountID();
+
+                net.setClientConnected();
+                net.handleClientReceived(con);
+
+                Log.info("Initiated direct Steam P2P connection to server: @", currentServer.getAccountID());
+            }catch(NumberFormatException e){
+                throw new IOException("Failed to parse server Steam ID: " + server);
+            }
         }else{
             provider.connectClient(ip, port, success);
         }
@@ -165,13 +191,11 @@ public class SNet implements SteamNetworkingCallback, SteamMatchmakingCallback, 
     @Override
     public void disconnectClient(){
         if(isSteamClient()){
-            if(currentLobby != null){
-                smat.leaveLobby(currentLobby);
-                snet.closeP2PSessionWithUser(currentServer);
-                currentServer = null;
-                currentLobby = null;
-                net.handleClientReceived(new Disconnect());
-            }
+            if(currentLobby != null) smat.leaveLobby(currentLobby);
+            snet.closeP2PSessionWithUser(currentServer);
+            currentServer = null;
+            currentLobby = null;
+            net.handleClientReceived(new Disconnect());
         }else{
             provider.disconnectClient();
         }
@@ -406,6 +430,13 @@ public class SNet implements SteamNetworkingCallback, SteamMatchmakingCallback, 
         }else if(steamIDRemote.equals(currentServer)){
             Log.info("Disconnected! @: @", steamIDRemote.getAccountID(), sessionError);
             net.handleClientReceived(new Disconnect());
+
+            Core.app.post(() -> {
+                ui.loadfrag.hide();
+                ui.showErrorMessage(Core.bundle.format("cantconnect", sessionError.name()));
+                net.handleClientReceived(new Disconnect());
+                currentServer = null;
+            });
         }
     }
 

--- a/desktop/src/mindustry/desktop/steam/SNet.java
+++ b/desktop/src/mindustry/desktop/steam/SNet.java
@@ -139,23 +139,23 @@ public class SNet implements SteamNetworkingCallback, SteamMatchmakingCallback, 
                 SteamID serverID = SteamID.createFromNativeHandle(Long.parseLong(server));
                 if(!serverID.isValid()) throw new IOException("Invalid Steam ID structure: " + server);
 
-                // Prepare for connection
-                logic.reset();
-                net.reset();
-                currentLobby = null;
-                currentServer = serverID;
+                Core.app.post(() -> {
+                    currentLobby = null;
+                    currentServer = serverID;
 
-                // Run success
-                if(success != null) success.run();
+                    // Run success
+                    if(success != null) success.run();
 
-                // Connect
-                Connect con = new Connect();
-                con.addressTCP = "steam:" + currentServer.getAccountID();
+                    // Connect
+                    Connect con = new Connect();
+                    con.addressTCP = "steam:" + currentServer.getAccountID();
 
-                net.setClientConnected();
-                net.handleClientReceived(con);
+                    net.setClientConnected();
+                    net.handleClientReceived(con);
+                    Core.app.post(() -> ui.loadfrag.show("@connecting")); // TODO: This gets hidden and I can't figure out how to not do so.
 
-                Log.info("Initiated direct Steam P2P connection to server: @", currentServer.getAccountID());
+                    Log.info("Initiated direct Steam P2P connection to server: @", currentServer.getAccountID());
+                });
             }catch(NumberFormatException e){
                 throw new IOException("Failed to parse server Steam ID: " + server);
             }

--- a/desktop/src/mindustry/desktop/steam/SNet.java
+++ b/desktop/src/mindustry/desktop/steam/SNet.java
@@ -152,7 +152,13 @@ public class SNet implements SteamNetworkingCallback, SteamMatchmakingCallback, 
 
                     net.setClientConnected();
                     net.handleClientReceived(con);
-                    Core.app.post(() -> ui.loadfrag.show("@connecting")); // TODO: This gets hidden and I can't figure out how to not do so.
+                    Core.app.post(() -> {  // TODO: This gets hidden and I can't figure out how to not do so.
+                        ui.loadfrag.show("@connecting");
+                        ui.loadfrag.setButton(() -> {
+                            ui.loadfrag.hide();
+                            netClient.disconnectQuietly();
+                        });
+                    });
 
                     Log.info("Initiated direct Steam P2P connection to server: @", currentServer.getAccountID());
                 });


### PR DESCRIPTION
Allows servers to connect players to dedicated steam servers using `steamserver:<serverID>` format. Similar to the existing lobbies  except that these can be hosted without a steam client instance (which requires a GUI and isn't practical on servers) and without an account that owns a copy of the game. The primary use of this (as per usual with my steam PRs) is standalone steam "verification" servers that tie a UUID to a steam ID.


- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
