### PR TITLE
No unnecessary map editor menu hiding

### DIFF
--- a/core/src/mindustry/editor/MapEditorDialog.java
+++ b/core/src/mindustry/editor/MapEditorDialog.java
@@ -70,23 +70,23 @@ public class MapEditorDialog extends Dialog implements Disposable{
         menu.cont.table(t -> {
             t.defaults().size(swidth, 60f).padBottom(5).padRight(5).padLeft(5);
 
-            t.button("@editor.savemap", Icon.save, this::save);
+            t.button("@editor.savemap", Icon.save, () -> {
+                Map map = save(); // must be saved successfully if doesn't return null
+                if(map != null) menu.hide();
+            });
 
             t.button("@editor.mapinfo", Icon.pencil, () -> {
                 infoDialog.show();
-                menu.hide();
             });
 
             t.row();
 
             t.button("@editor.generate", Icon.terrain, () -> {
                 generateDialog.show(generateDialog::applyToEditor);
-                menu.hide();
             });
 
             t.button("@editor.resize", Icon.resize, () -> {
                 resizeDialog.show();
-                menu.hide();
             });
 
             t.row();
@@ -179,7 +179,6 @@ public class MapEditorDialog extends Dialog implements Disposable{
         }
 
         menu.cont.button("@editor.sectorgenerate", Icon.terrain, () -> {
-            menu.hide();
             sectorGenDialog.show();
         }).padTop(!steam ? -3 : 1).size(swidth * 2f + 10, 60f);
 
@@ -256,7 +255,6 @@ public class MapEditorDialog extends Dialog implements Disposable{
 
         menu.cont.button("@quit", Icon.exit, () -> {
             tryExit();
-            menu.hide();
         }).padTop(1).size(swidth * 2f + 10, 60f);
 
         resizeDialog = new MapResizeDialog((width, height, shiftX, shiftY) -> {
@@ -373,7 +371,6 @@ public class MapEditorDialog extends Dialog implements Disposable{
     }
 
     private void playtest(){
-        menu.hide();
         Map map = save();
 
         if(map != null){
@@ -437,7 +434,6 @@ public class MapEditorDialog extends Dialog implements Disposable{
             }
         }
 
-        menu.hide();
         saved = true;
         state.rules.editor = isEditor;
         return returned;
@@ -791,6 +787,7 @@ public class MapEditorDialog extends Dialog implements Disposable{
         ui.showConfirm("@confirm", "@editor.unsaved", () -> {
             //clears data patches
             logic.reset();
+            menu.hide();
             hide();
         });
     }
@@ -883,5 +880,9 @@ public class MapEditorDialog extends Dialog implements Disposable{
         if(i == 0){
             blockSelection.add("@none.found").padLeft(54f).padTop(10f);
         }
+    }
+
+    public void hide_menu(){
+        menu.hide();
     }
 }

--- a/core/src/mindustry/editor/MapGenerateDialog.java
+++ b/core/src/mindustry/editor/MapGenerateDialog.java
@@ -72,6 +72,7 @@ public class MapGenerateDialog extends BaseDialog{
             buttons.button("@editor.apply", Icon.ok, () -> {
                 ui.loadAnd(() -> {
                     apply();
+                    ui.editor.hide_menu();
                     hide();
                 });
             });

--- a/core/src/mindustry/editor/MapInfoDialog.java
+++ b/core/src/mindustry/editor/MapInfoDialog.java
@@ -69,19 +69,16 @@ public class MapInfoDialog extends BaseDialog{
 
                 r.button("@editor.rules", Icon.list, style, () -> {
                     ruleInfo.show(Vars.state.rules, () -> Vars.state.rules = new Rules());
-                    hide();
                 }).marginLeft(10f);
 
                 r.button("@editor.waves", Icon.units, style, () -> {
                     waveInfo.show();
-                    hide();
                 }).marginLeft(10f);
 
                 r.row();
 
                 r.button("@editor.objectives", Icon.info, style, () -> {
                     objectives.show(state.rules.objectives.all, state.rules.objectives.all::set);
-                    hide();
                 }).marginLeft(10f);
 
                 r.button("@editor.generation", Icon.terrain, style, () -> {
@@ -95,7 +92,6 @@ public class MapInfoDialog extends BaseDialog{
                         filters.each(f -> f.seed = 0);
                         editor.tags.put("genfilters", JsonIO.write(filters));
                     });
-                    hide();
                 }).marginLeft(10f);
 
                 r.row();
@@ -108,18 +104,15 @@ public class MapInfoDialog extends BaseDialog{
                         locales.show(new MapLocales());
                         ui.showException(e);
                     }
-                    hide();
                 }).marginLeft(10f);
 
                 r.button("@editor.worldprocessors", Icon.logic, style, () -> {
-                    hide();
                     processors.show();
                 }).marginLeft(10f);
 
                 r.row();
 
                 r.button("@asset.title", Icon.fileCode, style, () -> {
-                    hide();
                     patches.show();
                 }).marginLeft(10f).colspan(2).width(460f).row();
             }).colspan(2).center();

--- a/core/src/mindustry/editor/MapResizeDialog.java
+++ b/core/src/mindustry/editor/MapResizeDialog.java
@@ -57,6 +57,7 @@ public class MapResizeDialog extends BaseDialog{
         buttons.button("@cancel", this::hide);
         buttons.button("@ok", () -> {
             cons.get(width, height, shiftX, shiftY);
+            ui.editor.hide_menu();
             hide();
         });
     }

--- a/core/src/mindustry/editor/SectorGenerateDialog.java
+++ b/core/src/mindustry/editor/SectorGenerateDialog.java
@@ -78,6 +78,7 @@ public class SectorGenerateDialog extends BaseDialog{
 
         buttons.button("@editor.apply", Icon.ok, () -> {
             ui.loadAnd(() -> {
+                ui.editor.hide_menu();
                 apply();
                 hide();
             });

--- a/core/src/mindustry/ui/dialogs/MapPlayDialog.java
+++ b/core/src/mindustry/ui/dialogs/MapPlayDialog.java
@@ -88,6 +88,7 @@ public class MapPlayDialog extends BaseDialog{
             if(playListener != null) playListener.run();
             control.playMap(map, rules, playtesting);
             hide();
+            ui.editor.hide_menu();
             ui.custom.hide();
         }).size(210f, 64f);
 

--- a/core/src/mindustry/ui/dialogs/PausedDialog.java
+++ b/core/src/mindustry/ui/dialogs/PausedDialog.java
@@ -102,7 +102,6 @@ public class PausedDialog extends BaseDialog{
 
             if(state.isEditor()){
                 cont.button("@editor.worldprocessors", Icon.logic, () -> {
-                    hide();
                     processors.show();
                 });
             }


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

Basically when you pick almost any option in the map editor menu or the map info menu it hides , so you when you go back you go straight to the map editor itself and sometimes its very annoying
I removed all lines of code that unnecessairly do that and added where needed
Also the save/export buttons dont hide the menu so i think it wont hurt if all buttons didn't

- [V] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [V] I have ensured that my code compiles, if applicable.
- [V] I have ensured that any new features in this PR function correctly in-game, if applicable.
