### PR TITLE
Fix disabled HeatConductors still redirecting heat

### DIFF
--- a/core/src/mindustry/world/blocks/heat/HeatConductor.java
+++ b/core/src/mindustry/world/blocks/heat/HeatConductor.java
@@ -23,6 +23,7 @@ public class HeatConductor extends Block{
         update = solid = rotate = true;
         rotateDraw = false;
         size = 3;
+        noUpdateDisabled = true;
     }
 
     @Override
@@ -86,7 +87,7 @@ public class HeatConductor extends Block{
             if(lastHeatUpdate == Vars.state.updateId) return;
 
             lastHeatUpdate = Vars.state.updateId;
-            heat = calculateHeat(sideHeat, cameFrom);
+            heat = enabled ? calculateHeat(sideHeat, cameFrom) : 0f;
         }
 
         @Override


### PR DESCRIPTION
Disabling a heat redirector/router via logic had no effect, heat kept flowing through it.

The cause was that neighboring blocks force-call `HeatConductorBuild.updateHeat()` directly in `calculateHeat()`, bypassing the normal `enabled`/`update()` gate.

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
