### PR TITLE
Force System.exit(0) after SdlApplication returns to prevent zombie processes

### DIFF
--- a/desktop/src/mindustry/desktop/DesktopLauncher.java
+++ b/desktop/src/mindustry/desktop/DesktopLauncher.java
@@ -114,6 +114,7 @@ public class DesktopLauncher extends ClientLauncher{
         }catch(Throwable e){
             handleCrash(e);
         }
+        System.exit(0);
     }
 
     static void checkJavaVersion(){


### PR DESCRIPTION
## Summary

- Add `System.exit(0)` at the end of `DesktopLauncher.main()` to force JVM exit after `SdlApplication` returns

## Problem

On Windows, closing the Mindustry window can leave a zombie `javaw.exe` process. The main thread gets stuck in `SDL_GL_SwapWindow` (native) and never returns. All other threads are daemon threads, so the JVM waits indefinitely.

**jstack of zombie:**
```
"main" #3 prio=5 ... runnable
  java.lang.Thread.State: RUNNABLE
    at arc.backend.sdl.jni.SDL.SDL_GL_SwapWindow(Native Method)
    at arc.backend.sdl.SdlApplication.loop(SdlApplication.java:218)
    at arc.backend.sdl.SdlApplication.<init>(SdlApplication.java:58)
    at mindustry.desktop.DesktopLauncher.main(DesktopLauncher.java:53)
```

## Fix

`System.exit(0)` after the try-catch block in `main()`. This is the standard approach used by libGDX's LWJGL3 backend. The `SdlApplication` constructor handles all cleanup (dispose, `SDL_DestroyWindow`, `SDL_Quit`) before returning, so `System.exit(0)` is safe here.

Fixes #12221
