### PR TITLE
Implement image streaming API

### DIFF
--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -165,6 +165,16 @@ public class NetClient implements ApplicationListener{
             Call.requestAssets(missing.toArray());
         });
 
+        net.handleClient(TextureStream.class, data -> {
+            try(DataInputStream in = new DataInputStream(data.stream)){
+                String name = in.readUTF();
+                byte[] pngData = in.readAllBytes();
+                if(!headless) state.data.addTexture(name, pngData);
+            }catch(IOException e){
+                Log.err("Failed to read server texture stream", e);
+            }
+        });
+
         net.handleClient(StreamBegin.class, data -> {
             boolean isWorld = data.type == Net.packetIdWorldStream, isAssets = data.type == Net.packetIdAssetStream;
 

--- a/core/src/mindustry/core/NetServer.java
+++ b/core/src/mindustry/core/NetServer.java
@@ -552,6 +552,38 @@ public class NetServer implements ApplicationListener{
         debug("Packed @ of world data to @ (@ / @)", Strings.formatByteCount(stream.size()), player.name, player.con.address, player.uuid());
     }
 
+    /**
+     * Streams a texture to a single connected client. This may take some time if the image is large or if the connection is poor.
+     * Make sure to call {@link mindustry.mod.DataManager#removeTexture} when the image is no longer needed to prevent resource leaks.
+     * Use {@link PixmapIO#writePngBytes} to get Pixmap bytes. Respect {@link mindustry.mod.DataPatcher#maxImageSize}. */
+    public void sendTexture(NetConnection con, String name, byte[] pngData){
+        mainExecutor.submit(() -> {
+            var stream = packTexture(name, pngData);
+            con.sendStreamAsync(new TextureStream(), stream);
+        });
+    }
+
+    /** Streams a texture to every connected client. See {@link #sendTexture(NetConnection, String, byte[])} for more info. */
+    public void sendTexture(String name, byte[] pngData){
+        mainExecutor.submit(() -> {
+            var stream = packTexture(name, pngData);
+            for(NetConnection con : net.getConnections()){
+                con.sendStreamAsync(new TextureStream(), stream);
+            }
+        });
+    }
+
+    private ByteArrayOutputStream packTexture(String name, byte[] pngData){
+        var stream = new ByteArrayOutputStream();
+        try(DataOutputStream out = new DataOutputStream(stream)){
+            out.writeUTF(name);
+            out.write(pngData);
+        }catch(IOException e){
+            throw new RuntimeException(e);
+        }
+        return stream;
+    }
+
     public void addPacketHandler(String type, Cons2<Player, String> handler){
         customPacketHandlers.get(type, Seq::new).add(handler);
     }

--- a/core/src/mindustry/core/UI.java
+++ b/core/src/mindustry/core/UI.java
@@ -322,9 +322,11 @@ public class UI implements ApplicationListener, Loadable{
             }});
         }else{
             new Dialog(titleText){{
-                cont.margin(30).add(text).padRight(6f);
+                cont.image().width(400f).pad(2).height(4f).color(Pal.accent);
+                cont.row();
+                cont.add(text).row();
                 TextFieldFilter filter = numbers ? TextFieldFilter.digitsOnly : (f, c) -> true;
-                TextField field = cont.field(def, t -> {}).size(330f, 50f).get();
+                TextField field = cont.field(def, t -> {}).size(400f, 50f).get();
                 field.setMaxLength(textLength);
                 field.setFilter(filter);
                 buttons.defaults().size(120, 54).pad(4);

--- a/core/src/mindustry/game/EventType.java
+++ b/core/src/mindustry/game/EventType.java
@@ -119,6 +119,15 @@ public class EventType{
         }
     }
 
+    /** Called when a new texture is received from the server via {@link mindustry.core.NetServer#sendTexture}. */
+    public static class TextureStreamEvent {
+        public final String name;
+
+        public TextureStreamEvent(String name){
+            this.name = name;
+        }
+    }
+
     public static class SaveLoadEvent{
         public final boolean isMap;
 

--- a/core/src/mindustry/mod/DataImagePacker.java
+++ b/core/src/mindustry/mod/DataImagePacker.java
@@ -11,6 +11,7 @@ import arc.struct.*;
 import arc.util.*;
 import arc.util.Log.*;
 import mindustry.*;
+import mindustry.game.EventType.*;
 import mindustry.mod.data.*;
 
 import java.io.*;
@@ -20,8 +21,12 @@ import java.util.concurrent.atomic.*;
 /** Manages data patch images. */
 public class DataImagePacker{
     public static final String regionPrefix = "dp-";
+    /** Prefix for images pushed dynamically by the server via {@link #addTexture(String, byte[])}, as opposed to map/mod data patches. */
+    public static final String serverRegionPrefix = "net-";
 
     private @Nullable TextureAtlas patchAtlas;
+    /** Textures added at runtime via addTexture(), keyed by their unprefixed name. Tracked separately from patchAtlas so they can be added/removed individually. */
+    private ObjectMap<String, Texture> serverImages = new ObjectMap<>();
 
     /** Packs a new set of images. If images are already packed, disposes of the old ones. */
     public void pack(Seq<ImageAsset> images){
@@ -183,6 +188,62 @@ public class DataImagePacker{
             patchAtlas.dispose();
             patchAtlas = null;
         }
+
+        serverImages.each((name, texture) -> {
+            Core.atlas.getRegionMap().remove(serverRegionPrefix + name);
+            Core.atlas.getTextures().remove(texture);
+            texture.dispose();
+            Core.atlas.getDrawables().remove(serverRegionPrefix + name);
+
+        });
+        serverImages.clear();
+    }
+
+    /** Decodes PNG bytes and registers them into the atlas under "netRegionPrefix + name", replacing any existing image with the same name. Safe to call from any thread. */
+    public void addTexture(String name, byte[] pngData){
+        Vars.mainExecutor.submit(() -> {
+            Pixmap pixmap;
+            try{
+                pixmap = new Pixmap(pngData);
+            }catch(Throwable e){
+                Log.err("Invalid server-provided image data for '" + name + "'", e);
+                return;
+            }
+
+            if(pixmap.width > DataPatcher.maxImageSize || pixmap.height > DataPatcher.maxImageSize){
+                Log.err("Server-provided image '" + name + "' exceeds max size of " + DataPatcher.maxImageSize);
+                pixmap.dispose();
+                return;
+            }
+
+            Core.app.post(() -> {
+                removeTexture(name);
+
+                Texture texture = new Texture(pixmap);
+                pixmap.dispose();
+
+                var region = new TextureAtlas.AtlasRegion(texture, 0, 0, texture.width, texture.height);
+                region.name = serverRegionPrefix + name;
+
+                serverImages.put(name, texture);
+                Core.atlas.getTextures().add(texture);
+                Core.atlas.getRegionMap().put(serverRegionPrefix + name, region);
+
+                //fired with the full atlas region name
+                Events.fire(new TextureStreamEvent(serverRegionPrefix + name));
+            });
+        });
+    }
+
+    /** Removes a texture previously added with {@link #addTexture} */
+    public void removeTexture(String name){
+        Texture texture = serverImages.remove(name);
+        if(texture != null){
+            Core.atlas.getRegionMap().remove(serverRegionPrefix + name);
+            Core.atlas.getTextures().remove(texture);
+            texture.dispose();
+            Core.atlas.getDrawables().remove(serverRegionPrefix + name);
+        }
     }
 
     public void printStats(PixmapPacker mainPacker, PixmapPacker envPacker){
@@ -203,16 +264,6 @@ public class DataImagePacker{
 
                 i ++;
             }
-        }
-    }
-
-    static class PackResult{
-        String name;
-        Pixmap pixmap;
-
-        public PackResult(String name, Pixmap pixmap){
-            this.name = name;
-            this.pixmap = pixmap;
         }
     }
 }

--- a/core/src/mindustry/mod/DataManager.java
+++ b/core/src/mindustry/mod/DataManager.java
@@ -7,6 +7,7 @@ import arc.graphics.g2d.TextureAtlas.*;
 import arc.struct.*;
 import arc.util.*;
 import mindustry.*;
+import mindustry.annotations.Annotations.*;
 import mindustry.ctype.*;
 import mindustry.graphics.*;
 import mindustry.mod.data.*;
@@ -186,6 +187,18 @@ public class DataManager{
         if(images != getImages()) getImages().set(images);
 
         reloadImages();
+    }
+
+    /** Adds/replaces a single image pushed by the server at runtime, independent of map/mod data patches.
+     * Use {@link mindustry.core.NetServer#sendTexture} to send a texture to connected clients. */
+    public void addTexture(String name, byte[] pngData){
+        if(!Vars.headless) packer.addTexture(name, pngData);
+    }
+
+    /** Removes a texture previously added with {@link #addTexture}. */
+    @Remote(variants = Variant.both)
+    public static void removeTexture(String name){
+        if(!Vars.headless) Vars.state.data.packer.removeTexture(name);
     }
 
     public void reloadAudio(){

--- a/core/src/mindustry/net/Net.java
+++ b/core/src/mindustry/net/Net.java
@@ -22,7 +22,7 @@ import static mindustry.Vars.*;
 
 @SuppressWarnings("unchecked")
 public class Net{
-    public static final int packetIdAssetStream, packetIdWorldStream;
+    public static final int packetIdAssetStream, packetIdWorldStream, packetIdTextureStream;
 
     private static Seq<Prov<? extends Packet>> packetProvs = new Seq<>();
     private static Seq<Class<? extends Packet>> packetClasses = new Seq<>();
@@ -50,6 +50,7 @@ public class Net{
         registerPacket(ConnectPacket::new);
         registerPacket(AssetRequirementStream::new);
         packetIdAssetStream = registerPacket(AssetStream::new);
+        packetIdTextureStream = registerPacket(TextureStream::new);
 
         //register generated packet classes
         Call.registerPackets();

--- a/core/src/mindustry/net/Packets.java
+++ b/core/src/mindustry/net/Packets.java
@@ -71,6 +71,10 @@ public class Packets{
 
     }
 
+    public static class TextureStream extends Streamable{
+
+    }
+
     public static class AssetRequirementStream extends Streamable{
 
     }

--- a/core/src/mindustry/ui/Menus.java
+++ b/core/src/mindustry/ui/Menus.java
@@ -83,7 +83,9 @@ public class Menus{
             }
         };
 
-        dialog.idToElement = UiTreeBuilder.build(dialog.cont, builder, dialog.originalListener);
+        var result = UiTreeBuilder.build(dialog.cont, builder, dialog.originalListener);
+        dialog.idToElement = result.idElements;
+        dialog.addImages(result.images);
 
         var oldDialog = menuDialogs.remove(id);
 
@@ -108,12 +110,13 @@ public class Menus{
         if(table == null) return;
 
         table.clear();
-        var newElements = UiTreeBuilder.build(table, builder, result -> {
+        var result = UiTreeBuilder.build(table, builder, res -> {
             //forward results to original listener
-            dialog.originalListener.get(result);
+            dialog.originalListener.get(res);
         });
-        //save new element IDs
-        dialog.idToElement.putAll(newElements);
+        //save new element IDs and images
+        dialog.idToElement.putAll(result.idElements);
+        dialog.addImages(result.images);
     }
 
     @Remote(variants = Variant.both)
@@ -388,11 +391,30 @@ public class Menus{
     static class MenuDialog extends BaseDialog{
         //retained for easy lookup if an element needs to be replaced
         ObjectMap<String, Element> idToElement;
+        //every streamed image built into this dialog, keyed by the region name
+        ObjectMap<String, Seq<Image>> images = new ObjectMap<>();
         Cons<MenuResult> originalListener;
         boolean wasHidden;
 
+        static{
+            // refresh images that are received after the dialog is already opened
+            Events.on(TextureStreamEvent.class, e -> {
+                for(var dialog : menuDialogs.values()){
+                    var imgs = dialog.images.get(e.name);
+                    if(imgs != null){
+                        var drawable = Core.atlas.drawable(e.name);
+                        imgs.each(img -> img.setDrawable(drawable));
+                    }
+                }
+            });
+        }
+
         public MenuDialog(){
             super("");
+        }
+
+        void addImages(ObjectMap<String, Seq<Image>> images){
+            images.each((region, imgs) -> this.images.get(region, Seq::new).addAll(imgs));
         }
     }
 

--- a/core/src/mindustry/ui/builder/UiBuilder.java
+++ b/core/src/mindustry/ui/builder/UiBuilder.java
@@ -253,6 +253,7 @@ public class UiBuilder{
         ImageBuilder(){ super(UiKey.image); }
 
         public ImageBuilder region(String region){ return prop(UiKey.region, region); }
+        public ImageBuilder placeholder(String placeholder){ return prop(UiKey.placeholder, placeholder); }
         public ImageBuilder scaling(Scaling scaling){ return prop(UiKey.scaling, scaling.name()); }
     }
 
@@ -261,6 +262,7 @@ public class UiBuilder{
 
         public ButtonBuilder text(String text){ return prop(UiKey.text, text); }
         public ButtonBuilder icon(String icon){ return prop(UiKey.icon, icon); }
+        public ButtonBuilder placeholder(String placeholder){ return prop(UiKey.placeholder, placeholder); }
         public ButtonBuilder style(String style){ return prop(UiKey.style, style); }
         public ButtonBuilder clicked(String result){ return prop(UiKey.clicked, result); }
         public ButtonBuilder disabled(boolean disabled){ return prop(UiKey.disabled, disabled); }
@@ -272,6 +274,7 @@ public class UiBuilder{
         ImageButtonBuilder(){ super(UiKey.imageButton); }
 
         public ImageButtonBuilder icon(String icon){ return prop(UiKey.icon, icon); }
+        public ImageButtonBuilder placeholder(String placeholder){ return prop(UiKey.placeholder, placeholder); }
         public ImageButtonBuilder style(String style){ return prop(UiKey.style, style); }
         public ImageButtonBuilder clicked(String result){ return prop(UiKey.clicked, result); }
         public ImageButtonBuilder disabled(boolean disabled){ return prop(UiKey.disabled, disabled); }

--- a/core/src/mindustry/ui/builder/UiKey.java
+++ b/core/src/mindustry/ui/builder/UiKey.java
@@ -6,7 +6,7 @@ public enum UiKey{
     table, pane, stack, label, image, button, imageButton, field, check, slider, space, defaults, buttonTable, row, //NOTE: all node types must be before 'row'
 
     // node-specific properties
-    text, wrap, region, icon, scaling, background, margin, id, hint, maxLength, checked, min, max, step,
+    text, wrap, region, icon, placeholder, scaling, background, margin, id, hint, maxLength, checked, min, max, step,
     defaultValue, clicked, enter, style, group, condition, color, disabled,
 
     // cell properties

--- a/core/src/mindustry/ui/builder/UiTreeBuilder.java
+++ b/core/src/mindustry/ui/builder/UiTreeBuilder.java
@@ -20,20 +20,21 @@ import arc.scene.utils.*;
 import arc.struct.*;
 import arc.util.*;
 import mindustry.gen.*;
+import mindustry.mod.*;
 import mindustry.ui.*;
 import mindustry.ui.builder.UiBuilder.*;
 
 /** Builds a UI into an existing Table from a NodeBuilder tree. */
 public class UiTreeBuilder{
 
-    public static ObjectMap<String, Element> build(Table root, NodeBuilder<?> builder){
+    public static BuildResult build(Table root, NodeBuilder<?> builder){
         return build(root, builder, null);
     }
 
-    public static ObjectMap<String, Element> build(Table root, NodeBuilder<?> builder, @Nullable Cons<MenuResult> resultListener){
+    public static BuildResult build(Table root, NodeBuilder<?> builder, @Nullable Cons<MenuResult> resultListener){
         BuildContext ctx = new BuildContext(resultListener);
         buildInto(root, builder.entries, ctx);
-        return ctx.idElements;
+        return new BuildResult(ctx.idElements, ctx.images);
     }
 
     private static void buildInto(Table table, Seq<Entry> entries, BuildContext ctx){
@@ -125,7 +126,10 @@ public class UiTreeBuilder{
                 yield label;
             }
             case image -> {
-                Image image = new Image(findDrawable(node.str(UiKey.region, node.str(UiKey.icon, "error"))));
+                String region = node.str(UiKey.region, node.str(UiKey.icon, "error"));
+                Image image = new Image(findDrawable(region, node.str(UiKey.placeholder)));
+                // track server-streamed images so that they can be reloaded when streaming finishes
+                if(region.startsWith(DataImagePacker.serverRegionPrefix)) ctx.images.get(region, Seq::new).add(image);
                 String scl = node.str(UiKey.scaling);
                 if(scl != null){
                     try{
@@ -141,7 +145,10 @@ public class UiTreeBuilder{
 
                 String icon = node.str(UiKey.icon);
                 if(icon != null){
-                    btn.add(new Image(findDrawable(icon)).setScaling(Scaling.fit)).size(32f);
+                    Image iconImage = new Image(findDrawable(icon, node.str(UiKey.placeholder))).setScaling(Scaling.fit);
+                    // track server-streamed images so that they can be reloaded when streaming finishes
+                    if(icon.startsWith(DataImagePacker.serverRegionPrefix)) ctx.images.get(icon, Seq::new).add(iconImage);
+                    btn.add(iconImage).size(32f);
                     btn.getCells().reverse();
                 }
                 wireButton(btn, node, ctx);
@@ -149,7 +156,9 @@ public class UiTreeBuilder{
             }
             case imageButton -> {
                 String icon = node.str(UiKey.icon);
-                ImageButton btn = new ImageButton(icon != null ? findDrawable(icon) : null);
+                ImageButton btn = new ImageButton(icon != null ? findDrawable(icon, node.str(UiKey.placeholder)) : null);
+                // track server-streamed images so that they can be reloaded when streaming finishes
+                if(icon != null && icon.startsWith(DataImagePacker.serverRegionPrefix)) ctx.images.get(icon, Seq::new).add(btn.getImage());
                 applyStyle(node, ImageButtonStyle.class, btn::setStyle);
                 wireButton(btn, node, ctx);
                 yield btn;
@@ -308,13 +317,20 @@ public class UiTreeBuilder{
     }
 
     private static Drawable findDrawable(String name){
+        return findDrawable(name, "error");
+    }
+
+    /** @param placeholder shown instead of the error sprite if {@code name} isn't streamed from the server yet */
+    private static Drawable findDrawable(String name, @Nullable String placeholder){
         if(Core.atlas.has(name)){
             return Core.atlas.drawable(name);
         }
         //icons are a fallback (TODO: bad idea?)
         var result = Icon.icons.get(name);
-        if(result == null) return Core.atlas.drawable("error");
-        return result;
+        if(result != null) return result;
+
+        if(placeholder != null) return findDrawable(placeholder, null);
+        return Core.atlas.drawable("nomap"); // no placeholder provided, use the default of the map preview texture
     }
 
     /** Evaluates a condition string: "portrait", "landscape", or "width|height >=|>|<|<= number". */
@@ -363,6 +379,7 @@ public class UiTreeBuilder{
         final @Nullable Cons<MenuResult> resultListener;
         final ObjectMap<String, Element> idElements = new ObjectMap<>();
         final ObjectMap<String, ButtonGroup<Button>> buttonGroups = new ObjectMap<>();
+        final ObjectMap<String, Seq<Image>> images = new ObjectMap<>();
 
         BuildContext(@Nullable Cons<MenuResult> resultListener){
             this.resultListener = resultListener;
@@ -370,6 +387,17 @@ public class UiTreeBuilder{
 
         ButtonGroup<Button> group(String name){
             return buttonGroups.get(name, ButtonGroup::new);
+        }
+    }
+
+    /** Result of building a NodeBuilder: named elements (those with an explicit id), plus any server-streamed images, keyed by region name */
+    public static class BuildResult{
+        public final ObjectMap<String, Element> idElements;
+        public final ObjectMap<String, Seq<Image>> images;
+
+        BuildResult(ObjectMap<String, Element> idElements, ObjectMap<String, Seq<Image>> images){
+            this.idElements = idElements;
+            this.images = images;
         }
     }
 }


### PR DESCRIPTION
Took me a while to finally get around to cleaning it up but it's finally done.
Adds support for dynamically sending clients images via `Vars.netServer.sendTexture(...)`.
Dynamic images must be manually cleaned up with `Call.removeTexture(...)` to avoid garbage piling up during a game.

Streaming considerations:
- Since the images are streamed, they are not bound to typical packet size limits
  - It may be worth adding some way to limit the size of a stream as well as the number of them incoming as currently there are no such limitations. Only the dimensions of the image are checked and even so it is once the stream is fully received. A malicious server could abuse this to OOM clients with high bandwidth connections.
- Asynchronous streaming means that sending many textures should be minimally disruptive on low bandwidth connections
- **If attempting to `Call.removeTexture` before the texture is fully received on the client, it could be processed out of order resulting in dangling textures.**
  - Fixing this one would require rearchitecting some of the streaming stuff or adding a timestamp to the stream start, maintaining a list of removed textures and their timestamps to see if it was removed after streaming commenced.
- Some changes were made under the hood to the menu API to accommodate streamed images
  - Image, Button, ImageButton now have an optional placeholder that will be used if the primary TextureRegion can't be located
  - When a texture stream is finished, any Image objects in open menus will be updated to point to the texture instead of the fallback.
    - Currently, if the texture is subsequently removed again the image will just go blank rather than returning to the placeholder. This should probably be changed.


Other notes:
- I don't know when the proper time to forcefully evict all of the server streamed textures is so I'm just doing it on DataImagePacker.unload() which seems to work fine but it's potentially not ideal (for example, wouldn't that mean that servers would have to resend images every map if they want to have them between maps?)
- There was an unused class in DataImagePacker (likely from before a refactor) so I nuked it
- I have tested this on my own server but there are likely still issues with it considering the scope


Edit: Man this almost reads like one of those wall of text ai slop PRs but it'd be impossible to interpret my weird writing style as that

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
