### PR TITLE
Fix PlacementFragment at large ui scales.

### DIFF
--- a/core/src/mindustry/ui/fragments/PlacementFragment.java
+++ b/core/src/mindustry/ui/fragments/PlacementFragment.java
@@ -691,7 +691,7 @@ public class PlacementFragment{
                             t.row();
                             control.input.buildPlacementUI(t);
                         }).name("inputTable").growX();
-                    }).fillY().bottom().touchable(Touchable.enabled);
+                    }).growX().fillY().bottom().touchable(Touchable.enabled);
                     blockCatTable.table(categories -> {
                         categories.bottom();
                         categories.add(new Image(Styles.black6){


### PR DESCRIPTION
The changes made in https://github.com/Anuken/Arc/pull/209 made this off by one at large (135) ui scale unfortunately, so the solution is to just grow it back up to size. I hope this pr doesn't do this anywhere else. Either way, It's probably still worth it just for the stuff that it does fix.
Before
<img width="74" height="122" alt="image" src="https://github.com/user-attachments/assets/bbe4c383-0b1a-49c8-90e5-0aa406996f87" />

After
<img width="190" height="178" alt="image" src="https://github.com/user-attachments/assets/99db4202-6a5b-4f3f-a03f-40cf3755f556" />


- [X] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [X] I have ensured that my code compiles, if applicable.
- [X] I have ensured that any new features in this PR function correctly in-game, if applicable.
