### PR TITLE
Blacklist UDP address along with TCP address

### DIFF
--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -319,7 +319,7 @@ public class NetClient implements ApplicationListener{
         //detect and kick for foul play
         if(player != null && player.con != null && !player.con.chatRate.allow(2000, Config.chatSpamLimit.num())){
             player.con.kick(KickReason.kick);
-            netServer.admins.blacklistDos(player.con.address);
+            player.con.blacklist();
             return;
         }
 

--- a/core/src/mindustry/net/ArcNetProvider.java
+++ b/core/src/mindustry/net/ArcNetProvider.java
@@ -162,7 +162,7 @@ public class ArcNetProvider implements NetProvider{
                 if(packetSpamLimit > 0 && !k.packetRate.allow(3000, packetSpamLimit)){
                     Log.warn("Blacklisting IP '@' as potential DOS attack - packet spam.", k.address);
                     connection.close(DcReason.closed);
-                    netServer.admins.blacklistDos(k.address);
+                    k.blacklist();
                     return;
                 }
 
@@ -364,6 +364,17 @@ public class ArcNetProvider implements NetProvider{
         @Override
         public boolean isConnected(){
             return connection.isConnected();
+        }
+
+        @Override
+        public void blacklist(){
+            //Blacklist TCP address
+            super.blacklist();
+            //Blacklist UDP address
+            var address = connection.getRemoteAddressUDP();
+            if(address != null){
+                netServer.admins.blacklistDos(address.getAddress().getHostAddress());
+            }
         }
 
         @Override

--- a/core/src/mindustry/net/NetConnection.java
+++ b/core/src/mindustry/net/NetConnection.java
@@ -129,6 +129,10 @@ public abstract class NetConnection{
         }
     }
 
+    public void blacklist(){
+        netServer.admins.blacklistDos(address);
+    }
+
     public abstract void send(Object object, boolean reliable);
 
     public abstract void close();


### PR DESCRIPTION
I've heard rumors that the recent wave of bots is using a TCP-only proxy and is using different IPs for UDP and TCP. Currently Mindustry only blacklists the TCP address. They have fewer UDP addresses so blacklisting those should result in better mitigation.

(You may instead want to edit arc netcode to require TCP and UDP addresses have the same host)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
