### PR TITLE
allow for custom forceShrinkEffect for modded or patched blocks based on the ForceProjector class

### DIFF
--- a/core/src/mindustry/world/blocks/defense/ForceProjector.java
+++ b/core/src/mindustry/world/blocks/defense/ForceProjector.java
@@ -48,6 +48,7 @@ public class ForceProjector extends Block{
     public float hitSoundVolume = 0.12f;
     public Effect absorbEffect = Fx.absorb;
     public Effect shieldBreakEffect = Fx.shieldBreak;
+    public Effect forceShrinkEffect = Fx.forceShrink;
     public @Load("@-top") TextureRegion topRegion;
 
     //TODO json support
@@ -187,7 +188,7 @@ public class ForceProjector extends Block{
         @Override
         public void onRemoved(){
             float radius = realRadius();
-            if(!broken && radius > 1f) Fx.forceShrink.at(x, y, radius, team.color);
+            if(!broken && radius > 1f) forceShrinkEffect.at(x, y, radius, team.color);
             super.onRemoved();
         }
 


### PR DESCRIPTION
let people define forceShrinkEffect themselves in order for the effect that plays when a block based on the ForceProjector class is broken to have the same amount of sides as the shield itself

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [ X ] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ X ] I have ensured that my code compiles, if applicable.
- [ X ] I have ensured that any new features in this PR function correctly in-game, if applicable.
