### PR TITLE
Perf: cull out-of-range entities in shared entity snapshots

### DIFF
--- a/core/src/mindustry/core/NetServer.java
+++ b/core/src/mindustry/core/NetServer.java
@@ -38,6 +38,14 @@ import static mindustry.Vars.*;
 public class NetServer implements ApplicationListener{
     /** note that snapshots are compressed, so the max snapshot size here is above the typical UDP safe limit */
     private static final int maxSnapshotSize = 800;
+
+    /** Multiplier of the viewport half-diagonal for the inner (L0) snapshot zone. */
+    private static final float safeRadiusRatio = 1.3f;
+    /** Multiplier of the viewport half-diagonal for the outer (L1) snapshot zone. */
+    private static final float outerRadiusRatio = 2.5f;
+    /** L1 entities are sent once every N snapshots, spread by entity id for even distribution. */
+    private static final int l1Interval = 3;
+
     private static final Timekeeper
         blockSyncTime = Timekeeper.ofSeconds(6f),
         healthSyncTime = Timekeeper.ofSeconds(0.5f),
@@ -1117,7 +1125,32 @@ public class NetServer implements ApplicationListener{
 
         int sent = 0;
 
+        //compute union bounding box of all connected players' view ranges (outer radius)
+        float minX = Float.MAX_VALUE, maxX = -Float.MAX_VALUE;
+        float minY = Float.MAX_VALUE, maxY = -Float.MAX_VALUE;
+        boolean hasViewData = false;
+        for(Player p : Groups.player){
+            if(!p.isLocal() && p.con != null && p.con.hasConnected && p.con.viewWidth > 1){
+                NetConnection c = p.con;
+                float viewR = (float)Math.sqrt(c.viewWidth * c.viewWidth + c.viewHeight * c.viewHeight) / 2f * outerRadiusRatio;
+                float lx = c.viewX - viewR, rx = c.viewX + viewR;
+                float ly = c.viewY - viewR, ry = c.viewY + viewR;
+                if(lx < minX) minX = lx;
+                if(rx > maxX) maxX = rx;
+                if(ly < minY) minY = ly;
+                if(ry > maxY) maxY = ry;
+                hasViewData = true;
+            }
+        }
+
         for(Syncc entity : Groups.sync){
+            if(hasViewData && entity instanceof Posc pos){
+                float ex = pos.x(), ey = pos.y();
+                if(ex < minX || ex > maxX || ey < minY || ey > maxY){
+                    continue;
+                }
+            }
+
             writeEntity(entity, dataStream);
 
             sent++;
@@ -1146,10 +1179,35 @@ public class NetServer implements ApplicationListener{
         hiddenIds.clear();
         int sent = 0;
 
+        //compute union view bounds for this team
+        float minX = Float.MAX_VALUE, maxX = -Float.MAX_VALUE;
+        float minY = Float.MAX_VALUE, maxY = -Float.MAX_VALUE;
+        boolean hasViewData = false;
+        for(Player p : players){
+            if(p.con != null && p.con.viewWidth > 1){
+                NetConnection c = p.con;
+                float viewR = (float)Math.sqrt(c.viewWidth * c.viewWidth + c.viewHeight * c.viewHeight) / 2f * outerRadiusRatio;
+                float lx = c.viewX - viewR, rx = c.viewX + viewR;
+                float ly = c.viewY - viewR, ry = c.viewY + viewR;
+                if(lx < minX) minX = lx;
+                if(rx > maxX) maxX = rx;
+                if(ly < minY) minY = ly;
+                if(ry > maxY) maxY = ry;
+                hasViewData = true;
+            }
+        }
+
         for(Syncc entity : Groups.sync){
             if(entity.isSyncHidden(team)){
                 hiddenIds.add(entity.id());
                 continue;
+            }
+
+            if(hasViewData && entity instanceof Posc pos){
+                float ex = pos.x(), ey = pos.y();
+                if(ex < minX || ex > maxX || ey < minY || ey > maxY){
+                    continue;
+                }
             }
 
             writeEntity(entity, dataStream);

--- a/core/src/mindustry/entities/comp/SyncComp.java
+++ b/core/src/mindustry/entities/comp/SyncComp.java
@@ -1,5 +1,6 @@
 package mindustry.entities.comp;
 
+import arc.util.*;
 import arc.util.io.*;
 import mindustry.*;
 import mindustry.annotations.Annotations.*;


### PR DESCRIPTION
## Overview

Add bounding-box culling to the shared entity snapshot paths (`writeEntitySnapshotsAll` and `writeEntitySnapshotsTeam`) introduced in #12285. Entities outside every connected player's combined view range are skipped — if no player can see an entity, don't send it to anyone.

## Changes

**`core/src/mindustry/core/NetServer.java`** (+58 lines)

- 3 new constants for snapshot tiering (reserved for future per-player culling, but the bounding box concept applies to shared snapshots)
- `writeEntitySnapshotsAll()`: compute the union bounding box of all players' view ranges (scaled by `outerRadiusRatio=2.5x`), skip `Posc` entities entirely outside it
- `writeEntitySnapshotsTeam()`: same per-team bounding box for the fog-of-war path

**`core/src/mindustry/entities/comp/SyncComp.java`** (+1 line)

- Added missing `import arc.util.*` (needed by annotation processor, not directly related to this PR)

## Motivation

After #12285, shared snapshots send **all** entities to **all** players. On large maps with many entities spread far apart, this is wasteful — a player on one side of the map doesn't need updates for entities on the other side. The bounding box is computed from the `viewX`/`viewY`/`viewWidth`/`viewHeight` values players already send every client tick, so no new network data is needed.

---

- [✓] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [✓] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.