### PR TITLE
Re-order tech tree to remove unnecessary prerequisites

### DIFF
--- a/core/src/mindustry/content/SerpuloTechTree.java
+++ b/core/src/mindustry/content/SerpuloTechTree.java
@@ -41,8 +41,8 @@ public class SerpuloTechTree{
 
                         node(itemBridge, () -> {
                             node(titaniumConveyor, Seq.with(new SectorComplete(crateredBattleground)), () -> {
-                                node(phaseConveyor, () -> {
-                                    node(massDriver, Seq.with(new SectorComplete(tarFields)), () -> {
+                                node(massDriver, Seq.with(new SectorComplete(tarFields)), () -> {
+                                    node(phaseConveyor, () -> {
 
                                     });
                                 });
@@ -53,8 +53,8 @@ public class SerpuloTechTree{
                                     });
                                 });
 
-                                node(armoredConveyor, () -> {
-                                    node(plastaniumConveyor, () -> {
+                                node(plastaniumConveyor, () -> {
+                                    node(armoredConveyor, () -> {
 
                                     });
                                 });


### PR DESCRIPTION
- Mass driver requires phase fabric to research, but it doesn't use phase fabric. This makes it impossible to use mass drivers in Tar Fields, where they would be pretty useful, for no good reason.
- Plastanium conveyor requires thorium to research, but it doesn't use thorium. This makes it impossible to use plastanium conveyors for several sectors before you get thorium.

This can be easily fixed by swapping these nodes with their parents. Phase conveyor requires thorium anyway, and armored conveyor requires plastanium anyway.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
