### PR TITLE
Titanium Conveyor-related transport blocks displaySpeed polishing

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -2100,7 +2100,6 @@ public class Blocks{
             capacity = 6;
             health = 30;
             buildCostMultiplier = 3f;
-            displayedSpeed = 10f;
         }};
 
         itemBridge = new BufferedItemBridge("bridge-conveyor"){{

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -2091,7 +2091,7 @@ public class Blocks{
             requirements(Category.distribution, with(Items.plastanium, 1, Items.thorium, 1, Items.metaglass, 1));
             health = 280;
             speed = 0.08f;
-            displayedSpeed = 11f;
+            displayedSpeed = 10f;
         }};
 
         junction = new Junction("junction"){{
@@ -2100,6 +2100,7 @@ public class Blocks{
             capacity = 6;
             health = 30;
             buildCostMultiplier = 3f;
+            displayedSpeed = 10f;
         }};
 
         itemBridge = new BufferedItemBridge("bridge-conveyor"){{

--- a/core/src/mindustry/world/blocks/distribution/Junction.java
+++ b/core/src/mindustry/world/blocks/distribution/Junction.java
@@ -12,7 +12,7 @@ import static mindustry.Vars.*;
 public class Junction extends Block{
     public float speed = 26; //frames taken to go through this junction
     public int capacity = 6;
-    public float displayedSpeed = 13f;
+    public float displayedSpeed = 10f;
 
     public Junction(String name){
         super(name);

--- a/core/src/mindustry/world/blocks/distribution/Junction.java
+++ b/core/src/mindustry/world/blocks/distribution/Junction.java
@@ -12,7 +12,7 @@ import static mindustry.Vars.*;
 public class Junction extends Block{
     public float speed = 26; //frames taken to go through this junction
     public int capacity = 6;
-    public float displayedSpeed = 10f;
+    public float displayedSpeed = 13f;
 
     public Junction(String name){
         super(name);


### PR DESCRIPTION
With the displayed speed of titanium conveyor changed to include FPS/TPS-related inaccuracies, Armored Conveyor and Junction should also be changed to reflect that and be more consistent. _again, it's only a database info edit_

#### Armored conveyor;
<img width="350" height="283" alt="armo" src="https://github.com/user-attachments/assets/98a695a3-617f-494c-9392-7d600c79211c" />

#### Junction;
<img width="394" height="290" alt="junc" src="https://github.com/user-attachments/assets/775a8015-854d-4800-86ff-7e99346cfdb5" />

Sadly, Bridge Conveyors don't have a displaySpeed field, and I'm not confident enough to introduce actual new code yet. _even though it's probably a copy-paste_


If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
