### PR TITLE
Fix mod settings not displayed correctly

### DIFF
--- a/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
+++ b/core/src/mindustry/ui/dialogs/SettingsMenuDialog.java
@@ -352,7 +352,7 @@ public class SettingsMenuDialog extends BaseDialog{
         menu.button("@settings.data", Icon.save, style, isize, () -> dataDialog.show()).marginLeft(marg).row();
         menu.button("@settings.dev", Icon.fileCode, style, isize, () -> visible(3)).marginLeft(marg).row();
 
-        int i = 3;
+        int i = 4;
         for(var cat : categories){
             int index = i;
             if(cat.icon == null){


### PR DESCRIPTION
After adding the new Developer Options settings category, the custom mod setting categories were shifted: clicking the first mod's settings displayed the Developer Options, clicking the second displayed the options created by the first, and so on.

<img width="357" height="596" alt="image" src="https://github.com/user-attachments/assets/a636ff85-c3a1-4abd-ade5-983ccce0af07" />

Clicking Mlog Watcher displays the Developer Options screen, clicking Mlog Assertions displays Mlog Watcher's, and the last one remains inaccessible.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
