### PR TITLE
Add rotation offset support for ForceProjector's shield breaking effect (2)

### DIFF
--- a/core/src/mindustry/content/Fx.java
+++ b/core/src/mindustry/content/Fx.java
@@ -14,6 +14,7 @@ import mindustry.graphics.*;
 import mindustry.type.*;
 import mindustry.world.*;
 import mindustry.world.blocks.units.UnitAssembler.*;
+import mindustry.world.blocks.defense.ForceProjector.*;
 
 import static arc.graphics.g2d.Draw.rect;
 import static arc.graphics.g2d.Draw.*;

--- a/core/src/mindustry/content/Fx.java
+++ b/core/src/mindustry/content/Fx.java
@@ -2807,6 +2807,10 @@ public class Fx{
     shieldBreak = new Effect(40, e -> {
         color(e.color);
         stroke(3f * e.fout());
+        if(e.data instanceof ForceProjector f){
+            Lines.poly(e.x, e.y, f.sides, e.rotation + e.fin(), f.shieldRotation);
+            return;
+        }
         Lines.poly(e.x, e.y, e.data instanceof Integer i ? i : 6, e.rotation + e.fin());
     }).followParent(true),
 

--- a/core/src/mindustry/world/blocks/defense/ForceProjector.java
+++ b/core/src/mindustry/world/blocks/defense/ForceProjector.java
@@ -242,7 +242,7 @@ public class ForceProjector extends Block{
             if(buildup >= shieldHealth + phaseShieldBoost * phaseHeat && !broken){
                 broken = true;
                 buildup = shieldHealth;
-                shieldBreakEffect.at(x, y, realRadius(), team.color, sides);
+                shieldBreakEffect.at(x, y, realRadius(), team.color, this.block);
                 breakSound.at(x, y);
                 if(team != state.rules.defaultTeam){
                     Events.fire(Trigger.forceProjectorBreak);


### PR DESCRIPTION
I couldn't clone the repository so I tested it in my own Java mod. It worked.
Used 'this.block' instead of 'sides' only. So shieldBreak can read ForceProjector's shieldRotation as its own rotation offset.
I tried to add this for ForceFieldAbility but it always went wrong.

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
