### PR TITLE
Add icon formatting to content descriptions and details

### DIFF
--- a/core/src/mindustry/ui/dialogs/ContentInfoDialog.java
+++ b/core/src/mindustry/ui/dialogs/ContentInfoDialog.java
@@ -7,6 +7,7 @@ import arc.scene.ui.*;
 import arc.scene.ui.layout.*;
 import arc.struct.*;
 import arc.util.*;
+import mindustry.core.UI;
 import mindustry.ctype.*;
 import mindustry.gen.*;
 import mindustry.graphics.*;
@@ -64,7 +65,7 @@ public class ContentInfoDialog extends BaseDialog{
                 table.row();
             }
 
-            table.add("[lightgray]" + content.displayDescription()).wrap().fillX().padLeft(any ? 10 : 0).width(500f).padTop(any ? 0 : 10).left();
+            table.add("[lightgray]" + UI.formatIcons(content.displayDescription())).wrap().fillX().padLeft(any ? 10 : 0).width(500f).padTop(any ? 0 : 10).left();
             table.row();
 
             if(!content.stats.useCategories && any){
@@ -100,7 +101,7 @@ public class ContentInfoDialog extends BaseDialog{
         }
 
         if(content.details != null){
-            table.add("[gray]" + (content.unlocked() || !content.hideDetails ? content.details : Iconc.lock + " " + Core.bundle.get("unlock.incampaign"))).pad(6).padTop(20).width(400f).wrap().fillX();
+            table.add("[gray]" + (content.unlocked() || !content.hideDetails ? UI.formatIcons(content.details) : Iconc.lock + " " + Core.bundle.get("unlock.incampaign"))).pad(6).padTop(20).width(400f).wrap().fillX();
             table.row();
         }
 


### PR DESCRIPTION
Adds icon parsing to the description and details label in the Content Info Dialog.

<img width="532" height="517" alt="image" src="https://github.com/user-attachments/assets/4d6dffda-8a69-4d4c-9455-c86e340e92c7" />

<img width="547" height="767" alt="image" src="https://github.com/user-attachments/assets/e5ed6d78-08af-4966-8fc5-dd19ea76cefe" />

NOTE: I did not modify the bundle. The images above serve as examples only.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [Y] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [Y] I have ensured that my code compiles, if applicable.
- [Y] I have ensured that any new features in this PR function correctly in-game, if applicable.
