### PR TITLE
Fix the issue where the icon for UnlockableContent characters in the text isn't centered on the character

### DIFF
--- a/core/assets/contributors
+++ b/core/assets/contributors
@@ -195,3 +195,4 @@ Jovinull
 Alon
 硫缺铅/PyratiteNoLead
 Space
+NeilGreenFly

--- a/core/src/mindustry/ui/Fonts.java
+++ b/core/src/mindustry/ui/Fonts.java
@@ -153,8 +153,8 @@ public class Fonts{
         glyph.v = region.v2;
         glyph.u2 = region.u2;
         glyph.v2 = region.v;
-        glyph.xoffset = 0;
-        glyph.yoffset = -size;
+        glyph.xoffset = (size - glyph.width) / 2;
+        glyph.yoffset = (size - glyph.height) / 2 - size;
         glyph.xadvance = size;
         glyph.kerning = null;
         glyph.fixedWidth = true;

--- a/core/src/mindustry/world/blocks/logic/TileableLogicDisplay.java
+++ b/core/src/mindustry/world/blocks/logic/TileableLogicDisplay.java
@@ -33,6 +33,7 @@ public class TileableLogicDisplay extends LogicDisplay{
         super(name);
 
         displaySize = 32;
+        allowRectanglePlacement = true;
     }
 
     public static void linkDisplays(TileableLogicDisplayBuild start){


### PR DESCRIPTION
Fix the issue where the icon for UnlockableContent characters in the text isn't centered on the character.

Before :
<img width="447" height="591" alt="屏幕截图 2026-06-25 232544" src="https://github.com/user-attachments/assets/c93a3714-18a5-4793-9095-5cd247f0e2fd" />

After fixing :
<img width="448" height="591" alt="屏幕截图 2026-06-25 232059" src="https://github.com/user-attachments/assets/0a901f8a-6893-4ca4-853c-f558a4797637" />

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
