### PR TITLE
Fixing the wrong shieldBreak effect for ForceProjector

### DIFF
--- a/core/src/mindustry/content/Fx.java
+++ b/core/src/mindustry/content/Fx.java
@@ -2807,7 +2807,15 @@ public class Fx{
     shieldBreak = new Effect(40, e -> {
         color(e.color);
         stroke(3f * e.fout());
-        Lines.poly(e.x, e.y, e.data instanceof Integer i ? i : 6, e.rotation + e.fin());
+        if(e.data instanceof ForceFieldAbility ab){
+            Lines.poly(e.x, e.y, ab.sides, e.rotation + e.fin(), ab.rotation);
+            return;
+        }else if(e.data instanceof ForceProjector ab){
+            Lines.poly(e.x, e.y, ab.sides, e.rotation + e.fin(), ab.shieldRotation);
+            return;
+        }else{
+            Lines.poly(e.x, e.y, e.data instanceof Integer i ? i : 6, e.rotation + e.fin());
+        }
     }).followParent(true),
 
     arcShieldBreak = new Effect(40, e -> {

--- a/core/src/mindustry/entities/abilities/ForceFieldAbility.java
+++ b/core/src/mindustry/entities/abilities/ForceFieldAbility.java
@@ -91,7 +91,7 @@ public class ForceFieldAbility extends Ability{
         if(unit.shield <= 0f && !wasBroken){
             unit.shield -= cooldown * regen;
 
-            Fx.shieldBreak.at(unit.x, unit.y, radius, unit.type.shieldColor(unit), sides);
+            Fx.shieldBreak.at(unit.x, unit.y, radius, unit.type.shieldColor(unit), this);
             breakSound.at(unit.x, unit.y);
         }
 

--- a/core/src/mindustry/entities/abilities/ForceFieldAbility.java
+++ b/core/src/mindustry/entities/abilities/ForceFieldAbility.java
@@ -120,7 +120,7 @@ public class ForceFieldAbility extends Ability{
 
         //self-destructing units can have a shield on death
         if(unit.shield > 0f && !wasBroken){
-            Fx.shieldBreak.at(unit.x, unit.y, radius, unit.type.shieldColor(unit), sides);
+            Fx.shieldBreak.at(unit.x, unit.y, radius, unit.type.shieldColor(unit), this);
             breakSound.at(unit.x, unit.y);
         }
     }

--- a/core/src/mindustry/world/blocks/defense/ForceProjector.java
+++ b/core/src/mindustry/world/blocks/defense/ForceProjector.java
@@ -242,7 +242,7 @@ public class ForceProjector extends Block{
             if(buildup >= shieldHealth + phaseShieldBoost * phaseHeat && !broken){
                 broken = true;
                 buildup = shieldHealth;
-                shieldBreakEffect.at(x, y, realRadius(), team.color, sides);
+                shieldBreakEffect.at(x, y, realRadius(), team.color, this.block);
                 breakSound.at(x, y);
                 if(team != state.rules.defaultTeam){
                     Events.fire(Trigger.forceProjectorBreak);


### PR DESCRIPTION
Force projectors with not 6-sided shields will still create 6-sided shieldBreak effects in Build 159.7.
Only using 'sides' maybe will not let the effect get the right rotation offset.

- [√] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [√] I have ensured that my code compiles, if applicable.
- [√] I have ensured that any new features in this PR function correctly in-game, if applicable.

