### PR TITLE
Fix NullPointerException in LogicBlock.updateLinks() when linksVar is null

### DIFF
--- a/core/src/mindustry/world/blocks/logic/LogicBlock.java
+++ b/core/src/mindustry/world/blocks/logic/LogicBlock.java
@@ -573,6 +573,8 @@ public class LogicBlock extends Block{
         }
 
         public void updateLinks(){
+            if(linksVar == null) return;
+
             int valids = links.count(l -> l.valid);
             executor.links = new Building[valids];
             executor.linkIds.clear();


### PR DESCRIPTION
## Bug Fix

**Problem:**
`LogicBlock.LogicBuild.updateLinks()` crashes with `NullPointerException` when `linksVar` is `null`.

```
java.lang.NullPointerException: Cannot assign field "numval" because "this.linksVar" is null
    at mindustry.world.blocks.logic.LogicBlock$LogicBuild.updateLinks(LogicBlock.java:610)
    at mindustry.world.blocks.logic.LogicBlock$LogicBuild.updateTile(LogicBlock.java:567)
```

**Root Cause:**
`linksVar` is annotated as `@Nullable` (line 266) and only initialized during code compilation in `buildLASM()` (line 392). However, `updateLinks()` (line 575) directly accesses `linksVar.numval` without null checking. This can happen when:

- A logic block just spawned/placed and code hasn't compiled yet
- Code compilation failed (exception caught, empty code loaded)
- Link state changes before code is loaded

**Fix:**
Added null check at the beginning of `updateLinks()`:

```java
public void updateLinks(){
    if(linksVar == null) return;
    ...
}
```

This prevents the NPE and gracefully handles the case where links update before code compilation.