### PR TITLE
Fixing minor text issue in bundle_vi.properties

### DIFF
--- a/core/assets/bundles/bundle_vi.properties
+++ b/core/assets/bundles/bundle_vi.properties
@@ -951,7 +951,7 @@ difficulty.guide.title = Lưu ý
 difficulty.guide = Nếu một phân khu nào đó gây quá nhiều thử thách, độ khó của chiến dịch có thể được điều chỉnh để mang lại trải nghiệm dễ dàng hơn.
 difficulty.guide.confirm = Điều Chỉnh Độ Khó
 
-difficulty.casual = Giải trí
+difficulty.casual = Giải trí
 difficulty.easy = Dễ
 difficulty.normal = Vừa
 difficulty.hard = Khó


### PR DESCRIPTION
Currently, the string for Casual difficulty has rendering issue in Vietnamese - the actual text in-game doesn't match to what's seen in bundle_vi.properties because of shifted diacritics.
My retype fixes that (extremely) minor issue that could annoy a small group of people.
The problem might be related to different Unicode handling. Edited text looks exactly the same in the editor, but it doesn't have the said issue which, might affect future translations proposed by other people.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [ ] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
