### PR TITLE
Sensing heat

### DIFF
--- a/core/src/mindustry/world/blocks/defense/ShockwaveTower.java
+++ b/core/src/mindustry/world/blocks/defense/ShockwaveTower.java
@@ -107,8 +107,11 @@ public class ShockwaveTower extends Block{
 
         @Override
         public double sense(LAccess sensor) {
-            if(sensor == LAccess.progress) return reloadCounter / reload;
-            return super.sense(sensor);
+            return switch(sensor){
+                case progress -> reloadCounter / reload;
+                case heat -> heat;
+                default -> super.sense(sensor);
+            };
         }
 
 

--- a/core/src/mindustry/world/blocks/defense/turrets/PowerTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/PowerTurret.java
@@ -35,6 +35,7 @@ public class PowerTurret extends Turret{
             return switch(sensor){
                 case ammo -> power == null ? 0f : power.status;
                 case ammoCapacity -> 1;
+                case heat -> heat;
                 default -> super.sense(sensor);
             };
         }

--- a/core/src/mindustry/world/blocks/defense/turrets/PowerTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/PowerTurret.java
@@ -35,7 +35,7 @@ public class PowerTurret extends Turret{
             return switch(sensor){
                 case ammo -> power == null ? 0f : power.status;
                 case ammoCapacity -> 1;
-                case heat -> heat;
+                case heat -> heatRequirement > 0 ? heat : Float.NaN;
                 default -> super.sense(sensor);
             };
         }

--- a/core/src/mindustry/world/blocks/heat/HeatConductor.java
+++ b/core/src/mindustry/world/blocks/heat/HeatConductor.java
@@ -8,6 +8,7 @@ import mindustry.*;
 import mindustry.entities.units.*;
 import mindustry.gen.*;
 import mindustry.graphics.*;
+import mindustry.logic.*;
 import mindustry.ui.*;
 import mindustry.world.*;
 import mindustry.world.draw.*;
@@ -86,6 +87,12 @@ public class HeatConductor extends Block{
 
             lastHeatUpdate = Vars.state.updateId;
             heat = calculateHeat(sideHeat, cameFrom);
+        }
+
+        @Override
+        public double sense(LAccess sensor){
+            if (sensor == LAccess.heat) return heat;
+            return super.sense(sensor);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/heat/HeatConductor.java
+++ b/core/src/mindustry/world/blocks/heat/HeatConductor.java
@@ -91,7 +91,7 @@ public class HeatConductor extends Block{
 
         @Override
         public double sense(LAccess sensor){
-            if (sensor == LAccess.heat) return heat;
+            if(sensor == LAccess.heat) return heat;
             return super.sense(sensor);
         }
 

--- a/core/src/mindustry/world/blocks/heat/HeatProducer.java
+++ b/core/src/mindustry/world/blocks/heat/HeatProducer.java
@@ -4,6 +4,7 @@ import arc.math.*;
 import arc.struct.*;
 import arc.util.io.*;
 import mindustry.graphics.*;
+import mindustry.logic.*;
 import mindustry.ui.*;
 import mindustry.world.blocks.production.*;
 import mindustry.world.draw.*;
@@ -58,6 +59,12 @@ public class HeatProducer extends GenericCrafter{
         @Override
         public float heat(){
             return heat;
+        }
+
+        @Override
+        public double sense(LAccess sensor){
+            if (sensor == LAccess.heat) return heat;
+            return super.sense(sensor);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/heat/HeatProducer.java
+++ b/core/src/mindustry/world/blocks/heat/HeatProducer.java
@@ -63,7 +63,7 @@ public class HeatProducer extends GenericCrafter{
 
         @Override
         public double sense(LAccess sensor){
-            if (sensor == LAccess.heat) return heat;
+            if(sensor == LAccess.heat) return heat;
             return super.sense(sensor);
         }
 

--- a/core/src/mindustry/world/blocks/power/HeaterGenerator.java
+++ b/core/src/mindustry/world/blocks/power/HeaterGenerator.java
@@ -3,6 +3,7 @@ package mindustry.world.blocks.power;
 import arc.math.*;
 import arc.util.io.*;
 import mindustry.graphics.*;
+import mindustry.logic.*;
 import mindustry.ui.*;
 import mindustry.world.blocks.heat.*;
 import mindustry.world.draw.*;
@@ -60,6 +61,12 @@ public class HeaterGenerator extends ConsumeGenerator{
         @Override
         public float heat(){
             return heat;
+        }
+
+        @Override
+        public double sense(LAccess sensor){
+            if (sensor == LAccess.heat) return heat;
+            return super.sense(sensor);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/power/HeaterGenerator.java
+++ b/core/src/mindustry/world/blocks/power/HeaterGenerator.java
@@ -65,7 +65,7 @@ public class HeaterGenerator extends ConsumeGenerator{
 
         @Override
         public double sense(LAccess sensor){
-            if (sensor == LAccess.heat) return heat;
+            if(sensor == LAccess.heat) return heat;
             return super.sense(sensor);
         }
 

--- a/core/src/mindustry/world/blocks/power/VariableReactor.java
+++ b/core/src/mindustry/world/blocks/power/VariableReactor.java
@@ -12,6 +12,7 @@ import mindustry.entities.*;
 import mindustry.entities.effect.*;
 import mindustry.gen.*;
 import mindustry.graphics.*;
+import mindustry.logic.*;
 import mindustry.ui.*;
 import mindustry.world.blocks.heat.*;
 import mindustry.world.meta.*;
@@ -149,6 +150,12 @@ public class VariableReactor extends PowerGenerator{
         @Override
         public float heatRequirement(){
             return maxHeat;
+        }
+
+        @Override
+        public double sense(LAccess sensor){
+            if (sensor == LAccess.heat) return heat;
+            return super.sense(sensor);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/power/VariableReactor.java
+++ b/core/src/mindustry/world/blocks/power/VariableReactor.java
@@ -154,7 +154,7 @@ public class VariableReactor extends PowerGenerator{
 
         @Override
         public double sense(LAccess sensor){
-            if (sensor == LAccess.heat) return heat;
+            if(sensor == LAccess.heat) return heat;
             return super.sense(sensor);
         }
 

--- a/core/src/mindustry/world/blocks/production/HeatCrafter.java
+++ b/core/src/mindustry/world/blocks/production/HeatCrafter.java
@@ -3,6 +3,7 @@ package mindustry.world.blocks.production;
 import arc.*;
 import arc.math.*;
 import mindustry.graphics.*;
+import mindustry.logic.*;
 import mindustry.ui.*;
 import mindustry.world.blocks.heat.*;
 import mindustry.world.meta.*;
@@ -69,6 +70,12 @@ public class HeatCrafter extends GenericCrafter{
         @Override
         public float warmupTarget(){
             return Mathf.clamp(heat / heatRequirement);
+        }
+
+        @Override
+        public double sense(LAccess sensor){
+            if (sensor == LAccess.heat) return heat;
+            return super.sense(sensor);
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/production/HeatCrafter.java
+++ b/core/src/mindustry/world/blocks/production/HeatCrafter.java
@@ -74,7 +74,7 @@ public class HeatCrafter extends GenericCrafter{
 
         @Override
         public double sense(LAccess sensor){
-            if (sensor == LAccess.heat) return heat;
+            if(sensor == LAccess.heat) return heat;
             return super.sense(sensor);
         }
 


### PR DESCRIPTION
My attempt at implementing https://github.com/Anuken/Mindustry-Suggestions/issues/6353.

As there isn't a `heat` field common to all blocks, I've added the ability to sense `@heat` to blocks that define the field, returning the value of the field as-is. Apparently, different blocks use different ranges for heat, so maybe adding a `@heatCapacity` or `@maxHeat` property might be useful, but I didn't want to go there as I don't understand the mechanism all that much. It should still be useful for map authors using world processors as it is.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
