### PR TITLE
Add CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,6 +16,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Checkout Arc dependency
+        uses: actions/checkout@v4
+        with:
+          repository: Anuken/Arc
+          path: Arc
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,7 @@ name: CD
 on:
   push:
     branches:
+      - feature/cd-pipeline
       - master
 
 permissions:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,47 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Build
+        run: ./gradlew desktop:dist
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jar
+          path: desktop/build/libs/*.jar
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: jar
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: build-${{ github.run_number }}
+          files: |
+            *.jar

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - feature/cd-pipeline
 
 permissions:
   contents: write

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,6 @@ name: CD
 on:
   push:
     branches:
-      - feature/cd-pipeline
       - master
 
 permissions:
@@ -16,17 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout Arc dependency
-        uses: actions/checkout@v4
-        with:
-          repository: Anuken/Arc
-          path: Arc
-
-      - name: Setup Java
+      - name: Setup JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: '17'
+
+      - name: Fetch Arc
+        run: git clone --depth=1 --branch=master https://github.com/Anuken/Arc ../Arc
 
       - name: Build
         run: ./gradlew desktop:dist


### PR DESCRIPTION
## Summary

This pull request adds a Continuous Deployment (CD) workflow using GitHub Actions.

### Features

* Trigger on pushes to the master branch.
* Build the project using Gradle and Java 17.
* Upload generated JAR files as workflow artifacts.
* Automatically create a GitHub Release with the generated JAR attached.

### Purpose

This workflow was created as part of the Sprint 1 DevOps activities to automate the deployment process and improve release management.
