### PR TITLE
allow memory blocks to store any object

### DIFF
--- a/core/assets/contributors
+++ b/core/assets/contributors
@@ -197,3 +197,4 @@ Denilseven
 Alon
 硫缺铅/PyratiteNoLead
 Space
+Eric Wolf

--- a/core/assets/contributors
+++ b/core/assets/contributors
@@ -199,3 +199,4 @@ NeilGreenFly
 Sunky.MP3G
 jhonnata.andre
 Zaxerf1234
+Eric Wolf

--- a/core/src/mindustry/io/TypeIO.java
+++ b/core/src/mindustry/io/TypeIO.java
@@ -165,33 +165,11 @@ public class TypeIO{
     /** Read the {@code ObjectType} of the next object. */
     public static ObjectType readObjectType(Reads read){
         byte type = read.b();
-        return switch (type){
-            case 0 -> ObjectType.Null;
-            case 1 -> ObjectType.Integer;
-            case 2 -> ObjectType.Long;
-            case 3 -> ObjectType.Float;
-            case 4 -> ObjectType.String;
-            case 5 -> ObjectType.Content;
-            case 6 -> ObjectType.IntSeq;
-            case 7 -> ObjectType.Point2;
-            case 8 -> ObjectType.PointArray;
-            case 9 -> ObjectType.TechNode;
-            case 10 -> ObjectType.Boolean;
-            case 11 -> ObjectType.Double;
-            case 12 -> ObjectType.Building;
-            case 13 -> ObjectType.LAccess;
-            case 14 -> ObjectType.ByteArray;
-            case 15 -> ObjectType.Legacy;
-            case 16 -> ObjectType.BooleanArray;
-            case 17 -> ObjectType.Unit;
-            case 18 -> ObjectType.Vec2Array;
-            case 19 -> ObjectType.Vec2;
-            case 20 -> ObjectType.Team;
-            case 21 -> ObjectType.IntArray;
-            case 22 -> ObjectType.ObjectArray;
-            case 23 -> ObjectType.UnitCommand;
-            default -> throw new IllegalArgumentException("Unknown object type: " + type);
-        };
+        if(0 <= type && type < ObjectType.all.length){
+            return ObjectType.all[type];
+        }
+
+        throw new IllegalArgumentException("Unknown object type: " + type);
     }
 
     public static @Nullable Object readObject(Reads read){
@@ -1436,6 +1414,8 @@ public class TypeIO{
         IntArray        ((byte)21),
         ObjectArray     ((byte)22),
         UnitCommand     ((byte)23);
+
+        static final ObjectType[] all = values();
 
         final byte identifier;
 

--- a/core/src/mindustry/io/TypeIO.java
+++ b/core/src/mindustry/io/TypeIO.java
@@ -41,119 +41,157 @@ import static mindustry.Vars.*;
 public class TypeIO{
     private static final int maxArraySize = 1000, maxByteArraySize = 40_000, maxSyncedPlans = 20;
 
+    /** Write an object, prepending its {@code ObjectType}. */
     public static void writeObject(Writes write, Object object){
         if(object == null){
-            write.b((byte)0);
+            write.b(ObjectType.Null.identifier);
         }else if(object instanceof Integer i){
-            write.b((byte)1);
+            write.b(ObjectType.Integer.identifier);
             write.i(i);
         }else if(object instanceof Long l){
-            write.b((byte)2);
+            write.b(ObjectType.Long.identifier);
             write.l(l);
         }else if(object instanceof Float f){
-            write.b((byte)3);
+            write.b(ObjectType.Float.identifier);
             write.f(f);
         }else if(object instanceof String s){
-            write.b((byte)4);
+            write.b(ObjectType.String.identifier);
             writeString(write, s);
         }else if(object instanceof Content map){
-            write.b((byte)5);
+            write.b(ObjectType.Content.identifier);
             write.b((byte)map.getContentType().ordinal());
             write.s(map.id);
         }else if(object instanceof IntSeq arr){
             if(arr.size > maxArraySize) throw new ArcRuntimeException("Array size too large: " + arr.size);
-            write.b((byte)6);
+            write.b(ObjectType.IntSeq.identifier);
             write.s((short)arr.size);
             for(int i = 0; i < arr.size; i++){
                 write.i(arr.items[i]);
             }
         }else if(object instanceof Point2 p){
-            write.b((byte)7);
+            write.b(ObjectType.Point2.identifier);
             write.i(p.x);
             write.i(p.y);
         }else if(object instanceof Point2[] p){
             //255 is the limit here, because it's a byte for some reason
             if(p.length > 255) throw new ArcRuntimeException("Array size too large: " + p.length);
-            write.b((byte)8);
+            write.b(ObjectType.PointArray.identifier);
             write.b(p.length);
             for(Point2 point2 : p){
                 write.i(point2.pack());
             }
         }else if(object instanceof TechNode map){
-            write.b(9);
+            write.b(ObjectType.TechNode.identifier);
             write.b((byte)map.content.getContentType().ordinal());
             write.s(map.content.id);
         }else if(object instanceof Boolean b){
-            write.b((byte)10);
+            write.b(ObjectType.Boolean.identifier);
             write.bool(b);
         }else if(object instanceof Double d){
-            write.b((byte)11);
-            write.d(d);
+            writeObject(write, d.doubleValue());
         }else if(object instanceof Building b){
-            write.b(12);
+            write.b(ObjectType.Building.identifier);
             write.i(b.pos());
         }else if(object instanceof BuildingBox b){
-            write.b(12);
+            write.b(ObjectType.Building.identifier);
             write.i(b.pos);
         }else if(object instanceof LAccess l){
-            write.b((byte)13);
+            write.b(ObjectType.LAccess.identifier);
             write.s(l.ordinal());
         }else if(object instanceof byte[] b){
             if(b.length > maxByteArraySize) throw new ArcRuntimeException("Array size too large: " + b.length);
-            write.b((byte)14);
+            write.b(ObjectType.ByteArray.identifier);
             write.i(b.length);
             write.b(b);
         }else if(object instanceof boolean[] b){
             if(b.length > maxArraySize) throw new ArcRuntimeException("Array size too large: " + b.length);
 
-            write.b(16);
+            write.b(ObjectType.BooleanArray.identifier);
             write.i(b.length);
             for(boolean bool : b){
                 write.bool(bool);
             }
         }else if(object instanceof Unit u){
-            write.b(17);
+            write.b(ObjectType.Unit.identifier);
             write.i(u.id);
         }else if(object instanceof UnitBox u){
-            write.b(17);
+            write.b(ObjectType.Unit.identifier);
             write.i(u.id);
         }else if(object instanceof Vec2[] vecs){
             if(vecs.length > maxArraySize) throw new ArcRuntimeException("Array size too large: " + vecs.length);
 
-            write.b(18);
+            write.b(ObjectType.Vec2Array.identifier);
             write.s(vecs.length);
             for(Vec2 v : vecs){
                 write.f(v.x);
                 write.f(v.y);
             }
         }else if(object instanceof Vec2 v){
-            write.b((byte)19);
+            write.b(ObjectType.Vec2.identifier);
             write.f(v.x);
             write.f(v.y);
         }else if(object instanceof Team t){
-            write.b((byte)20);
+            write.b(ObjectType.Team.identifier);
             write.b(t.id);
         }else if(object instanceof int[] i){
             if(i.length > maxArraySize) throw new ArcRuntimeException("Array size too large: " + i.length);
 
-            write.b((byte)21);
+            write.b(ObjectType.IntArray.identifier);
             writeInts(write, i);
         }else if(object instanceof Object[] objs){
             if(objs.length > maxArraySize) throw new ArcRuntimeException("Array size too large: " + objs.length);
 
-            write.b((byte)22);
+            write.b(ObjectType.ObjectArray.identifier);
             write.i(objs.length);
             for(Object obj : objs){
                 writeObject(write, obj);
             }
         }else if(object instanceof UnitCommand command){
-            write.b(23);
+            write.b(ObjectType.UnitCommand.identifier);
             write.s(command.id);
         }else if(object instanceof Bullet b || object instanceof Seq<?> s){ //write bullets as null
             write.b((byte)0);
         }else{
             throw new IllegalArgumentException("Unknown object type: " + object.getClass());
         }
+    }
+
+    /** Overload of {@code writeObject(Writes, Object)} which prevents boxing. */
+    public static void writeObject(Writes write, double object){
+        write.b(ObjectType.Double.identifier);
+        write.d(object);
+    }
+
+    /** Read the {@code ObjectType} of the next object. */
+    public static ObjectType readObjectType(Reads read){
+        byte type = read.b();
+        return switch (type){
+            case 0 -> ObjectType.Null;
+            case 1 -> ObjectType.Integer;
+            case 2 -> ObjectType.Long;
+            case 3 -> ObjectType.Float;
+            case 4 -> ObjectType.String;
+            case 5 -> ObjectType.Content;
+            case 6 -> ObjectType.IntSeq;
+            case 7 -> ObjectType.Point2;
+            case 8 -> ObjectType.PointArray;
+            case 9 -> ObjectType.TechNode;
+            case 10 -> ObjectType.Boolean;
+            case 11 -> ObjectType.Double;
+            case 12 -> ObjectType.Building;
+            case 13 -> ObjectType.LAccess;
+            case 14 -> ObjectType.ByteArray;
+            case 15 -> ObjectType.Legacy;
+            case 16 -> ObjectType.BooleanArray;
+            case 17 -> ObjectType.Unit;
+            case 18 -> ObjectType.Vec2Array;
+            case 19 -> ObjectType.Vec2;
+            case 20 -> ObjectType.Team;
+            case 21 -> ObjectType.IntArray;
+            case 22 -> ObjectType.ObjectArray;
+            case 23 -> ObjectType.UnitCommand;
+            default -> throw new IllegalArgumentException("Unknown object type: " + type);
+        };
     }
 
     public static @Nullable Object readObject(Reads read){
@@ -178,16 +216,20 @@ public class TypeIO{
     }
 
     public static @Nullable Object readObject(Reads read, boolean box, @Nullable ContentMapper mapper, boolean safe, boolean allowArrays){
+        ObjectType type = readObjectType(read);
+        return readObject(read, box, mapper, safe, allowArrays, type);
+    }
+
+    public static @Nullable Object readObject(Reads read, boolean box, @Nullable ContentMapper mapper, boolean safe, boolean allowArrays, ObjectType type){
         //use a much lower array size limit for build plans
         int maxArraySize = safe ? TypeIO.maxArraySize : 200;
 
-        byte type = read.b();
         return switch(type){
-            case 0 -> null;
-            case 1 -> read.i();
-            case 2 -> read.l();
-            case 3 -> read.f();
-            case 4 -> {
+            case Null -> null;
+            case Integer -> read.i();
+            case Long -> read.l();
+            case Float -> read.f();
+            case String -> {
                 byte exists = read.b();
                 if(exists != 0){
                     //in a safe context, strings can only be 1200 chars
@@ -196,8 +238,8 @@ public class TypeIO{
                     yield null;
                 }
             }
-            case 5 -> mapper == null ? content.getByID(ContentType.all[read.b()], read.s()) : mapper.get(ContentType.all[read.b()], read.s());
-            case 6 -> {
+            case Content -> mapper == null ? content.getByID(ContentType.all[read.b()], read.s()) : mapper.get(ContentType.all[read.b()], read.s());
+            case IntSeq -> {
                 if(!allowArrays) throw new RuntimeException("Nested arrays are not allowed");
                 short len = read.s();
                 if(len > maxArraySize) throw new RuntimeException("Invalid array size: " + len);
@@ -205,20 +247,20 @@ public class TypeIO{
                 for(int i = 0; i < len; i ++) arr.add(read.i());
                 yield arr;
             }
-            case 7 -> new Point2(read.i(), read.i());
-            case 8 -> {
+            case Point2 -> new Point2(read.i(), read.i());
+            case PointArray -> {
                 if(!allowArrays) throw new RuntimeException("Nested arrays are not allowed");
                 int len = read.ub();
                 Point2[] out = new Point2[len];
                 for(int i = 0; i < len; i ++) out[i] = Point2.unpack(read.i());
                 yield out;
             }
-            case 9 -> content.<UnlockableContent>getByID(ContentType.all[read.b()], read.s()).techNode;
-            case 10 -> read.bool();
-            case 11 -> read.d();
-            case 12 -> !box ? world.build(read.i()) : new BuildingBox(read.i());
-            case 13 -> LAccess.all[read.s()];
-            case 14 -> {
+            case TechNode -> content.<UnlockableContent>getByID(ContentType.all[read.b()], read.s()).techNode;
+            case Boolean -> read.bool();
+            case Double -> read.d();
+            case Building -> !box ? world.build(read.i()) : new BuildingBox(read.i());
+            case LAccess -> LAccess.all[read.s()];
+            case ByteArray -> {
                 if(!allowArrays) throw new RuntimeException("Nested arrays are not allowed");
                 int len = read.i();
                 if(len > maxByteArraySize) throw new RuntimeException("Invalid array size: " + len);
@@ -228,11 +270,11 @@ public class TypeIO{
                 yield bytes;
             }
             //unit command
-            case 15 -> {
+            case Legacy -> {
                 read.b();
                 yield null;
             }
-            case 16 -> {
+            case BooleanArray -> {
                 if(!allowArrays) throw new RuntimeException("Nested arrays are not allowed");
                 int len = read.i();
                 if(len > maxArraySize) throw new RuntimeException("Invalid array size: " + len);
@@ -241,8 +283,8 @@ public class TypeIO{
                 for(int i = 0; i < len; i ++) bools[i] = read.bool();
                 yield bools;
             }
-            case 17 -> !box ? Groups.unit.getByID(read.i()) : new UnitBox(read.i());
-            case 18 -> {
+            case Unit -> !box ? Groups.unit.getByID(read.i()) : new UnitBox(read.i());
+            case Vec2Array -> {
                 if(!allowArrays) throw new RuntimeException("Nested arrays are not allowed");
                 int len = read.s();
                 if(len > maxArraySize) throw new RuntimeException("Invalid array size: " + len);
@@ -251,10 +293,10 @@ public class TypeIO{
                 for(int i = 0; i < len; i ++) out[i] = new Vec2(read.f(), read.f());
                 yield out;
             }
-            case 19 -> new Vec2(read.f(), read.f());
-            case 20 -> Team.all[read.ub()];
-            case 21 -> readInts(read);
-            case 22 -> {
+            case Vec2 -> new Vec2(read.f(), read.f());
+            case Team -> Team.all[read.ub()];
+            case IntArray -> readInts(read);
+            case ObjectArray -> {
                 if(!allowArrays) throw new RuntimeException("Nested arrays are not allowed");
                 int len = read.i();
                 if(len > maxArraySize) throw new RuntimeException("Invalid array size: " + len);
@@ -265,8 +307,8 @@ public class TypeIO{
                 }
                 yield objs;
             }
-            case 23 -> content.unitCommand(read.us());
-            default -> throw new IllegalArgumentException("Unknown object type: " + type);
+            case UnitCommand -> content.unitCommand(read.us());
+            default -> throw new IllegalArgumentException("Unknown object type: " + type.identifier);
         };
     }
 
@@ -1365,6 +1407,40 @@ public class TypeIO{
             return new String(bytes, charset);
         }else{
             return null;
+        }
+    }
+
+    /** Type of a written object. */
+    public static enum ObjectType{
+        Null            ((byte)0),
+        Integer         ((byte)1),
+        Long            ((byte)2),
+        Float           ((byte)3),
+        String          ((byte)4),
+        Content         ((byte)5),
+        IntSeq          ((byte)6),
+        Point2          ((byte)7),
+        PointArray      ((byte)8),
+        TechNode        ((byte)9),
+        Boolean         ((byte)10),
+        Double          ((byte)11),
+        Building        ((byte)12),
+        LAccess         ((byte)13),
+        ByteArray       ((byte)14),
+        Legacy          ((byte)15),
+        BooleanArray    ((byte)16),
+        Unit            ((byte)17),
+        Vec2Array       ((byte)18),
+        Vec2            ((byte)19),
+        Team            ((byte)20),
+        IntArray        ((byte)21),
+        ObjectArray     ((byte)22),
+        UnitCommand     ((byte)23);
+
+        final byte identifier;
+
+        private ObjectType(byte identifier){
+            this.identifier = identifier;
         }
     }
 

--- a/core/src/mindustry/io/TypeIO.java
+++ b/core/src/mindustry/io/TypeIO.java
@@ -40,30 +40,31 @@ import static mindustry.Vars.*;
 @TypeIOHandler
 public class TypeIO{
     /** Possible Types of written objects. */
-    public static final byte nullType = 0;
-    public static final byte integerType = 1;
-    public static final byte longType = 2;
-    public static final byte floatType = 3;
-    public static final byte stringType = 4;
-    public static final byte contentType = 5;
-    public static final byte intSeqType = 6;
-    public static final byte point2Type = 7;
-    public static final byte point2ArrayType = 8;
-    public static final byte techNodeType = 9;
-    public static final byte booleanType = 10;
-    public static final byte doubleType = 11;
-    public static final byte buildingType = 12;
-    public static final byte lAccessType = 13;
-    public static final byte byteArrayType = 14;
-    public static final byte leagacyType = 15;
-    public static final byte booleanArrayType = 16;
-    public static final byte unitType = 17;
-    public static final byte vec2ArrayType = 18;
-    public static final byte vec2Type = 19;
-    public static final byte teamType = 20;
-    public static final byte intArrayType = 21;
-    public static final byte objectArrayType = 22;
-    public static final byte unitCommandType = 23;
+    public static final byte
+        nullType = 0,
+        integerType = 1,
+        longType = 2,
+        floatType = 3,
+        stringType = 4,
+        contentType = 5,
+        intSeqType = 6,
+        point2Type = 7,
+        point2ArrayType = 8,
+        techNodeType = 9,
+        booleanType = 10,
+        doubleType = 11,
+        buildingType = 12,
+        lAccessType = 13,
+        byteArrayType = 14,
+        legacyType = 15,
+        booleanArrayType = 16,
+        unitType = 17,
+        vec2ArrayType = 18,
+        vec2Type = 19,
+        teamType = 20,
+        intArrayType = 21,
+        objectArrayType = 22,
+        unitCommandType = 23;
 
     private static final int maxArraySize = 1000, maxByteArraySize = 40_000, maxSyncedPlans = 20;
 

--- a/core/src/mindustry/io/TypeIO.java
+++ b/core/src/mindustry/io/TypeIO.java
@@ -39,121 +39,153 @@ import static mindustry.Vars.*;
 @SuppressWarnings("unused")
 @TypeIOHandler
 public class TypeIO{
+    /** Possible Types of written objects. */
+    public static final byte nullType = 0;
+    public static final byte integerType = 1;
+    public static final byte longType = 2;
+    public static final byte floatType = 3;
+    public static final byte stringType = 4;
+    public static final byte contentType = 5;
+    public static final byte intSeqType = 6;
+    public static final byte point2Type = 7;
+    public static final byte point2ArrayType = 8;
+    public static final byte techNodeType = 9;
+    public static final byte booleanType = 10;
+    public static final byte doubleType = 11;
+    public static final byte buildingType = 12;
+    public static final byte lAccessType = 13;
+    public static final byte byteArrayType = 14;
+    public static final byte leagacyType = 15;
+    public static final byte booleanArrayType = 16;
+    public static final byte unitType = 17;
+    public static final byte vec2ArrayType = 18;
+    public static final byte vec2Type = 19;
+    public static final byte teamType = 20;
+    public static final byte intArrayType = 21;
+    public static final byte objectArrayType = 22;
+    public static final byte unitCommandType = 23;
+
     private static final int maxArraySize = 1000, maxByteArraySize = 40_000, maxSyncedPlans = 20;
 
+    /** Write an object, prepending its {@code ObjectType}. */
     public static void writeObject(Writes write, Object object){
         if(object == null){
-            write.b((byte)0);
+            write.b(nullType);
         }else if(object instanceof Integer i){
-            write.b((byte)1);
+            write.b(integerType);
             write.i(i);
         }else if(object instanceof Long l){
-            write.b((byte)2);
+            write.b(longType);
             write.l(l);
         }else if(object instanceof Float f){
-            write.b((byte)3);
+            write.b(floatType);
             write.f(f);
         }else if(object instanceof String s){
-            write.b((byte)4);
+            write.b(stringType);
             writeString(write, s);
         }else if(object instanceof Content map){
-            write.b((byte)5);
+            write.b(contentType);
             write.b((byte)map.getContentType().ordinal());
             write.s(map.id);
         }else if(object instanceof IntSeq arr){
             if(arr.size > maxArraySize) throw new ArcRuntimeException("Array size too large: " + arr.size);
-            write.b((byte)6);
+            write.b(intSeqType);
             write.s((short)arr.size);
             for(int i = 0; i < arr.size; i++){
                 write.i(arr.items[i]);
             }
         }else if(object instanceof Point2 p){
-            write.b((byte)7);
+            write.b(point2Type);
             write.i(p.x);
             write.i(p.y);
         }else if(object instanceof Point2[] p){
             //255 is the limit here, because it's a byte for some reason
             if(p.length > 255) throw new ArcRuntimeException("Array size too large: " + p.length);
-            write.b((byte)8);
+            write.b(point2ArrayType);
             write.b(p.length);
             for(Point2 point2 : p){
                 write.i(point2.pack());
             }
         }else if(object instanceof TechNode map){
-            write.b(9);
+            write.b(techNodeType);
             write.b((byte)map.content.getContentType().ordinal());
             write.s(map.content.id);
         }else if(object instanceof Boolean b){
-            write.b((byte)10);
+            write.b(booleanType);
             write.bool(b);
         }else if(object instanceof Double d){
-            write.b((byte)11);
-            write.d(d);
+            writeObject(write, d.doubleValue());
         }else if(object instanceof Building b){
-            write.b(12);
+            write.b(buildingType);
             write.i(b.pos());
         }else if(object instanceof BuildingBox b){
-            write.b(12);
+            write.b(buildingType);
             write.i(b.pos);
         }else if(object instanceof LAccess l){
-            write.b((byte)13);
+            write.b(lAccessType);
             write.s(l.ordinal());
         }else if(object instanceof byte[] b){
             if(b.length > maxByteArraySize) throw new ArcRuntimeException("Array size too large: " + b.length);
-            write.b((byte)14);
+            write.b(byteArrayType);
             write.i(b.length);
             write.b(b);
         }else if(object instanceof boolean[] b){
             if(b.length > maxArraySize) throw new ArcRuntimeException("Array size too large: " + b.length);
 
-            write.b(16);
+            write.b(booleanArrayType);
             write.i(b.length);
             for(boolean bool : b){
                 write.bool(bool);
             }
         }else if(object instanceof Unit u){
-            write.b(17);
+            write.b(unitType);
             write.i(u.id);
         }else if(object instanceof UnitBox u){
-            write.b(17);
+            write.b(unitType);
             write.i(u.id);
         }else if(object instanceof Vec2[] vecs){
             if(vecs.length > maxArraySize) throw new ArcRuntimeException("Array size too large: " + vecs.length);
 
-            write.b(18);
+            write.b(vec2ArrayType);
             write.s(vecs.length);
             for(Vec2 v : vecs){
                 write.f(v.x);
                 write.f(v.y);
             }
         }else if(object instanceof Vec2 v){
-            write.b((byte)19);
+            write.b(vec2Type);
             write.f(v.x);
             write.f(v.y);
         }else if(object instanceof Team t){
-            write.b((byte)20);
+            write.b(teamType);
             write.b(t.id);
         }else if(object instanceof int[] i){
             if(i.length > maxArraySize) throw new ArcRuntimeException("Array size too large: " + i.length);
 
-            write.b((byte)21);
+            write.b(intArrayType);
             writeInts(write, i);
         }else if(object instanceof Object[] objs){
             if(objs.length > maxArraySize) throw new ArcRuntimeException("Array size too large: " + objs.length);
 
-            write.b((byte)22);
+            write.b(objectArrayType);
             write.i(objs.length);
             for(Object obj : objs){
                 writeObject(write, obj);
             }
         }else if(object instanceof UnitCommand command){
-            write.b(23);
+            write.b(unitCommandType);
             write.s(command.id);
         }else if(object instanceof Bullet b || object instanceof Seq<?> s){ //write bullets as null
             write.b((byte)0);
         }else{
             throw new IllegalArgumentException("Unknown object type: " + object.getClass());
         }
+    }
+
+    /** Overload of {@code writeObject(Writes, Object)} which prevents boxing. */
+    public static void writeObject(Writes write, double object){
+        write.b(doubleType);
+        write.d(object);
     }
 
     public static @Nullable Object readObject(Reads read){
@@ -178,16 +210,20 @@ public class TypeIO{
     }
 
     public static @Nullable Object readObject(Reads read, boolean box, @Nullable ContentMapper mapper, boolean safe, boolean allowArrays){
+        byte type = read.b();
+        return readObject(read, box, mapper, safe, allowArrays, type);
+    }
+
+    public static @Nullable Object readObject(Reads read, boolean box, @Nullable ContentMapper mapper, boolean safe, boolean allowArrays, byte type){
         //use a much lower array size limit for build plans
         int maxArraySize = safe ? TypeIO.maxArraySize : 200;
 
-        byte type = read.b();
         return switch(type){
-            case 0 -> null;
-            case 1 -> read.i();
-            case 2 -> read.l();
-            case 3 -> read.f();
-            case 4 -> {
+            case nullType -> null;
+            case integerType -> read.i();
+            case longType -> read.l();
+            case floatType -> read.f();
+            case stringType -> {
                 byte exists = read.b();
                 if(exists != 0){
                     //in a safe context, strings can only be 1200 chars
@@ -196,8 +232,8 @@ public class TypeIO{
                     yield null;
                 }
             }
-            case 5 -> mapper == null ? content.getByID(ContentType.all[read.b()], read.s()) : mapper.get(ContentType.all[read.b()], read.s());
-            case 6 -> {
+            case contentType -> mapper == null ? content.getByID(ContentType.all[read.b()], read.s()) : mapper.get(ContentType.all[read.b()], read.s());
+            case intSeqType -> {
                 if(!allowArrays) throw new RuntimeException("Nested arrays are not allowed");
                 short len = read.s();
                 if(len > maxArraySize) throw new RuntimeException("Invalid array size: " + len);
@@ -205,20 +241,20 @@ public class TypeIO{
                 for(int i = 0; i < len; i ++) arr.add(read.i());
                 yield arr;
             }
-            case 7 -> new Point2(read.i(), read.i());
-            case 8 -> {
+            case point2Type -> new Point2(read.i(), read.i());
+            case point2ArrayType -> {
                 if(!allowArrays) throw new RuntimeException("Nested arrays are not allowed");
                 int len = read.ub();
                 Point2[] out = new Point2[len];
                 for(int i = 0; i < len; i ++) out[i] = Point2.unpack(read.i());
                 yield out;
             }
-            case 9 -> content.<UnlockableContent>getByID(ContentType.all[read.b()], read.s()).techNode;
-            case 10 -> read.bool();
-            case 11 -> read.d();
-            case 12 -> !box ? world.build(read.i()) : new BuildingBox(read.i());
-            case 13 -> LAccess.all[read.s()];
-            case 14 -> {
+            case techNodeType -> content.<UnlockableContent>getByID(ContentType.all[read.b()], read.s()).techNode;
+            case booleanType -> read.bool();
+            case doubleType -> read.d();
+            case buildingType -> !box ? world.build(read.i()) : new BuildingBox(read.i());
+            case lAccessType -> LAccess.all[read.s()];
+            case byteArrayType -> {
                 if(!allowArrays) throw new RuntimeException("Nested arrays are not allowed");
                 int len = read.i();
                 if(len > maxByteArraySize) throw new RuntimeException("Invalid array size: " + len);
@@ -228,11 +264,11 @@ public class TypeIO{
                 yield bytes;
             }
             //unit command
-            case 15 -> {
+            case leagacyType -> {
                 read.b();
                 yield null;
             }
-            case 16 -> {
+            case booleanArrayType -> {
                 if(!allowArrays) throw new RuntimeException("Nested arrays are not allowed");
                 int len = read.i();
                 if(len > maxArraySize) throw new RuntimeException("Invalid array size: " + len);
@@ -241,8 +277,8 @@ public class TypeIO{
                 for(int i = 0; i < len; i ++) bools[i] = read.bool();
                 yield bools;
             }
-            case 17 -> !box ? Groups.unit.getByID(read.i()) : new UnitBox(read.i());
-            case 18 -> {
+            case unitType -> !box ? Groups.unit.getByID(read.i()) : new UnitBox(read.i());
+            case vec2ArrayType -> {
                 if(!allowArrays) throw new RuntimeException("Nested arrays are not allowed");
                 int len = read.s();
                 if(len > maxArraySize) throw new RuntimeException("Invalid array size: " + len);
@@ -251,10 +287,10 @@ public class TypeIO{
                 for(int i = 0; i < len; i ++) out[i] = new Vec2(read.f(), read.f());
                 yield out;
             }
-            case 19 -> new Vec2(read.f(), read.f());
-            case 20 -> Team.all[read.ub()];
-            case 21 -> readInts(read);
-            case 22 -> {
+            case vec2Type -> new Vec2(read.f(), read.f());
+            case teamType -> Team.all[read.ub()];
+            case intArrayType -> readInts(read);
+            case objectArrayType -> {
                 if(!allowArrays) throw new RuntimeException("Nested arrays are not allowed");
                 int len = read.i();
                 if(len > maxArraySize) throw new RuntimeException("Invalid array size: " + len);
@@ -265,7 +301,7 @@ public class TypeIO{
                 }
                 yield objs;
             }
-            case 23 -> content.unitCommand(read.us());
+            case unitCommandType -> content.unitCommand(read.us());
             default -> throw new IllegalArgumentException("Unknown object type: " + type);
         };
     }

--- a/core/src/mindustry/io/TypeIO.java
+++ b/core/src/mindustry/io/TypeIO.java
@@ -265,7 +265,7 @@ public class TypeIO{
                 yield bytes;
             }
             //unit command
-            case leagacyType -> {
+            case legacyType -> {
                 read.b();
                 yield null;
             }

--- a/core/src/mindustry/world/blocks/logic/MemoryBlock.java
+++ b/core/src/mindustry/world/blocks/logic/MemoryBlock.java
@@ -18,6 +18,7 @@ public class MemoryBlock extends Block{
 
     public MemoryBlock(String name){
         super(name);
+        update = true;
         destructible = true;
         solid = true;
         group = BlockGroup.logic;

--- a/core/src/mindustry/world/blocks/logic/MemoryBlock.java
+++ b/core/src/mindustry/world/blocks/logic/MemoryBlock.java
@@ -51,7 +51,7 @@ public class MemoryBlock extends Block{
     }
 
     public class MemoryBuild extends Building implements LReadable, LWritable{
-        /** Marks a memory slot as being stored in {@code numberMemory} (insted of {@code objectMemory}) */
+        /** Marks a memory slot as being stored in {@code numberMemory} (instead of {@code objectMemory}) */
         private static final Object sentinel = new Object();
 
         /** Objects stored in this memory building */

--- a/core/src/mindustry/world/blocks/logic/MemoryBlock.java
+++ b/core/src/mindustry/world/blocks/logic/MemoryBlock.java
@@ -113,7 +113,7 @@ public class MemoryBlock extends Block{
             int address = position.numi();
             if(address < 0 || address >= objectMemory.length) return;
 
-            if(value.isobj) {
+            if(value.isobj){
                 objectMemory[address] = value.objval;
             }else{
                 objectMemory[address] = sentinel;

--- a/core/src/mindustry/world/blocks/logic/MemoryBlock.java
+++ b/core/src/mindustry/world/blocks/logic/MemoryBlock.java
@@ -18,7 +18,6 @@ public class MemoryBlock extends Block{
 
     public MemoryBlock(String name){
         super(name);
-        update = true;
         destructible = true;
         solid = true;
         group = BlockGroup.logic;

--- a/core/src/mindustry/world/blocks/logic/MemoryBlock.java
+++ b/core/src/mindustry/world/blocks/logic/MemoryBlock.java
@@ -55,9 +55,6 @@ public class MemoryBlock extends Block{
         /** Marks a memory slot as being stored in {@code numberMemory} (insted of {@code objectMemory}) */
         private static final Object sentinel = new Object();
 
-        /** Block of code to run after load. */
-        private @Nullable Runnable loadBlock;
-
         /** Objects stored in this memory building */
         private Object[] objectMemory = new Object[memoryCapacity];
 
@@ -152,10 +149,10 @@ public class MemoryBlock extends Block{
             for(int i = 0; i < objectMemory.length; i++){
                 Object value = objectMemory[i];
                 if(value == sentinel){
-                    value = numberMemory[i];
+                    TypeIO.writeObject(write, numberMemory[i]);
+                }else{
+                    TypeIO.writeObject(write, value);
                 }
-
-                TypeIO.writeObject(write, value);
             }
         }
 
@@ -176,35 +173,34 @@ public class MemoryBlock extends Block{
                 return;
             }
 
-            //memory contents need to be temporarily stored in an array until they can be used
-            Object[] values = new Object[Math.min(amount, objectMemory.length)];
+            //read all data, but ignore anything not fitting inside this memory building
             for(int i = 0; i < amount; i++){
-                Object value = TypeIO.readObjectBoxed(read, true);
-                if(i < values.length) values[i] = value;
-            }
-
-            loadBlock = () -> {
-                //load up the memory contents that were stored
-                for(int i = 0; i < values.length; i++){
-                    Object value = values[i];
-                    if (value instanceof Boxed<?> boxed) value = boxed.unbox();
-
-                    if(value instanceof Number num){
+                byte type = read.b();
+                if(type == TypeIO.doubleType){
+                    //same logic as readObject, but prevents boxing
+                    double value = read.d();
+                    if(i < objectMemory.length){
                         objectMemory[i] = sentinel;
-                        numberMemory[i] = num.doubleValue();
-                    }else{
+                        numberMemory[i] = value;
+                    }
+                }else{
+                    Object value = TypeIO.readObject(read, true, null, false, true, type);
+                    if(i < objectMemory.length){
                         objectMemory[i] = value;
                     }
                 }
-            };
+            }
         }
 
         @Override
         public void afterReadAll(){
             super.afterReadAll();
-            if(loadBlock != null){
-                loadBlock.run();
-                loadBlock = null;
+            //unbox any memory contents which require it
+            for(int i = 0; i < objectMemory.length; i++){
+                //skips sentinel objects
+                if(objectMemory[i] instanceof Boxed<?> boxed){
+                    objectMemory[i] = boxed.unbox();
+                }
             }
         }
     }

--- a/core/src/mindustry/world/blocks/logic/MemoryBlock.java
+++ b/core/src/mindustry/world/blocks/logic/MemoryBlock.java
@@ -1,12 +1,17 @@
 package mindustry.world.blocks.logic;
 
+import arc.util.*;
 import arc.util.io.*;
 import mindustry.gen.*;
+import mindustry.io.*;
+import mindustry.io.TypeIO.*;
 import mindustry.logic.*;
 import mindustry.world.*;
 import mindustry.world.meta.*;
 
 import static mindustry.Vars.*;
+
+import java.util.*;
 
 public class MemoryBlock extends Block{
     public int memoryCapacity = 32;
@@ -46,7 +51,22 @@ public class MemoryBlock extends Block{
     }
 
     public class MemoryBuild extends Building implements LReadable, LWritable{
-        public double[] memory = new double[memoryCapacity];
+        /** Marks a memory slot as being stored in {@code numberMemory} (insted of {@code objectMemory}) */
+        private static final Object sentinel = new Object();
+
+        /** Block of code to run after load. */
+        private @Nullable Runnable loadBlock;
+
+        /** Objects stored in this memory building */
+        private Object[] objectMemory = new Object[memoryCapacity];
+
+        /** Numbers stored in this memory building */
+        private double[] numberMemory = new double[memoryCapacity];
+
+        {
+            //all memory slots contain 0 when first initialized
+            Arrays.fill(objectMemory, sentinel);
+        }
 
         //massive byte size means picking up causes sync issues
         @Override
@@ -73,7 +93,17 @@ public class MemoryBlock extends Block{
         public void read(LVar position, LVar output){
             int address = position.numi();
             //Return null when out of bounds. (instead of 0)
-            output.setnum(address < 0 || address >= memory.length ? Double.NaN : memory[address]);
+            if(address < 0 || address >= objectMemory.length){
+                output.setobj(null);
+                return;
+            }
+
+            Object value = objectMemory[address];
+            if(value == sentinel){
+                output.setnum(numberMemory[address]);
+            }else{
+                output.setobj(value);
+            }
         }
 
         @Override
@@ -84,8 +114,14 @@ public class MemoryBlock extends Block{
         @Override
         public void write(LVar position, LVar value){
             int address = position.numi();
-            if(address < 0 || address >= memory.length) return;
-            memory[address] = value.num();
+            if(address < 0 || address >= objectMemory.length) return;
+
+            if(value.isobj) {
+                objectMemory[address] = value.objval;
+            }else{
+                objectMemory[address] = sentinel;
+                numberMemory[address] = value.numval;
+            }
         }
 
         @Override
@@ -103,12 +139,22 @@ public class MemoryBlock extends Block{
         }
 
         @Override
+        public byte version(){
+            return 1;
+        }
+
+        @Override
         public void write(Writes write){
             super.write(write);
 
-            write.i(memory.length);
-            for(double v : memory){
-                write.d(v);
+            write.i(objectMemory.length);
+            for(int i = 0; i < objectMemory.length; i++){
+                Object value = objectMemory[i];
+                if(value == sentinel){
+                    value = numberMemory[i];
+                }
+
+                TypeIO.writeObject(write, value);
             }
         }
 
@@ -117,9 +163,47 @@ public class MemoryBlock extends Block{
             super.read(read, revision);
 
             int amount = read.i();
+
+            if(revision == 0){
+                for(int i = 0; i < amount; i++){
+                    double val = read.d();
+                    if(i < objectMemory.length){
+                        objectMemory[i] = sentinel;
+                        numberMemory[i] = val;
+                    }
+                }
+                return;
+            }
+
+            //memory contents need to be temporarily stored in an array until they can be used
+            Object[] values = new Object[Math.min(amount, objectMemory.length)];
             for(int i = 0; i < amount; i++){
-                double val = read.d();
-                if(i < memory.length) memory[i] = val;
+                Object value = TypeIO.readObjectBoxed(read, true);
+                if(i < values.length) values[i] = value;
+            }
+
+            loadBlock = () -> {
+                //load up the memory contents that were stored
+                for(int i = 0; i < values.length; i++){
+                    Object value = values[i];
+                    if (value instanceof Boxed<?> boxed) value = boxed.unbox();
+
+                    if(value instanceof Number num){
+                        objectMemory[i] = sentinel;
+                        numberMemory[i] = num.doubleValue();
+                    }else{
+                        objectMemory[i] = value;
+                    }
+                }
+            };
+        }
+
+        @Override
+        public void afterReadAll(){
+            super.afterReadAll();
+            if(loadBlock != null){
+                loadBlock.run();
+                loadBlock = null;
             }
         }
     }

--- a/core/src/mindustry/world/blocks/logic/MemoryBlock.java
+++ b/core/src/mindustry/world/blocks/logic/MemoryBlock.java
@@ -55,9 +55,6 @@ public class MemoryBlock extends Block{
         /** Marks a memory slot as being stored in {@code numberMemory} (insted of {@code objectMemory}) */
         private static final Object sentinel = new Object();
 
-        /** Block of code to run after load. */
-        private @Nullable Runnable loadBlock;
-
         /** Objects stored in this memory building */
         private Object[] objectMemory = new Object[memoryCapacity];
 
@@ -152,10 +149,10 @@ public class MemoryBlock extends Block{
             for(int i = 0; i < objectMemory.length; i++){
                 Object value = objectMemory[i];
                 if(value == sentinel){
-                    value = numberMemory[i];
+                    TypeIO.writeObject(write, numberMemory[i]);
+                }else{
+                    TypeIO.writeObject(write, value);
                 }
-
-                TypeIO.writeObject(write, value);
             }
         }
 
@@ -176,35 +173,34 @@ public class MemoryBlock extends Block{
                 return;
             }
 
-            //memory contents need to be temporarily stored in an array until they can be used
-            Object[] values = new Object[Math.min(amount, objectMemory.length)];
+            //read all data, but ignore anything not fitting inside this memory building
             for(int i = 0; i < amount; i++){
-                Object value = TypeIO.readObjectBoxed(read, true);
-                if(i < values.length) values[i] = value;
-            }
-
-            loadBlock = () -> {
-                //load up the memory contents that were stored
-                for(int i = 0; i < values.length; i++){
-                    Object value = values[i];
-                    if (value instanceof Boxed<?> boxed) value = boxed.unbox();
-
-                    if(value instanceof Number num){
+                ObjectType type = TypeIO.readObjectType(read);
+                if(type == ObjectType.Double){
+                    //same logic as readObject, but prevents boxing
+                    double value = read.d();
+                    if(i < objectMemory.length){
                         objectMemory[i] = sentinel;
-                        numberMemory[i] = num.doubleValue();
-                    }else{
+                        numberMemory[i] = value;
+                    }
+                }else{
+                    Object value = TypeIO.readObject(read, true, null, false, true, type);
+                    if(i < objectMemory.length){
                         objectMemory[i] = value;
                     }
                 }
-            };
+            }
         }
 
         @Override
         public void afterReadAll(){
             super.afterReadAll();
-            if(loadBlock != null){
-                loadBlock.run();
-                loadBlock = null;
+            //unbox any memory contents which require it
+            for(int i = 0; i < objectMemory.length; i++){
+                //skips sentinel objects
+                if(objectMemory[i] instanceof Boxed<?> boxed){
+                    objectMemory[i] = boxed.unbox();
+                }
             }
         }
     }


### PR DESCRIPTION
This is an improved version of #10833 which reduces the additional memory usage introduced in the mentioned pull request.

This is achieved by keeping two arrays (one for `double` numbers and one for `Object` instances), with the array to be read from / written to being determined by storing an internal (static) sentinel object in the object array.
Its presence marks a slot as being stored in the numbers array.

NaN is not being used as a sentinel value to prevent unwanted surprises should they be valid numbers somewhere in the future. 

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
