### PR TITLE
buff spectre's ammo efficiency

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -4265,7 +4265,7 @@ public class Blocks{
                     width = 15f;
                     height = 21f;
                     shootEffect = Fx.shootBig;
-                    ammoMultiplier = 4;
+                    ammoMultiplier = 6;
                     reloadMultiplier = 1.7f;
                     knockback = 0.3f;
 
@@ -4278,6 +4278,7 @@ public class Blocks{
                     width = 16f;
                     height = 23f;
                     shootEffect = Fx.shootBig;
+                    ammoMultiplier = 3;
                     pierceCap = 2;
                     pierceBuilding = true;
                     knockback = 0.7f;
@@ -4298,7 +4299,7 @@ public class Blocks{
                     pierceCap = 2;
                     pierceBuilding = true;
                     knockback = 0.6f;
-                    ammoMultiplier = 3;
+                    ammoMultiplier = 5;
                     splashDamage = 20f;
                     splashDamageRadius = 25f;
                 }}


### PR DESCRIPTION
spectre is a bit too expensive to fuel for its damage output imo; just one unboosted thor spectre already uses ~4.25 thor/s, so im buffing ammo efficiency of all of spectre's ammos a little bit

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [ ] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
