### PR TITLE
navanax EMP damage buff

### DIFF
--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -2355,7 +2355,7 @@ public class UnitTypes{
                     timeIncrease = 3f;
                     timeDuration = 60f * 20f;
                     powerDamageScl = 3f;
-                    damage = 60;
+                    damage = 110;
                     hitColor = lightColor = Pal.heal;
                     lightRadius = 70f;
                     clipSize = 250f;
@@ -2372,7 +2372,7 @@ public class UnitTypes{
                     trailWidth = 6f;
                     trailColor = Pal.heal;
                     trailInterval = 3f;
-                    splashDamage = 70f;
+                    splashDamage = 110f;
                     splashDamageRadius = rad;
                     hitShake = 4f;
                     trailRotation = true;


### PR DESCRIPTION
allows the EMPs to kill powered mend projectors in 1 hit, and increases navanax's dps from 119.6 to 202.4 because navanax could _really_ use some extra ranged damage

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [ ] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
