### PR TITLE
Bugfix: wreck/explosive damage bypassing shields sometimes

### DIFF
--- a/core/src/mindustry/entities/Damage.java
+++ b/core/src/mindustry/entities/Damage.java
@@ -107,9 +107,9 @@ public class Damage{
             float damagePerWave = explosiveness / 2f;
 
             for(int i = 0; i < waves; i++){
-                var shields = ignoreTeam == null ? null : indexer.getEnemy(ignoreTeam, BlockFlag.shield);
                 int f = i;
                 Time.run(i * 2f, () -> {
+                    var shields = ignoreTeam == null ? null : indexer.getEnemy(ignoreTeam, BlockFlag.shield);
                     if(shields == null || shields.isEmpty() || !shields.contains(b -> b instanceof ExplosionShield s && s.absorbExplosion(x, y, damagePerWave))){
                         damage(ignoreTeam, x, y, Mathf.clamp(radius + explosiveness, 0, 50f) * ((f + 1f) / waves), damagePerWave, false);
                     }


### PR DESCRIPTION
Code references older index calls instead of updated ones inside time.run

### Before
<img width="1451" height="697" alt="image" src="https://github.com/user-attachments/assets/9b99b61c-1d43-46d3-b20b-1a70a4e0cc4d" />


### After
<img width="1535" height="669" alt="Captura de pantalla 2026-06-29 152150" src="https://github.com/user-attachments/assets/4d456da0-fe42-4394-ac6e-0deb670683f8" />

(Full blast quad for reference)

.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
