### PR TITLE
faster core proximity updates

### DIFF
--- a/core/src/mindustry/core/Logic.java
+++ b/core/src/mindustry/core/Logic.java
@@ -282,7 +282,7 @@ public class Logic implements ApplicationListener{
 
                     for(ItemStack stack : state.rules.loadout){
                         //make sure to cap storage
-                        entity.items.add(stack.item, Math.min(stack.amount, entity.storageCapacity - entity.items.get(stack.item)));
+                        entity.items.add(stack.item, Math.min(stack.amount, entity.capacity() - entity.items.get(stack.item)));
                     }
                 }
             }

--- a/core/src/mindustry/core/World.java
+++ b/core/src/mindustry/core/World.java
@@ -212,7 +212,7 @@ public class World{
 
     /**
      * Call to signify the end of map loading. Updates tile proximities and sets up physics for the world.
-     * A WorldLoadEvent will be fire.
+     * A WorldLoadEvent will be fired.
      */
     public void endMapLoad(){
         Events.fire(new WorldLoadEndEvent());

--- a/core/src/mindustry/editor/MapEditorDialog.java
+++ b/core/src/mindustry/editor/MapEditorDialog.java
@@ -328,8 +328,15 @@ public class MapEditorDialog extends Dialog implements Disposable{
         ui.loadAnd(() -> {
             lastSavedRules = state.rules;
             hide();
+
+            Teams data = new Teams();
+            //keep the old itemCap for each team, otherwise it breaks
+            state.teams.active.each(t ->
+                data.get(t.team).itemCap = t.itemCap
+            );
+            state.teams = data;
+
             //only reset the player; logic.reset() will clear entities, which we do not want
-            state.teams = new Teams();
             player.reset();
             state.rules = Gamemode.editor.apply(lastSavedRules.copy());
             state.rules.limitMapArea = false;

--- a/core/src/mindustry/game/SectorInfo.java
+++ b/core/src/mindustry/game/SectorInfo.java
@@ -191,7 +191,7 @@ public class SectorInfo{
             entity.items.clear();
             entity.items.add(items);
             //ensure capacity.
-            entity.items.each((i, a) -> entity.items.set(i, Mathf.clamp(a, 0, entity.storageCapacity)));
+            entity.items.each((i, a) -> entity.items.set(i, Mathf.clamp(a, 0, entity.capacity())));
         }
     }
 
@@ -221,7 +221,7 @@ public class SectorInfo{
         attack = state.rules.attackMode;
         hasCore = entity != null;
         bestCoreType = !hasCore ? Blocks.air : state.rules.defaultTeam.cores().max(e -> e.block.size).block;
-        storageCapacity = entity != null ? entity.storageCapacity : 0;
+        storageCapacity = entity != null ? entity.capacity() : 0;
         hasSpawns = spawner.countSpawns() > 0;
         lastPresetName = sector.preset == null ? null : sector.preset.name;
         lastWidth = world.width();

--- a/core/src/mindustry/game/Teams.java
+++ b/core/src/mindustry/game/Teams.java
@@ -15,7 +15,7 @@ import mindustry.type.*;
 import mindustry.world.*;
 import mindustry.world.blocks.payloads.*;
 import mindustry.world.blocks.storage.CoreBlock.*;
-import mindustry.world.modules.ItemModule;
+import mindustry.world.modules.*;
 
 import java.util.*;
 
@@ -311,8 +311,8 @@ public class Teams{
         public Seq<Player> players = new Seq<>(false);
         /** All buildings. Updated on team change / building addition or removal. Includes even buildings that do not update(). */
         public Seq<Building> buildings = new Seq<>(false);
-        /** The item module for cores of this team. */
-        public ItemModule items = new ItemModule();
+        /** The item module for cores of this team. Null if no core was loaded. */
+        public @Nullable ItemModule items;
         /** Units of this team by type. Updated each frame. */
         public @Nullable Seq<Unit>[] unitsByType;
 

--- a/core/src/mindustry/game/Teams.java
+++ b/core/src/mindustry/game/Teams.java
@@ -15,6 +15,7 @@ import mindustry.type.*;
 import mindustry.world.*;
 import mindustry.world.blocks.payloads.*;
 import mindustry.world.blocks.storage.CoreBlock.*;
+import mindustry.world.modules.ItemModule;
 
 import java.util.*;
 
@@ -298,6 +299,8 @@ public class Teams{
         public int unitCap;
         /** Total unit count. */
         public int unitCount;
+        /** Current item cap. */
+        public int itemCap;
         /** Counts for each type of unit. Do not access directly. */
         public @Nullable int[] typeCounts;
         /** Cached buildings by type. */
@@ -308,6 +311,8 @@ public class Teams{
         public Seq<Player> players = new Seq<>(false);
         /** All buildings. Updated on team change / building addition or removal. Includes even buildings that do not update(). */
         public Seq<Building> buildings = new Seq<>(false);
+        /** The item module for cores of this team. */
+        public ItemModule items = new ItemModule();
         /** Units of this team by type. Updated each frame. */
         public @Nullable Seq<Unit>[] unitsByType;
 

--- a/core/src/mindustry/type/Sector.java
+++ b/core/src/mindustry/type/Sector.java
@@ -221,7 +221,7 @@ public class Sector{
         if(isBeingPlayed()){
             if(state.rules.defaultTeam.core() != null){
                 ItemModule storage = state.rules.defaultTeam.items();
-                int cap = state.rules.defaultTeam.core().storageCapacity;
+                int cap = state.rules.defaultTeam.data().itemCap;
                 items.each((item, amount) -> storage.add(item, Math.min(cap - storage.get(item), amount)));
             }
         }else if(hasBase()){

--- a/core/src/mindustry/ui/fragments/HintsFragment.java
+++ b/core/src/mindustry/ui/fragments/HintsFragment.java
@@ -298,7 +298,7 @@ public class HintsFragment{
         ),
 
         coreIncinerate(
-            () -> state.isCampaign() && state.rules.defaultTeam.core() != null && state.rules.defaultTeam.core().items.get(Items.copper) >= state.rules.defaultTeam.core().storageCapacity - 10,
+            () -> state.isCampaign() && state.rules.defaultTeam.core() != null && state.rules.defaultTeam.core().items.get(Items.copper) >= state.rules.defaultTeam.data().itemCap - 10,
             () -> false
         )
         ;

--- a/core/src/mindustry/world/blocks/ConstructBlock.java
+++ b/core/src/mindustry/world/blocks/ConstructBlock.java
@@ -366,7 +366,7 @@ public class ConstructBlock extends Block{
 
                 if(clampedAmount > 0 && accumulated > 0){ //if it's positive, add it to the core
                     if(core != null && requirements[i].item.unlockedNowHost()){ //only accept items that are unlocked
-                        int accepting = Math.min(accumulated, core.storageCapacity - core.items.get(requirements[i].item));
+                        int accepting = Math.min(accumulated, core.capacity() - core.items.get(requirements[i].item));
                         //transfer items directly, as this is not production.
                         if(!state.rules.infiniteResources) core.items.add(requirements[i].item, accepting);
                         itemsLeft[i] += accepting;
@@ -387,7 +387,7 @@ public class ConstructBlock extends Block{
                         int remaining = target - itemsLeft[i];
 
                         if(requirements[i].item.unlockedNowHost()){
-                            core.items.add(requirements[i].item, Mathf.clamp(remaining, 0, core.storageCapacity - core.items.get(requirements[i].item)));
+                            core.items.add(requirements[i].item, Mathf.clamp(remaining, 0, core.capacity() - core.items.get(requirements[i].item)));
                         }
                         itemsLeft[i] = target;
                     }

--- a/core/src/mindustry/world/blocks/storage/CoreBlock.java
+++ b/core/src/mindustry/world/blocks/storage/CoreBlock.java
@@ -252,7 +252,7 @@ public class CoreBlock extends StorageBlock{
     }
 
     public class CoreBuild extends Building implements LaunchAnimator{
-        private int storageCapacity, previousCapacity;
+        private int storageCapacity;
 
         public boolean noEffect = false;
         public Team lastDamage = Team.derelict;
@@ -711,6 +711,7 @@ public class CoreBlock extends StorageBlock{
             super.onProximityUpdate();
 
             state.teams.registerCore(this);
+            int previousCapacity = storageCapacity;
 
             storageCapacity = itemCapacity;
             proximity.each(this::owns, t -> {
@@ -720,7 +721,6 @@ public class CoreBlock extends StorageBlock{
             });
 
             team.data().itemCap += storageCapacity - previousCapacity;
-            previousCapacity = storageCapacity;
 
             if(!world.isGenerating()){
                 clampItems();

--- a/core/src/mindustry/world/blocks/storage/CoreBlock.java
+++ b/core/src/mindustry/world/blocks/storage/CoreBlock.java
@@ -531,8 +531,6 @@ public class CoreBlock extends StorageBlock{
         @Override
         public void created(){
             super.created();
-
-            items = team.data().items;
             Events.fire(new CoreChangeEvent(this));
         }
 
@@ -710,6 +708,14 @@ public class CoreBlock extends StorageBlock{
         public void onProximityUpdate(){
             super.onProximityUpdate();
 
+
+            if(team.data().items == null){
+                // this is the first core of this team, assign its ItemModule as the default one
+                team.data().items = items;
+            }else{
+                items = team.data().items;
+            }
+
             state.teams.registerCore(this);
             int previousCapacity = storageCapacity;
 
@@ -808,6 +814,18 @@ public class CoreBlock extends StorageBlock{
                 ent.items = new ItemModule();
                 for(Item item : content.items()){
                     ent.items.set(item, (int)Math.min(ent.block.itemCapacity, items.get(item) * (float)ent.block.itemCapacity / totalCapacity));
+                }
+
+                // check if there are any other nearby cores
+                Point2[] edges = Edges.getEdges(ent.block.size);
+                for(Point2 edge : edges){
+                    Building b = world.build(ent.tileX() + edge.x, ent.tileY() + edge.y);
+                    if(b != this && b instanceof CoreBuild c){
+                        c.onProximityUpdate();
+                        if(ent.linkedCore == c){
+                            break;
+                        }
+                    }
                 }
             });
 

--- a/core/src/mindustry/world/blocks/storage/CoreBlock.java
+++ b/core/src/mindustry/world/blocks/storage/CoreBlock.java
@@ -708,7 +708,6 @@ public class CoreBlock extends StorageBlock{
         public void onProximityUpdate(){
             super.onProximityUpdate();
 
-
             if(team.data().items == null){
                 // this is the first core of this team, assign its ItemModule as the default one
                 team.data().items = items;

--- a/core/src/mindustry/world/blocks/storage/CoreBlock.java
+++ b/core/src/mindustry/world/blocks/storage/CoreBlock.java
@@ -143,9 +143,9 @@ public class CoreBlock extends StorageBlock{
         super.setBars();
 
         addBar("capacity", (CoreBuild e) -> new Bar(
-            () -> Core.bundle.format("bar.capacity", UI.formatAmount(e.storageCapacity)),
+            () -> Core.bundle.format("bar.capacity", UI.formatAmount(e.team.data().itemCap)),
             () -> Pal.items,
-            () -> e.items.total() / ((float)e.storageCapacity * content.items().count(UnlockableContent::unlockedNow))
+            () -> e.items.total() / ((float)e.team.data().itemCap * content.items().count(UnlockableContent::unlockedNow))
         ));
     }
 
@@ -252,7 +252,8 @@ public class CoreBlock extends StorageBlock{
     }
 
     public class CoreBuild extends Building implements LaunchAnimator{
-        public int storageCapacity;
+        private int storageCapacity, previousCapacity;
+
         public boolean noEffect = false;
         public Team lastDamage = Team.derelict;
         public float iframes = -1f;
@@ -531,6 +532,7 @@ public class CoreBlock extends StorageBlock{
         public void created(){
             super.created();
 
+            items = team.data().items;
             Events.fire(new CoreChangeEvent(this));
         }
 
@@ -542,6 +544,7 @@ public class CoreBlock extends StorageBlock{
 
             super.changeTeam(next);
 
+            items = next.data().items;
             onProximityUpdate();
 
             Events.fire(new CoreChangeEvent(this));
@@ -549,7 +552,7 @@ public class CoreBlock extends StorageBlock{
 
         @Override
         public double sense(LAccess sensor){
-            if(sensor == LAccess.itemCapacity) return storageCapacity;
+            if(sensor == LAccess.itemCapacity) return team.data().itemCap;
             if(sensor == LAccess.maxUnits) return Units.getCap(team);
             return super.sense(sensor);
         }
@@ -684,6 +687,10 @@ public class CoreBlock extends StorageBlock{
             }
         }
 
+        public int capacity(){
+            return team.data().itemCap;
+        }
+
         @Override
         public void drawLight(){
             Drawf.light(x, y, lightRadius, Pal.accent, 0.65f + Mathf.absin(20f, 0.1f));
@@ -696,46 +703,34 @@ public class CoreBlock extends StorageBlock{
 
         @Override
         public int getMaximumAccepted(Item item){
-            return state.rules.coreIncinerates ? Integer.MAX_VALUE/2 : storageCapacity;
+            return state.rules.coreIncinerates ? Integer.MAX_VALUE/2 : team.data().itemCap;
         }
 
         @Override
         public void onProximityUpdate(){
             super.onProximityUpdate();
 
-            for(Building other : state.teams.cores(team)){
-                if(other.tile != tile){
-                    this.items = other.items;
-                }
-            }
             state.teams.registerCore(this);
 
-            storageCapacity = itemCapacity + proximity.sum(e -> owns(e) ? e.block.itemCapacity : 0);
+            storageCapacity = itemCapacity;
             proximity.each(this::owns, t -> {
                 t.items = items;
+                storageCapacity += t.block.itemCapacity;
                 ((StorageBuild)t).linkedCore = this;
             });
 
-            for(Building other : state.teams.cores(team)){
-                if(other.tile == tile) continue;
-                storageCapacity += other.block.itemCapacity + other.proximity.sum(e -> owns(other, e) ? e.block.itemCapacity : 0);
-            }
+            team.data().itemCap += storageCapacity - previousCapacity;
+            previousCapacity = storageCapacity;
 
             if(!world.isGenerating()){
-                for(Item item : content.items()){
-                    items.set(item, Math.min(items.get(item), storageCapacity));
-                }
-            }
-
-            for(CoreBuild other : state.teams.cores(team)){
-                other.storageCapacity = storageCapacity;
+                clampItems();
             }
         }
 
         @Override
         public void handleStack(Item item, int amount, Teamc source){
             boolean incinerate = incinerateNonBuildable && !item.buildable;
-            int realAmount = incinerate ? 0 : Math.min(amount, storageCapacity - items.get(item));
+            int realAmount = incinerate ? 0 : Math.min(amount, team.data().itemCap - items.get(item));
             super.handleStack(item, realAmount, source);
 
             if(team == state.rules.defaultTeam && state.isCampaign()){
@@ -758,6 +753,12 @@ public class CoreBlock extends StorageBlock{
             }
 
             return result;
+        }
+
+        public void clampItems(){
+            for(Item item : content.items()){
+                items.set(item, Math.min(items.get(item), team.data().itemCap));
+            }
         }
 
         @Override
@@ -801,7 +802,7 @@ public class CoreBlock extends StorageBlock{
         public void onRemoved(){
             int totalCapacity = proximity.sum(e -> e.items != null && e.items == items ? e.block.itemCapacity : 0);
 
-            proximity.each(e -> owns(e) && e.items == items && owns(e), t -> {
+            proximity.each(e -> owns(e) && e.items == items, t -> {
                 StorageBuild ent = (StorageBuild)t;
                 ent.linkedCore = null;
                 ent.items = new ItemModule();
@@ -810,11 +811,10 @@ public class CoreBlock extends StorageBlock{
                 }
             });
 
+            team.data().itemCap -= storageCapacity;
             state.teams.unregisterCore(this);
 
-            for(CoreBuild other : state.teams.cores(team)){
-                other.onProximityUpdate();
-            }
+            clampItems();
         }
 
         @Override
@@ -844,7 +844,7 @@ public class CoreBlock extends StorageBlock{
                     state.rules.sector.info.handleCoreItem(item, 1);
                 }
 
-                if(items.get(item) >= storageCapacity || incinerate){
+                if(items.get(item) >= team.data().itemCap || incinerate){
                     //create item incineration effect at random intervals
                     if(!noEffect){
                         incinerateEffect(this, source);
@@ -853,7 +853,7 @@ public class CoreBlock extends StorageBlock{
                 }else{
                     super.handleItem(source, item);
                 }
-            }else if(((state.rules.coreIncinerates && items.get(item) >= storageCapacity) || incinerate) && !noEffect){
+            }else if(((state.rules.coreIncinerates && items.get(item) >= team.data().itemCap) || incinerate) && !noEffect){
                 //create item incineration effect at random intervals
                 incinerateEffect(this, source);
                 noEffect = false;

--- a/core/src/mindustry/world/blocks/storage/StorageBlock.java
+++ b/core/src/mindustry/world/blocks/storage/StorageBlock.java
@@ -1,6 +1,5 @@
 package mindustry.world.blocks.storage;
 
-import arc.Core;
 import arc.math.*;
 import arc.struct.*;
 import arc.util.*;
@@ -136,13 +135,6 @@ public class StorageBlock extends Block{
         @Override
         public boolean allowDeposit(){
             return linkedCore != null || super.allowDeposit();
-        }
-
-        @Override
-        public void onDestroyed(){
-            if(linkedCore != null){
-                Core.app.post(linkedCore::clampItems);
-            }
         }
     }
 }

--- a/core/src/mindustry/world/blocks/storage/StorageBlock.java
+++ b/core/src/mindustry/world/blocks/storage/StorageBlock.java
@@ -1,5 +1,6 @@
 package mindustry.world.blocks.storage;
 
+import arc.Core;
 import arc.math.*;
 import arc.struct.*;
 import arc.util.*;
@@ -46,7 +47,7 @@ public class StorageBlock extends Block{
     }
 
     public class StorageBuild extends Building{
-        public @Nullable Building linkedCore;
+        public @Nullable CoreBuild linkedCore;
 
         @Override
         public boolean acceptItem(Building source, Item item){
@@ -61,10 +62,10 @@ public class StorageBlock extends Block{
         @Override
         public void handleItem(Building source, Item item){
             if(linkedCore != null){
-                if(linkedCore.items.get(item) >= ((CoreBuild)linkedCore).storageCapacity){
+                if(linkedCore.items.get(item) >= team.data().itemCap){
                     incinerateEffect(this, source);
                 }
-                ((CoreBuild)linkedCore).noEffect = true;
+                linkedCore.noEffect = true;
                 linkedCore.handleItem(source, item);
             }else{
                 super.handleItem(source, item);
@@ -135,6 +136,13 @@ public class StorageBlock extends Block{
         @Override
         public boolean allowDeposit(){
             return linkedCore != null || super.allowDeposit();
+        }
+
+        @Override
+        public void onDestroyed(){
+            if(linkedCore != null){
+                Core.app.post(linkedCore::clampItems);
+            }
         }
     }
 }

--- a/server/src/mindustry/server/ServerControl.java
+++ b/server/src/mindustry/server/ServerControl.java
@@ -681,7 +681,7 @@ public class ServerControl implements ApplicationListener{
             }
 
             for(Item item : content.items()){
-                state.teams.cores(team).first().items.set(item, state.teams.cores(team).first().storageCapacity);
+                state.teams.cores(team).first().items.set(item, state.teams.get(team).itemCap);
             }
 
             info("Core filled.");


### PR DESCRIPTION
Removes the need to iterate all of the team's cores upon one updating its proximity
_Should_ work just fine, I've tested all the cases that came to my mind (adding storage, removing storage, cores and storage dying, changing teams, etc)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
