### PR TITLE
Fixes tileable displays not working with marker texture after map load

### DIFF
--- a/core/src/mindustry/game/MapObjectives.java
+++ b/core/src/mindustry/game/MapObjectives.java
@@ -1402,8 +1402,8 @@ public class MapObjectives implements Iterable<MapObjective>, Eachable<MapObject
         }else if(texture instanceof UnlockableContent u){
             out.set(u.fullIcon);
         }else if(texture instanceof LogicDisplayBuild d && d.isAdded()){
-            d.ensureBuffer();
-            d.getBufferRegion(out);
+            d.rootDisplay.ensureBuffer();
+            d.rootDisplay.getBufferRegion(out);
         }else if(texture instanceof CanvasBuild c && c.isAdded()){
             c.updateTexture();
             if(c.texture != null) out.set(c.texture);

--- a/core/src/mindustry/world/blocks/logic/TileableLogicDisplay.java
+++ b/core/src/mindustry/world/blocks/logic/TileableLogicDisplay.java
@@ -267,6 +267,16 @@ public class TileableLogicDisplay extends LogicDisplay{
             }
         }
 
+        @Override
+        public void ensureBuffer() {
+            if(buffer == null){
+                buffer = new FrameBuffer(32 * tilesWidth - 2 * frameSize, 32 * tilesHeight - 2 * frameSize);
+                //clear the buffer - some OSs leave garbage in it
+                buffer.begin(backgroundColor);
+                buffer.end();
+            }
+        }
+
         public void updateOthers(){
             for(int i = 0; i < 4; i++){
                 Tile other = tile.nearby(Geometry.d8edge(i));


### PR DESCRIPTION
This PR fixes issues reported here: https://github.com/Anuken/Mindustry/issues/12327

Two bugs were fixed:
* `ensureBuffer()` gets called right after a map load when a texture marker using that display exists and it creates the buffer, but as `ensureBuffer()` wasn't overriden in `TileableLogicDisplayBuild`, a buffer with wrong dimensions got created.
* The texture didn't ensure to refer to the root display in tileable displays.

Tested successfully on the map supplied in the original issue.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
