### PR TITLE
Menu API: Support coloring stack elements.

### DIFF
--- a/core/src/mindustry/ui/builder/UiTreeBuilder.java
+++ b/core/src/mindustry/ui/builder/UiTreeBuilder.java
@@ -105,6 +105,9 @@ public class UiTreeBuilder{
                             element.name = id;
                             ctx.idElements.put(id, element);
                         }
+                        String colorStr = child.str(UiKey.color); // Apply color if provided
+                        if(colorStr != null) element.setColor(Strings.parseColor(colorStr, Color.white));
+
                         stack.add(element);
                     }
                 }


### PR DESCRIPTION
Allows setting colors of elements in stacks.
Example (sets the color of the background to black with 60% opacity):
<img width="670" height="169" alt="image" src="https://github.com/user-attachments/assets/3541e2a7-ccc9-4312-a8d0-8f54486f95e2" />
<img width="88" height="58" alt="image" src="https://github.com/user-attachments/assets/6dc58cab-4e71-4ce0-abf2-7a8169f98aa0" />




- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
