### PR TITLE
Fix setblock placement for even-sized multiblock buildings

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -1584,8 +1584,16 @@ public class LExecutor{
         public void run(LExecutor exec){
             if(net.client()) return;
 
-            Tile tile = world.tile(Mathf.round(x.numf()), Mathf.round(y.numf()));
-            if(tile != null && block.obj() instanceof Block b){
+            if(!(block.obj() instanceof Block b)) return;
+
+            Tile tile;
+            if(layer == TileLayer.block){
+                tile = world.tile(World.toTile(World.unconv(x.numf()) - b.offset), World.toTile(World.unconv(y.numf()) - b.offset));
+            }else{
+                tile = world.tile(Mathf.round(x.numf()), Mathf.round(y.numf()));
+            }
+
+            if(tile != null){
                 switch(layer){
                     case ore -> {
                         if((b instanceof OverlayFloor || b == Blocks.air) && tile.overlay() != b) tile.setOverlayNet(b);

--- a/tests/src/test/java/ApplicationTests.java
+++ b/tests/src/test/java/ApplicationTests.java
@@ -1,6 +1,7 @@
 import arc.*;
 import arc.backend.headless.*;
 import arc.files.*;
+import arc.math.*;
 import arc.math.geom.*;
 import arc.struct.*;
 import arc.util.*;
@@ -22,6 +23,7 @@ import mindustry.mod.*;
 import mindustry.mod.Mods.*;
 import mindustry.net.*;
 import mindustry.net.Packets.*;
+import mindustry.logic.*;
 import mindustry.type.*;
 import mindustry.world.*;
 import mindustry.world.blocks.payloads.*;
@@ -289,6 +291,27 @@ public class ApplicationTests{
                 assertEquals(world.tile(x, y).build, world.tile(bx, by).build);
             }
         }
+    }
+
+    @Test
+    void setBlockMultiblockSensorCoords(){
+        createMap();
+        state.set(State.playing);
+
+        LExecutor.runLogicScript("setblock block @container 5.5 5.5 @derelict 0");
+        assertEquals(Blocks.container, world.tile(5, 5).block());
+        assertEquals(5, world.tile(5, 5).build.tileX());
+        assertEquals(5, world.tile(5, 5).build.tileY());
+
+        world.tile(5, 5).setBlock(Blocks.air);
+
+        LExecutor.runLogicScript("setblock block @container 5.6 5.6 @derelict 0");
+        assertEquals(Blocks.container, world.tile(5, 5).block());
+
+        world.tile(5, 5).setBlock(Blocks.air);
+
+        LExecutor.runLogicScript("setblock block @vault 3 3 @derelict 0");
+        assertEquals(Blocks.vault, world.tile(3, 3).block());
     }
 
     @Test


### PR DESCRIPTION
## Description

`setblock` was using `Mathf.round` on logic coordinates directly, which lands one tile off when placing even-sized blocks from sensor `@x`/`@y` (those coords include the block draw offset, so a 2x2 anchor at tile 5 reads as 5.5).

I changed block-layer tile lookup to match manual placement and `ucontrol build`: subtract the target block's offset, then `World.toTile`. Floor/ore layers keep the old rounding path.

Fixes #12493

## Why

Replacing a 2x2 building via logic using sensed coordinates should anchor at the same tile the sensor came from, not one tile up/right.

## Verification

- before on `master`: `./gradlew tests:test --tests ApplicationTests.setBlockMultiblockSensorCoords` fails (`expected: <container> but was: <air>` on `setblock block @container 5.5 5.5`)
- after: same test passes (also checks 5.6 coords and a 3x3 vault case)

Made with [Cursor](https://cursor.com)