### PR TITLE
Fix texture streaming races

### DIFF
--- a/core/src/mindustry/core/NetClient.java
+++ b/core/src/mindustry/core/NetClient.java
@@ -169,7 +169,11 @@ public class NetClient implements ApplicationListener{
             try(DataInputStream in = new DataInputStream(data.stream)){
                 String name = in.readUTF();
                 byte[] pngData = in.readAllBytes();
-                if(!headless) state.data.addTexture(name, pngData);
+                if(!headless){
+                    //empty image data means we're removing the texture instead. see NetServer.removeTexture()
+                    if(pngData.length == 0) state.data.removeTexture(name);
+                    else state.data.addTexture(name, pngData);
+                }
             }catch(IOException e){
                 Log.err("Failed to read server texture stream", e);
             }

--- a/core/src/mindustry/core/NetServer.java
+++ b/core/src/mindustry/core/NetServer.java
@@ -554,34 +554,36 @@ public class NetServer implements ApplicationListener{
 
     /**
      * Streams a texture to a single connected client. This may take some time if the image is large or if the connection is poor.
-     * Make sure to call {@link mindustry.mod.DataManager#removeTexture} when the image is no longer needed to prevent resource leaks.
-     * Use {@link PixmapIO#writePngBytes} to get Pixmap bytes. Respect {@link mindustry.mod.DataPatcher#maxImageSize}. */
+     * Make sure to call {@link #removeTexture(NetConnection, String)} when the image is no longer needed to prevent resource leaks.
+     * Use {@link PixmapIO#writePngBytes} to get Pixmap bytes. Respect {@link mindustry.mod.DataPatcher#maxImageSize}.
+     * Should be called on main thread to ensure correct ordering of sends (multiple with same name), and removals (remove called right after adding). */
     public void sendTexture(NetConnection con, String name, byte[] pngData){
-        mainExecutor.submit(() -> {
-            var stream = packTexture(name, pngData);
-            con.sendStreamAsync(new TextureStream(), stream);
-        });
-    }
-
-    /** Streams a texture to every connected client. See {@link #sendTexture(NetConnection, String, byte[])} for more info. */
-    public void sendTexture(String name, byte[] pngData){
-        mainExecutor.submit(() -> {
-            var stream = packTexture(name, pngData);
-            for(NetConnection con : net.getConnections()){
-                con.sendStreamAsync(new TextureStream(), stream);
-            }
-        });
-    }
-
-    private ByteArrayOutputStream packTexture(String name, byte[] pngData){
         var stream = new ByteArrayOutputStream();
-        try(DataOutputStream out = new DataOutputStream(stream)){
-            out.writeUTF(name);
-            out.write(pngData);
-        }catch(IOException e){
-            throw new RuntimeException(e);
+        NetworkIO.packTexture(stream, name, pngData);
+        con.sendStreamAsync(new TextureStream(), stream);
+    }
+
+    /** Streams a texture to every connected client.
+     * See {@link #sendTexture(NetConnection, String, byte[])} for more info. */
+    public void sendTexture(String name, byte[] pngData){
+        var stream = new ByteArrayOutputStream();
+        NetworkIO.packTexture(stream, name, pngData);
+        for(NetConnection con : net.getConnections()){
+            con.sendStreamAsync(new TextureStream(), stream);
         }
-        return stream;
+    }
+
+    /** Removes a texture previously sent with {@link #sendTexture(NetConnection, String, byte[])} from a single client.
+     * If called while the texture is in use, it will be replaced with a black rectangle. Do not do this.
+     * Should be called on main thread for the same reasons as sendTexture. */
+    public void removeTexture(NetConnection con, String name){
+        sendTexture(con, name, Streams.emptyBytes);
+    }
+
+    /** Removes a texture previously sent with {@link #sendTexture(String, byte[])} from every connected client.
+     * See {@link #removeTexture(NetConnection, String)} for more info. */
+    public void removeTexture(String name){
+        sendTexture(name, Streams.emptyBytes);
     }
 
     public void addPacketHandler(String type, Cons2<Player, String> handler){

--- a/core/src/mindustry/mod/DataImagePacker.java
+++ b/core/src/mindustry/mod/DataImagePacker.java
@@ -26,7 +26,9 @@ public class DataImagePacker{
 
     private @Nullable TextureAtlas patchAtlas;
     /** Textures added at runtime via addTexture(), keyed by their unprefixed name. Tracked separately from patchAtlas so they can be added/removed individually. */
-    private ObjectMap<String, Texture> serverImages = new ObjectMap<>();
+    private final ObjectMap<String, Texture> serverImages = new ObjectMap<>();
+    /** Single threaded executor so that concurrent calls always complete in FIFO order. */
+    private final ExecutorService textureExecutor = Threads.executor("Server Texture Streamer", 1);
 
     /** Packs a new set of images. If images are already packed, disposes of the old ones. */
     public void pack(Seq<ImageAsset> images){
@@ -201,7 +203,7 @@ public class DataImagePacker{
 
     /** Decodes PNG bytes and registers them into the atlas under "netRegionPrefix + name", replacing any existing image with the same name. Safe to call from any thread. */
     public void addTexture(String name, byte[] pngData){
-        Vars.mainExecutor.submit(() -> {
+        textureExecutor.execute(() -> {
             Pixmap pixmap;
             try{
                 pixmap = new Pixmap(pngData);
@@ -235,8 +237,8 @@ public class DataImagePacker{
         });
     }
 
-    /** Removes a texture previously added with {@link #addTexture} */
-    public void removeTexture(String name){
+    /** Removes a texture previously added with {@link #addTexture}. Must be called on the main thread. */
+    private void removeTexture(String name){
         Texture texture = serverImages.remove(name);
         if(texture != null){
             Core.atlas.getRegionMap().remove(serverRegionPrefix + name);
@@ -244,6 +246,11 @@ public class DataImagePacker{
             texture.dispose();
             Core.atlas.getDrawables().remove(serverRegionPrefix + name);
         }
+    }
+
+    /** Queues a texture for removal. Will run after any pending {@link #addTexture} calls so that races do not occur. */
+    public void removeTextureQueued(String name){
+        textureExecutor.execute(() -> Core.app.post(() -> removeTexture(name)));
     }
 
     public void printStats(PixmapPacker mainPacker, PixmapPacker envPacker){

--- a/core/src/mindustry/mod/DataManager.java
+++ b/core/src/mindustry/mod/DataManager.java
@@ -7,10 +7,10 @@ import arc.graphics.g2d.TextureAtlas.*;
 import arc.struct.*;
 import arc.util.*;
 import mindustry.*;
-import mindustry.annotations.Annotations.*;
 import mindustry.ctype.*;
 import mindustry.graphics.*;
 import mindustry.mod.data.*;
+import mindustry.net.*;
 
 public class DataManager{
     private DataPatcher patcher = new DataPatcher();
@@ -189,15 +189,15 @@ public class DataManager{
     }
 
     /** Adds/replaces a single image pushed by the server at runtime, independent of map/mod data patches.
-     * Use {@link mindustry.core.NetServer#sendTexture} to send a texture to connected clients. */
+     * Use {@link mindustry.core.NetServer#sendTexture(NetConnection, String, byte[])} to send a texture to connected clients. */
     public void addTexture(String name, byte[] pngData){
         if(!Vars.headless) packer.addTexture(name, pngData);
     }
 
-    /** Removes a texture previously added with {@link #addTexture}. */
-    @Remote(variants = Variant.both)
-    public static void removeTexture(String name){
-        if(!Vars.headless) Vars.state.data.packer.removeTexture(name);
+    /** Removes a texture previously added with {@link #addTexture}.
+     * Use {@link mindustry.core.NetServer#removeTexture(NetConnection, String)} to remove a texture from connected clients. */
+    public void removeTexture(String name){
+        if(!Vars.headless) packer.removeTextureQueued(name);
     }
 
     public void reloadAudio(){

--- a/core/src/mindustry/net/ArcNetProvider.java
+++ b/core/src/mindustry/net/ArcNetProvider.java
@@ -426,6 +426,7 @@ public class ArcNetProvider implements NetProvider{
 
         @Override
         public void sendStream(Streamable stream){
+            //listeners are processed in the order they're added and each reads into the buffer greedily before the next gets a turn, so concurrent streams are sent in FIFO order
             connection.addListener(new InputStreamSender(stream.stream, 1024){
                 int id;
 

--- a/core/src/mindustry/net/NetworkIO.java
+++ b/core/src/mindustry/net/NetworkIO.java
@@ -163,6 +163,15 @@ public class NetworkIO{
         }
     }
 
+    public static void packTexture(OutputStream os, String name, byte[] pngData){
+        try(DataOutputStream stream = new DataOutputStream(os)){
+            stream.writeUTF(name);
+            stream.write(pngData);
+        }catch(IOException e){
+            throw new RuntimeException(e);
+        }
+    }
+
     public static ByteBuffer writeServerData(){
         String name = (headless ? Config.serverName.string() : player.name);
         String description = headless && !Config.desc.string().equals("off") ? Config.desc.string() : "";


### PR DESCRIPTION
As discussed in https://github.com/Anuken/Mindustry/pull/12482, there were a couple issues that still needed to be addressed. This PR fixes both of the issues that were raised there in fairly elegant manner. The API changed from `Call.removeTexture(...)` to `Vars.netServer.removeTexture(...)` (which actually just calls `sendTexture` with empty bytes) but since that hasn't even made it into a release yet it's not worth worrying about.

Depends on https://github.com/Anuken/Arc/pull/208

- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
