### PR TITLE
Rename 'unit control unbind' with 'unit control decontrol'

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -344,7 +344,7 @@ public class LExecutor{
             if(!exec.privileged && !state.rules.logicUnitControl) return;
 
             Object unitObj = exec.unit.obj();
-            boolean control = type != LUnitControl.unbind && type != LUnitControl.within;
+            boolean control = type != LUnitControl.decontrol && type != LUnitControl.within;
             LogicAI ai = checkLogicAI(exec, unitObj, control);
 
             //only control standard AI units
@@ -370,7 +370,7 @@ public class LExecutor{
                             unit.clearBuilding();
                         }
                     }
-                    case unbind -> {
+                    case decontrol -> {
                         if(unit.controller() instanceof LogicAI){
                             unit.resetController();
                         }

--- a/core/src/mindustry/logic/LParser.java
+++ b/core/src/mindustry/logic/LParser.java
@@ -81,6 +81,9 @@ public class LParser{
                 tokens[1] = "@status-" + tokens[1];
             }
         }
+        if(tokens[0].equals("ucontrol") && tokens[1].equals("unbind")){
+            tokens[1] = "decontrol";
+        }
     }
 
     /** Reads the next statement until EOL/EOF. */

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -1129,7 +1129,7 @@ public class LStatements{
             table.add(" ");
 
             table.button(b -> {
-                b.label(() -> type.symbol());
+                b.label(() -> type.name());
                 b.clicked(() -> showSelect(b, Structs.filter(LUnitControl.class, LUnitControl.all, t ->
                     t == LUnitControl.build ? state.rules.logicUnitBuild :
                     t == LUnitControl.deconstruct ? state.rules.logicUnitDeconstruct :

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -1129,7 +1129,7 @@ public class LStatements{
             table.add(" ");
 
             table.button(b -> {
-                b.label(() -> type.name());
+                b.label(() -> type.symbol());
                 b.clicked(() -> showSelect(b, Structs.filter(LUnitControl.class, LUnitControl.all, t ->
                     t == LUnitControl.build ? state.rules.logicUnitBuild :
                     t == LUnitControl.deconstruct ? state.rules.logicUnitDeconstruct :

--- a/core/src/mindustry/logic/LUnitControl.java
+++ b/core/src/mindustry/logic/LUnitControl.java
@@ -21,19 +21,12 @@ public enum LUnitControl{
     deconstruct("x", "y"),
     getBlock("x", "y", "type", "building", "floor"),
     within("x", "y", "radius", "result"),
-    unbind;
+    decontrol;
 
     public final String[] params;
     public static final LUnitControl[] all = values();
 
     LUnitControl(String... params){
         this.params = params;
-    }
-
-    public String symbol() {
-        return switch (this) {
-            case unbind -> "decontrol";
-            default -> this.name();
-        };
     }
 }

--- a/core/src/mindustry/logic/LUnitControl.java
+++ b/core/src/mindustry/logic/LUnitControl.java
@@ -29,4 +29,11 @@ public enum LUnitControl{
     LUnitControl(String... params){
         this.params = params;
     }
+
+    public String symbol() {
+        return switch (this) {
+            case unbind -> "decontrol";
+            default -> this.name();
+        };
+    }
 }


### PR DESCRIPTION
The name 'unbind' has led to the creation of many foolish programs, such as:

```gas
ubind @flare
ucontrol unbind 0 0 0 0 0
```

But the behavior of `ucontrol unbind` is to ~~control and~~ release control, but because of the name `unbind`, it guides people to use it in pairs with `ubind` (unit bind).
This has resulted in poor outcomes: some programs that do not require control have established unexpected ~~controls and~~ immediately released them, inadvertently disrupting the programs of many ongoing control units

So this PR renamed 'unbind' to 'decontrol', so that people no longer confuse control and binding

Since only the display of logic editor has been changed, there will be no compatibility problems with exporting/importing, and users who write code outside of logic editor are usually not misled by this confuse naming

**CURRENT**:
According to the comments, changing the internal naming helps with consistency, and we are waiting for your opinion on which commit to use

**NOTE**: This PR is missing translation updates, but I am unable to commit update patches as it has been closed

---

This is different from the fixes in https://github.com/Anuken/Mindustry/issues/8897#issuecomment-1683302765 (I noticed that was reverted), this PR establishes the correct naming to prevent it from being confused

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
