### PR TITLE
A functional not so buggy reload fix

### DIFF
--- a/core/src/mindustry/world/blocks/defense/turrets/PointDefenseTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/PointDefenseTurret.java
@@ -71,7 +71,7 @@ public class PointDefenseTurret extends ReloadTurret{
                 target = null;
             }
 
-            if(coolant != null){
+            if(coolant != null && reloadCounter < reload){
                 updateCooling();
             }
 

--- a/core/src/mindustry/world/blocks/defense/turrets/ReloadTurret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/ReloadTurret.java
@@ -26,7 +26,7 @@ public class ReloadTurret extends BaseTurret{
         public float reloadCounter;
 
         protected void updateCooling(){
-            if(canReload() && coolant != null && coolant.efficiency(this) > 0 && efficiency > 0){
+            if(coolant != null && coolant.efficiency(this) > 0 && efficiency > 0){
                 float capacity = coolant instanceof ConsumeLiquidFilter filter ? filter.getConsumed(this).heatCapacity : (coolant.consumes(liquids.current()) ? liquids.current().heatCapacity : 0.4f);
                 float amount = coolant.amount * coolant.efficiency(this);
                 coolant.update(this);
@@ -44,10 +44,6 @@ public class ReloadTurret extends BaseTurret{
 
         protected float baseReloadSpeed(){
             return efficiency;
-        }
-
-        protected boolean canReload(){
-            return reloadCounter < reload;
         }
     }
 }

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -544,11 +544,7 @@ public class Turret extends ReloadTurret{
                 ((Building)this).rotation = Mathf.mod(Mathf.round(rotation / 90f), 4);
             }
 
-            //turret always reloads regardless of whether it's targeting something
-            if(reloadWhileCharging || !charging()){
-                updateReload();
-                updateCooling();
-            }
+            handleReload();
 
             if(state.rules.fog){
                 float newRange = hasAmmo() ? peekAmmo().rangeChange : 0f;
@@ -716,8 +712,17 @@ public class Turret extends ReloadTurret{
             return queuedBullets > 0 && shoot.firstShotDelay > 0;
         }
 
+        protected void handleReload(){
+            //turret always reloads regardless of whether it's targeting something
+            if(reloadWhileCharging || !charging() && reloadCounter < reload){
+                //update the two reload related methods
+                updateReload();
+                updateCooling();
+            }
+        }
+
         protected void updateReload(){
-            if(reloadCounter < reload) reloadCounter += delta() * ammoReloadMultiplier() * baseReloadSpeed();
+            reloadCounter += delta() * ammoReloadMultiplier() * baseReloadSpeed();
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/defense/turrets/Turret.java
+++ b/core/src/mindustry/world/blocks/defense/turrets/Turret.java
@@ -714,7 +714,7 @@ public class Turret extends ReloadTurret{
 
         protected void handleReload(){
             //turret always reloads regardless of whether it's targeting something
-            if(reloadWhileCharging || !charging() && reloadCounter < reload){
+            if((reloadWhileCharging || !charging()) && reloadCounter < reload){
                 //update the two reload related methods
                 updateReload();
                 updateCooling();


### PR DESCRIPTION
This is a better version of https://github.com/Anuken/Mindustry/pull/11661 that shouldn't break anything.

This handles or fixes the case where the cooling reload doesn't go through due to updateReload blocking updateCoolant from being accounted for.
I removed the unused canReload() since... use handleReload() instead. And the reloadCounter < reload condition for updateCoolant is only added into the one non-Turret.java class manually... (PointDefenseTurret.java)

If any subclass adds like a updateItemCoolant() as an example, or if the if condition should be altered, handleReload() should help w/o requiring to mess up updateTile()

#### [A1] Firerate differences w/ Cyclone... all correct.
https://github.com/user-attachments/assets/496325de-3d3b-450d-838c-8f4474744039


**Q: (Shouldn't the changes be counternerfed due to the buffs?)**
_A: Turns out the changes in Blocks.java weren't reverted in the original reversion... so I don't need to... https://github.com/Anuken/Mindustry/commit/d90c830b2770556094951ada0eee4b1abc6a5968_
Or by checking the diff and seeing Blocks.java, and seeing the current stats and find that they weren't reverted... https://github.com/Anuken/Mindustry/pull/11245/changes#diff-5fcb58432c6c68d32771609241d663343e35cbd86baa58c85923fdb9890748be

**Q: (You shouldn't buff cyclone/swarmer!)**
_A: I already did the counternerf required months ago, do a seperate pr/suggestion post. I'm not dealing with any form of official balancing at all, but I do want this weird behavior altered._

**Q: (What happens when the reloadCounter goes past 2x the reload? The modulo induces a loss)**
_A: Learned my lesson to not handle what if cases that doesn't appear... if it does happen a seperate suggestion post or pr is preffered. It made the original pr a bit... more complicated than it needed to be due to me trying to handle this scenario._

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [n/a] I have ensured that any new features in this PR function correctly in-game, if applicable.
