### PR TITLE
Fix fortress and collaris bullets dying before reaching their intended position

### DIFF
--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -173,8 +173,8 @@ public class UnitTypes{
                 bullet = new ArtilleryBulletType(2f, 20, "shell"){{
                     hitEffect = Fx.blastExplosion;
                     knockback = 0.8f;
-                    lifetime = 120f;
-                    maxRange = 240f;
+                    lifetime = 120f - (35f - 8f) / 2f;
+                    maxRange = 213f;
                     width = height = 14f;
                     collides = true;
                     collidesTiles = true;
@@ -3680,7 +3680,7 @@ public class UnitTypes{
 
                 bullet = new ArtilleryBulletType(5.5f, 260){{
                     collidesTiles = collides = true;
-                    lifetime = 70f;
+                    lifetime = 60f;
                     shootEffect = Fx.shootBigColor;
                     smokeEffect = Fx.shootSmokeSquareBig;
                     frontColor = Color.white;
@@ -3688,7 +3688,7 @@ public class UnitTypes{
                     hitSound = Sounds.none;
                     width = 18f;
                     height = 24f;
-                    rangeOverride = 385f;
+                    rangeOverride = 330f;
 
                     lightColor = trailColor = hitColor = backColor = Pal.techBlue;
                     lightRadius = 40f;

--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -173,7 +173,7 @@ public class UnitTypes{
                 bullet = new ArtilleryBulletType(2f, 20, "shell"){{
                     hitEffect = Fx.blastExplosion;
                     knockback = 0.8f;
-                    lifetime = 120f - (35f - 8f) / 2f;
+                    lifetime = 120f;
                     maxRange = 240f;
                     width = height = 14f;
                     collides = true;
@@ -3680,7 +3680,7 @@ public class UnitTypes{
 
                 bullet = new ArtilleryBulletType(5.5f, 260){{
                     collidesTiles = collides = true;
-                    lifetime = 60f;
+                    lifetime = 70f;
                     shootEffect = Fx.shootBigColor;
                     smokeEffect = Fx.shootSmokeSquareBig;
                     frontColor = Color.white;


### PR DESCRIPTION
Fixes https://github.com/Anuken/Mindustry/issues/12407

- fortress: maxRange 240 → 213 (2 * 106.5 = 213, matches actual lifetime)
- collaris: rangeOverride 385 → 330 (5.5 * 60 = 330, matches actual lifetime)

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
