### PR TITLE
Entity serialization optimization, part 1

### DIFF
--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -537,7 +537,7 @@ public class NetClient implements ApplicationListener{
         }
     }
 
-    @Remote(variants = Variant.one, priority = PacketPriority.low, unreliable = true)
+    @Remote(priority = PacketPriority.low, unreliable = true)
     public static void entitySnapshot(short amount, byte[] data){
         try{
             netClient.lastSnapshotTimestamp = Time.millis();
@@ -591,7 +591,7 @@ public class NetClient implements ApplicationListener{
         }
     }
 
-    @Remote(variants = Variant.one, priority = PacketPriority.low, unreliable = true)
+    @Remote(priority = PacketPriority.low, unreliable = true)
     public static void stateSnapshot(float waveTime, int wave, int enemies, boolean paused, boolean gameOver, int timeData, byte tps, long rand0, long rand1, byte[] coreData){
         try{
             if(wave > state.wave){

--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -537,7 +537,7 @@ public class NetClient implements ApplicationListener{
         }
     }
 
-    @Remote(priority = PacketPriority.low, unreliable = true)
+    @Remote(variants = Variant.both, priority = PacketPriority.low, unreliable = true)
     public static void entitySnapshot(short amount, byte[] data){
         try{
             netClient.lastSnapshotTimestamp = Time.millis();

--- a/core/src/mindustry/core/NetServer.java
+++ b/core/src/mindustry/core/NetServer.java
@@ -115,8 +115,8 @@ public class NetServer implements ApplicationListener{
     /** Cooldown between votes in seconds. */
     public static int voteCooldown = 60 * 5;
     /**
-     * If this is true, the check for some hidden entities will be skipped if fog of war is disabled.
-     * Set this to false if a mod uses isSyncHidden to hide entities even when fog of war is disabled.
+     * If this is true, isSyncHidden will called only once per team if FoW is enabled, or not at all.
+     * Set this to false if a mod uses isSyncHidden to hide entities.
      */
     public boolean skipHiddenEntitiesCheck = true;
 
@@ -134,7 +134,7 @@ public class NetServer implements ApplicationListener{
     private ObjectMap<String, Seq<Cons2<Player, byte[]>>> customBinaryPacketHandlers = new ObjectMap<>();
     /** Packet handlers for logic client data */
     private ObjectMap<String, Seq<Cons2<Player, Object>>> logicClientDataHandlers = new ObjectMap<>();
-    /** Reused Seq<Player> for writing entity snapshots */
+    /** Reused Seq<Player> for writing entity snapshots per team. */
     private Seq<Player> playersToSend = new Seq<>(false);
 
     public NetServer(){
@@ -1286,6 +1286,7 @@ public class NetServer implements ApplicationListener{
 
     void sync(){
         try{
+            int interval = Config.snapshotInterval.num();
             Groups.player.each(p -> !p.isLocal(), player -> {
                 if(player.con == null || !player.con.isConnected()){
                     onDisconnect(player, "disappeared");
@@ -1293,7 +1294,6 @@ public class NetServer implements ApplicationListener{
                 }
             });
 
-            int interval = Config.snapshotInterval.num();
             boolean someNeedsSnapshot = Groups.player.contains(p -> Time.timeSinceMillis(p.con.syncTime) >= interval);
 
             if(someNeedsSnapshot){
@@ -1306,6 +1306,7 @@ public class NetServer implements ApplicationListener{
 
             if(skipHiddenEntitiesCheck){
                 if(Vars.state.rules.fog){
+                    //Serialize by teams and use TeamData.syncTime
                     for(Team team : Team.all){ //Not Teams.active, because players can be on inactive teams
                         var tdata = team.data();
                         playersToSend.selectFrom(tdata.players, p -> !p.isLocal() && p.con.hasConnected);
@@ -1319,11 +1320,13 @@ public class NetServer implements ApplicationListener{
                         }
                     }
                 } else {
+                    //Serialize once for all players and use NetConnection.syncTime
                     if(someNeedsSnapshot){
                         writeEntitySnapshotsAll();
                     }
                 }
             } else {
+                //Serialize for each player and use NetConnection.syncTime
                 Groups.player.each(p -> !p.isLocal() && p.con.hasConnected, player -> {
                     var connection = player.con;
 

--- a/core/src/mindustry/core/NetServer.java
+++ b/core/src/mindustry/core/NetServer.java
@@ -134,6 +134,8 @@ public class NetServer implements ApplicationListener{
     private ObjectMap<String, Seq<Cons2<Player, byte[]>>> customBinaryPacketHandlers = new ObjectMap<>();
     /** Packet handlers for logic client data */
     private ObjectMap<String, Seq<Cons2<Player, Object>>> logicClientDataHandlers = new ObjectMap<>();
+    /** Reused Seq<Player> for writing entity snapshots */
+    private Seq<Player> playersToSend = new Seq<>(false);
 
     public NetServer(){
 
@@ -1090,7 +1092,7 @@ public class NetServer implements ApplicationListener{
         }
     }
 
-    public void serializeStateSnapshot(){
+    public void writeStateSnapshot() throws IOException{
         byte tps = (byte)Math.min(Core.graphics.getFramesPerSecond(), 255);
         syncStream.reset();
         int activeTeams = (byte)state.teams.present.count(t -> t.cores.size > 0);
@@ -1107,15 +1109,12 @@ public class NetServer implements ApplicationListener{
         }
 
         dataStream.close();
+
+        Call.stateSnapshot(state.wavetime, state.wave, state.enemies, state.isPaused(), state.gameOver,
+        universe.seconds(), tps, GlobalVars.rand.seed0, GlobalVars.rand.seed1, syncStream.toByteArray());
     }
 
     public void writeEntitySnapshot(Player player) throws IOException{
-
-        //write basic state data.
-        serializeStateSnapshot();
-        Call.stateSnapshot(player.con, state.wavetime, state.wave, state.enemies, state.isPaused(), state.gameOver,
-        universe.seconds(), tps, GlobalVars.rand.seed0, GlobalVars.rand.seed1, syncStream.toByteArray());
-
         syncStream.reset();
 
         hiddenIds.clear();
@@ -1158,12 +1157,7 @@ public class NetServer implements ApplicationListener{
     }
 
     /** Does not check isSyncHidden. Call this if no entities are hidden. */
-    public void writeSharedEntitySnapshots() throws IOException{
-        //write basic state data.
-        serializeStateSnapshot();
-        Call.stateSnapshot(state.wavetime, state.wave, state.enemies, state.isPaused(), state.gameOver,
-        universe.seconds(), tps, GlobalVars.rand.seed0, GlobalVars.rand.seed1, syncStream.toByteArray());
-
+    public void writeEntitySnapshotsAll() throws IOException{
         syncStream.reset();
 
         int sent = 0;
@@ -1191,7 +1185,54 @@ public class NetServer implements ApplicationListener{
             Call.entitySnapshot((short)sent, syncStream.toByteArray());
         }
 
-        Groups.player.each(p -> p.con.snapshotsSent++);
+        Groups.player.each(p -> {
+            p.con.snapshotsSent++;
+            p.con.syncTime = Time.millis();
+        });
+    }
+
+    /** Checks isSyncHidden for only one player per team. Called if FoW is enabled but there is no custom syncHidden. */
+    public void writeEntitySnapshotsTeam(Seq<Player> players) throws IOException{
+        syncStream.reset();
+
+        hiddenIds.clear();
+        int sent = 0;
+
+        for(Syncc entity : Groups.sync){
+            //TODO write to special list
+            if(entity.isSyncHidden(players.first())){
+                hiddenIds.add(entity.id());
+                continue;
+            }
+
+            //write all entities now
+            dataStream.writeInt(entity.id()); //write id
+            dataStream.writeByte(entity.classId() & 0xFF); //write type ID
+            entity.beforeWrite();
+            entity.writeSync(dataStreamWrites); //write entity itself
+
+            sent++;
+
+            if(syncStream.size() > maxSnapshotSize){
+                dataStream.close();
+                final var ssent = (short)sent;
+                players.each(player -> Call.entitySnapshot(player.con, (short)ssent, syncStream.toByteArray()));
+                sent = 0;
+                syncStream.reset();
+            }
+        }
+
+        if(sent > 0){
+            dataStream.close();
+            final var ssent = (short)sent;
+            players.each(player -> Call.entitySnapshot(player.con, ssent, syncStream.toByteArray()));
+        }
+
+        if(hiddenIds.size > 0){
+            players.each(player -> Call.hiddenSnapshot(player.con, hiddenIds));
+        }
+
+        players.each(player -> player.con.snapshotsSent++);
     }
 
     public String fixName(String name){
@@ -1245,18 +1286,45 @@ public class NetServer implements ApplicationListener{
 
     void sync(){
         try{
-            int interval = Config.snapshotInterval.num();
-
-            boolean shareSnapshot = !Vars.state.rules.fog && (skipHiddenEntitiesCheck ||
-                Groups.player.contains(p -> Groups.sync.contains(e -> e.isSyncHidden(p))));
-
             Groups.player.each(p -> !p.isLocal(), player -> {
                 if(player.con == null || !player.con.isConnected()){
                     onDisconnect(player, "disappeared");
                     return;
                 }
+            });
 
-                if(!shareSnapshot){
+            int interval = Config.snapshotInterval.num();
+            boolean someNeedsSnapshot = Groups.player.contains(p -> Time.timeSinceMillis(p.con.syncTime) >= interval);
+
+            if(someNeedsSnapshot){
+                try{
+                    writeStateSnapshot();
+                }catch(IOException e){
+                    Log.err(e);
+                }
+            }
+
+            if(skipHiddenEntitiesCheck){
+                if(Vars.state.rules.fog){
+                    for(Team team : Team.all){ //Not Teams.active, because players can be on inactive teams
+                        var tdata = team.data();
+                        playersToSend.selectFrom(tdata.players, p -> !p.isLocal() && p.con.hasConnected);
+                        if(!playersToSend.isEmpty() && Time.timeSinceMillis(tdata.syncTime) >= interval){
+                            tdata.syncTime = Time.millis();
+                            try{
+                                writeEntitySnapshotsTeam(playersToSend);
+                            }catch(IOException e){
+                                Log.err(e);
+                            }
+                        }
+                    }
+                } else {
+                    if(someNeedsSnapshot){
+                        writeEntitySnapshotsAll();
+                    }
+                }
+            } else {
+                Groups.player.each(p -> !p.isLocal() && p.con.hasConnected, player -> {
                     var connection = player.con;
 
                     if(Time.timeSinceMillis(connection.syncTime) < interval || !connection.hasConnected) return;
@@ -1268,11 +1336,7 @@ public class NetServer implements ApplicationListener{
                     }catch(IOException e){
                         Log.err(e);
                     }
-                }
-            });
-
-            if(shareSnapshot && Groups.player.contains(p -> Time.timeSinceMillis(p.con.syncTime) >= interval)){
-                writeSharedEntitySnapshots();
+                });
             }
 
             if(Groups.player.size() > 0 && Core.settings.getBool("blocksync") && blockSyncTime.poll()){

--- a/core/src/mindustry/core/NetServer.java
+++ b/core/src/mindustry/core/NetServer.java
@@ -114,6 +114,11 @@ public class NetServer implements ApplicationListener{
     public static float voteDuration = 0.5f * 60;
     /** Cooldown between votes in seconds. */
     public static int voteCooldown = 60 * 5;
+    /**
+     * If this is true, the check for some hidden entities will be skipped if fog of war is disabled.
+     * Set this to false if a mod uses isSyncHidden to hide entities even when fog of war is disabled.
+     */
+    public boolean skipHiddenEntitiesCheck = true;
 
     private ReusableByteOutStream writeBuffer = new ReusableByteOutStream(127);
     private Writes outputBuffer = new Writes(new DataOutputStream(writeBuffer));
@@ -1085,7 +1090,7 @@ public class NetServer implements ApplicationListener{
         }
     }
 
-    public void writeEntitySnapshot(Player player) throws IOException{
+    public void serializeStateSnapshot(){
         byte tps = (byte)Math.min(Core.graphics.getFramesPerSecond(), 255);
         syncStream.reset();
         int activeTeams = (byte)state.teams.present.count(t -> t.cores.size > 0);
@@ -1102,8 +1107,12 @@ public class NetServer implements ApplicationListener{
         }
 
         dataStream.close();
+    }
+
+    public void writeEntitySnapshot(Player player) throws IOException{
 
         //write basic state data.
+        serializeStateSnapshot();
         Call.stateSnapshot(player.con, state.wavetime, state.wave, state.enemies, state.isPaused(), state.gameOver,
         universe.seconds(), tps, GlobalVars.rand.seed0, GlobalVars.rand.seed1, syncStream.toByteArray());
 
@@ -1146,6 +1155,43 @@ public class NetServer implements ApplicationListener{
         }
 
         player.con.snapshotsSent++;
+    }
+
+    /** Does not check isSyncHidden. Call this if no entities are hidden. */
+    public void writeSharedEntitySnapshots() throws IOException{
+        //write basic state data.
+        serializeStateSnapshot();
+        Call.stateSnapshot(state.wavetime, state.wave, state.enemies, state.isPaused(), state.gameOver,
+        universe.seconds(), tps, GlobalVars.rand.seed0, GlobalVars.rand.seed1, syncStream.toByteArray());
+
+        syncStream.reset();
+
+        int sent = 0;
+
+        for(Syncc entity : Groups.sync){
+            //write all entities now
+            dataStream.writeInt(entity.id()); //write id
+            dataStream.writeByte(entity.classId() & 0xFF); //write type ID
+            entity.beforeWrite();
+            entity.writeSync(dataStreamWrites); //write entity itself
+
+            sent++;
+
+            if(syncStream.size() > maxSnapshotSize){
+                dataStream.close();
+                Call.entitySnapshot((short)sent, syncStream.toByteArray());
+                sent = 0;
+                syncStream.reset();
+            }
+        }
+
+        if(sent > 0){
+            dataStream.close();
+
+            Call.entitySnapshot((short)sent, syncStream.toByteArray());
+        }
+
+        Groups.player.each(p -> p.con.snapshotsSent++);
     }
 
     public String fixName(String name){
@@ -1200,24 +1246,34 @@ public class NetServer implements ApplicationListener{
     void sync(){
         try{
             int interval = Config.snapshotInterval.num();
+
+            boolean shareSnapshot = !Vars.state.rules.fog && (skipHiddenEntitiesCheck ||
+                Groups.player.contains(p -> Groups.sync.contains(e -> e.isSyncHidden(p))));
+
             Groups.player.each(p -> !p.isLocal(), player -> {
                 if(player.con == null || !player.con.isConnected()){
                     onDisconnect(player, "disappeared");
                     return;
                 }
 
-                var connection = player.con;
+                if(!shareSnapshot){
+                    var connection = player.con;
 
-                if(Time.timeSinceMillis(connection.syncTime) < interval || !connection.hasConnected) return;
+                    if(Time.timeSinceMillis(connection.syncTime) < interval || !connection.hasConnected) return;
 
-                connection.syncTime = Time.millis();
+                    connection.syncTime = Time.millis();
 
-                try{
-                    writeEntitySnapshot(player);
-                }catch(IOException e){
-                    Log.err(e);
+                    try{
+                        writeEntitySnapshot(player);
+                    }catch(IOException e){
+                        Log.err(e);
+                    }
                 }
             });
+
+            if(shareSnapshot && Groups.player.contains(p -> Time.timeSinceMillis(p.con.syncTime) >= interval)){
+                writeSharedEntitySnapshots();
+            }
 
             if(Groups.player.size() > 0 && Core.settings.getBool("blocksync") && blockSyncTime.poll()){
                 writeBlockSnapshots();

--- a/core/src/mindustry/core/NetServer.java
+++ b/core/src/mindustry/core/NetServer.java
@@ -136,6 +136,8 @@ public class NetServer implements ApplicationListener{
     private ObjectMap<String, Seq<Cons2<Player, Object>>> logicClientDataHandlers = new ObjectMap<>();
     /** Reused Seq<Player> for writing entity snapshots per team. */
     private Seq<Player> playersToSend = new Seq<>(false);
+    /** Used for entity snapshot timing. */
+    public long snapshotSyncTime;
 
     public NetServer(){
 
@@ -1185,10 +1187,7 @@ public class NetServer implements ApplicationListener{
             Call.entitySnapshot((short)sent, syncStream.toByteArray());
         }
 
-        Groups.player.each(p -> {
-            p.con.snapshotsSent++;
-            p.con.syncTime = Time.millis();
-        });
+        Groups.player.each(p -> p.con.snapshotsSent++);
     }
 
     /** Checks isSyncHidden for only one player per team. Called if FoW is enabled but there is no custom syncHidden. */
@@ -1216,7 +1215,8 @@ public class NetServer implements ApplicationListener{
             if(syncStream.size() > maxSnapshotSize){
                 dataStream.close();
                 final var ssent = (short)sent;
-                players.each(player -> Call.entitySnapshot(player.con, (short)ssent, syncStream.toByteArray()));
+                var bytes = syncStream.toByteArray();
+                players.each(player -> Call.entitySnapshot(player.con, ssent, bytes));
                 sent = 0;
                 syncStream.reset();
             }
@@ -1225,7 +1225,8 @@ public class NetServer implements ApplicationListener{
         if(sent > 0){
             dataStream.close();
             final var ssent = (short)sent;
-            players.each(player -> Call.entitySnapshot(player.con, ssent, syncStream.toByteArray()));
+            var bytes = syncStream.toByteArray();
+            players.each(player -> Call.entitySnapshot(player.con, ssent, bytes));
         }
 
         if(hiddenIds.size > 0){
@@ -1294,53 +1295,37 @@ public class NetServer implements ApplicationListener{
                 }
             });
 
-            boolean someNeedsSnapshot = Groups.player.contains(p -> Time.timeSinceMillis(p.con.syncTime) >= interval);
+            if(Time.timeSinceMillis(snapshotSyncTime) >= interval){
+                snapshotSyncTime = Time.millis();
 
-            if(someNeedsSnapshot){
-                try{
-                    writeStateSnapshot();
-                }catch(IOException e){
-                    Log.err(e);
-                }
-            }
+                writeStateSnapshot();
 
-            if(skipHiddenEntitiesCheck){
-                if(Vars.state.rules.fog){
-                    //Serialize by teams and use TeamData.syncTime
-                    for(Team team : Team.all){ //Not Teams.active, because players can be on inactive teams
-                        var tdata = team.data();
-                        playersToSend.selectFrom(tdata.players, p -> !p.isLocal() && p.con.hasConnected);
-                        if(!playersToSend.isEmpty() && Time.timeSinceMillis(tdata.syncTime) >= interval){
-                            tdata.syncTime = Time.millis();
-                            try{
+                if(skipHiddenEntitiesCheck){
+                    if(Vars.state.rules.fog){
+                        //Serialize by teams
+                        for(Team team : Team.all){ //Not Teams.active, because players can be on inactive teams
+                            var tdata = team.data();
+                            playersToSend.selectFrom(tdata.players, p -> !p.isLocal() && p.con.hasConnected);
+                            if(!playersToSend.isEmpty()){
                                 writeEntitySnapshotsTeam(playersToSend);
-                            }catch(IOException e){
-                                Log.err(e);
                             }
                         }
-                    }
-                } else {
-                    //Serialize once for all players and use NetConnection.syncTime
-                    if(someNeedsSnapshot){
+                    }else{
+                        //Serialize once for all players
                         writeEntitySnapshotsAll();
                     }
+                }else{
+                    //Serialize for each player
+                    Groups.player.each(p -> !p.isLocal() && p.con.hasConnected, player -> {
+                        try{
+                            writeEntitySnapshot(player);
+                        }catch(IOException e){
+                            Log.err(e);
+                        }
+                    });
                 }
-            } else {
-                //Serialize for each player and use NetConnection.syncTime
-                Groups.player.each(p -> !p.isLocal() && p.con.hasConnected, player -> {
-                    var connection = player.con;
-
-                    if(Time.timeSinceMillis(connection.syncTime) < interval || !connection.hasConnected) return;
-
-                    connection.syncTime = Time.millis();
-
-                    try{
-                        writeEntitySnapshot(player);
-                    }catch(IOException e){
-                        Log.err(e);
-                    }
-                });
             }
+
 
             if(Groups.player.size() > 0 && Core.settings.getBool("blocksync") && blockSyncTime.poll()){
                 writeBlockSnapshots();

--- a/core/src/mindustry/game/Teams.java
+++ b/core/src/mindustry/game/Teams.java
@@ -310,8 +310,6 @@ public class Teams{
         public Seq<Building> buildings = new Seq<>(false);
         /** Units of this team by type. Updated each frame. */
         public @Nullable Seq<Unit>[] unitsByType;
-        /** Used for writing entity snapshots. */
-        public long syncTime;
 
         public TeamData(Team team){
             this.team = team;

--- a/core/src/mindustry/game/Teams.java
+++ b/core/src/mindustry/game/Teams.java
@@ -310,6 +310,8 @@ public class Teams{
         public Seq<Building> buildings = new Seq<>(false);
         /** Units of this team by type. Updated each frame. */
         public @Nullable Seq<Unit>[] unitsByType;
+        /** Used for writing entity snapshots. */
+        public long syncTime;
 
         public TeamData(Team team){
             this.team = team;

--- a/core/src/mindustry/net/NetConnection.java
+++ b/core/src/mindustry/net/NetConnection.java
@@ -16,7 +16,6 @@ public abstract class NetConnection{
     public boolean mobile, modclient;
     public @Nullable Player player;
     public boolean kicked = false;
-    public long syncTime;
 
     /** When this connection was established. */
     public long connectTime = Time.millis();


### PR DESCRIPTION
Currently, entity snapshots are written once for each player, because some entities can be hidden. In vanilla this is only used for fog of war, but it may also be used by mods.

In lategame attack maps, this requires serializing thousands of entities for up to 20 players, which is inefficient.

Previously:

<img width="1594" height="827" alt="image" src="https://github.com/user-attachments/assets/44e68ba8-d136-48c3-8a33-a77366b2604b" />

This PR changes entity snapshot serialization to use one of three options:
a) Always send all entities, serializing only once. This is used when FoW is off.
b) Serialize entities once for each team, and only call isSyncHidden for the first player in each team. This is used when FoW is off.
c) Serialize entities once per player and call isSyncHidden once per player. This is used when a flag is set, and is required for mods or plugins that use isSyncHidden to show entities only to some players.

After the optimization was applied:

<img width="1920" height="1033" alt="image" src="https://github.com/user-attachments/assets/5bfc5330-4c17-4830-9749-b0ca3cdf5946" />

This has been tested and works correctly with (a). This has not yet been tested with fog of war (b) or the flag disabled (c).

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
