### PR TITLE
Set result to null when sensor fails

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -691,6 +691,7 @@ public class LExecutor{
             if(target instanceof Senseable se){
                 if(sense instanceof Content co){
                     to.setnum(se.sense(co));
+                    return;
                 }else if(sense instanceof LAccess la){
                     Object objOut = se.senseObject(la);
 
@@ -701,6 +702,7 @@ public class LExecutor{
                         //object output
                         to.setobj(objOut);
                     }
+                    return;
                 }
             }else{
                 if(sense == LAccess.size || sense == LAccess.bufferSize){
@@ -712,9 +714,10 @@ public class LExecutor{
                         return;
                     }
                 }
-
-                to.setobj(null);
             }
+
+            //unrecognized or unhandled property
+            to.setobj(null);
         }
     }
 


### PR DESCRIPTION
When `sensor` fails due to unknown or unsupported property, the output variable is left unmodified instead of being set to `null` as is customary for other failed operations. Example:

This code prints `1`:
```
set result 1
sensor result @this null
print result
printflush message1
```

After the fix, the code prints `null`.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
