### PR TITLE
Logic-controlled payenter assembler fix

### DIFF
--- a/core/src/mindustry/world/blocks/units/UnitAssembler.java
+++ b/core/src/mindustry/world/blocks/units/UnitAssembler.java
@@ -706,6 +706,13 @@ public class UnitAssembler extends PayloadBlock{
         }
 
         @Override
+        public boolean acceptUnitPayload(Unit unit){
+            var plan = plan();
+            return plan.requirements.contains(b -> b.item == unit.type() &&
+                blocks.get(unit.type()) < Mathf.round(b.amount * state.rules.unitCost(team)));
+        }
+
+        @Override
         public PayloadSeq getPayloads(){
             return blocks;
         }


### PR DESCRIPTION
Now logic-controlled units can payenter in assemblers.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
