### PR TITLE
Make read/write object fields wider

### DIFF
--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -68,7 +68,7 @@ public class LStatements{
 
             table.add(" = ");
 
-            fields(table, target, str -> target = str);
+            field(table, target, str -> target = str);
 
             row(table);
 
@@ -100,7 +100,7 @@ public class LStatements{
 
             table.add(" to ");
 
-            fields(table, target, str -> target = str);
+            field(table, target, str -> target = str);
 
             row(table);
 


### PR DESCRIPTION
The `read`/`write` instructions now can accept processors as well as memory banks/cells. For processor link names, the short field doesn't display the full name. This PR makes the fields regularly-sized, which makes the processor links fully visible.

Before:

<img width="931" height="233" alt="image" src="https://github.com/user-attachments/assets/c9d197f6-afe6-4c79-8172-7baa2b22d309" />

After:

<img width="927" height="237" alt="image" src="https://github.com/user-attachments/assets/1fc53b13-a218-49fa-b1f2-d21d6beccb9c" />

<img width="431" height="321" alt="image" src="https://github.com/user-attachments/assets/87593b50-eac1-414f-90f8-02ef1035ad03" />

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
