### PR TITLE
fix: skip unrecognized block IDs in client plan deserialization

### DIFF
--- a/core/src/mindustry/io/TypeIO.java
+++ b/core/src/mindustry/io/TypeIO.java
@@ -630,6 +630,12 @@ public class TypeIO{
             int x = read.us();
             int y = read.us();
             Block block = Vars.content.block(read.us());
+            if(block == null){
+                // Skip unrecognised block IDs (e.g. from a modded client)
+                read.b(); // consume rotation byte
+                readClientPlanConfig(read); // consume config
+                continue;
+            }
             int rotation = (block.rotate ? read.b() : 0);
             Object config = readClientPlanConfig(read);
             BuildPlan plan = new BuildPlan(x, y, rotation, block, config);


### PR DESCRIPTION
When a client with a content mismatch sends a ClientPlanSnapshotCallPacket containing a block ID the server does not recognize, Vars.content.block() returns null. The null block is then accessed for .rotate, causing a NullPointerException that drops the client connection.

Skip unrecognized block plan entries instead of crashing.

Fixes #12243