### PR TITLE
Replace random+CRC32 UUID with proper time-based UUIDv1

### DIFF
--- a/core/src/mindustry/core/Platform.java
+++ b/core/src/mindustry/core/Platform.java
@@ -2,7 +2,6 @@ package mindustry.core;
 
 import arc.*;
 import arc.files.*;
-import arc.math.*;
 import arc.struct.*;
 import arc.util.serialization.*;
 import mindustry.mod.*;
@@ -85,13 +84,11 @@ public interface Platform{
     default void updateRPC(){
     }
 
-    /** Must be a base64 string 8 bytes in length. */
+    /** Must be a base64 string 16 bytes in length (a version 1 UUID). */
     default String getUUID(){
         String uuid = Core.settings.getString("uuid", "");
-        if(uuid.isEmpty()){
-            byte[] result = new byte[8];
-            new Rand().nextBytes(result);
-            uuid = new String(Base64Coder.encode(result));
+        if(uuid.isEmpty() || Base64Coder.decode(uuid).length != 16){
+            uuid = new String(Base64Coder.encode(UUIDv1.generate()));
             Core.settings.put("uuid", uuid);
             return uuid;
         }

--- a/core/src/mindustry/net/Packets.java
+++ b/core/src/mindustry/net/Packets.java
@@ -9,7 +9,6 @@ import mindustry.core.*;
 import mindustry.io.*;
 
 import java.io.*;
-import java.util.zip.*;
 
 /** Class for storing all packets. */
 public class Packets{
@@ -157,11 +156,7 @@ public class Packets{
             TypeIO.writeString(buffer, locale);
             TypeIO.writeString(buffer, usid);
 
-            byte[] b = Base64Coder.decode(uuid);
-            buffer.b(b);
-            CRC32 crc = new CRC32();
-            crc.update(Base64Coder.decode(uuid), 0, b.length);
-            buffer.l(crc.getValue());
+            buffer.b(Base64Coder.decode(uuid));
 
             buffer.b(mobile ? (byte)1 : 0);
             buffer.i(color);

--- a/core/src/mindustry/net/UUIDv1.java
+++ b/core/src/mindustry/net/UUIDv1.java
@@ -1,0 +1,72 @@
+package mindustry.net;
+
+import arc.math.*;
+import arc.util.*;
+
+import java.net.*;
+import java.util.*;
+
+/** Generates RFC 4122 version 1 (time-based) UUIDs, using the machine's MAC address as the node ID when possible. */
+public final class UUIDv1{
+    private static final long epochOffset = 0x01B21DD213814000L;
+    private static final Rand rand = new Rand();
+
+    private static long lastTime = -1;
+    private static int clockSeq = -1;
+
+    private UUIDv1(){}
+
+    /** @return a new version 1 UUID as 16 raw bytes, in RFC 4122 field order. */
+    public static synchronized byte[] generate(){
+        long time = Time.millis() * 10000L + epochOffset;
+        if(clockSeq == -1) clockSeq = rand.nextInt() & 0x3fff;
+        if(time <= lastTime) clockSeq = (clockSeq + 1) & 0x3fff;
+        lastTime = time;
+
+        long timeLow = time & 0xffffffffL;
+        long timeMid = (time >> 32) & 0xffffL;
+        long timeHi = ((time >> 48) & 0x0fffL) | 0x1000L;
+        int clockSeqHi = (clockSeq >> 8) | 0x80;
+        int clockSeqLow = clockSeq & 0xff;
+        long node = node();
+
+        byte[] out = new byte[16];
+        out[0] = (byte)(timeLow >> 24);
+        out[1] = (byte)(timeLow >> 16);
+        out[2] = (byte)(timeLow >> 8);
+        out[3] = (byte)timeLow;
+        out[4] = (byte)(timeMid >> 8);
+        out[5] = (byte)timeMid;
+        out[6] = (byte)(timeHi >> 8);
+        out[7] = (byte)timeHi;
+        out[8] = (byte)clockSeqHi;
+        out[9] = (byte)clockSeqLow;
+        out[10] = (byte)(node >> 40);
+        out[11] = (byte)(node >> 32);
+        out[12] = (byte)(node >> 24);
+        out[13] = (byte)(node >> 16);
+        out[14] = (byte)(node >> 8);
+        out[15] = (byte)node;
+        return out;
+    }
+
+    /** @return the 48-bit node ID, preferring a real MAC address; falls back to a random multicast-flagged one per RFC 4122. */
+    private static long node(){
+        try{
+            Enumeration<NetworkInterface> ifaces = NetworkInterface.getNetworkInterfaces();
+            while(ifaces != null && ifaces.hasMoreElements()){
+                NetworkInterface iface = ifaces.nextElement();
+                byte[] mac = iface.getHardwareAddress();
+                if(mac != null && mac.length == 6 && !iface.isLoopback()){
+                    long node = 0;
+                    for(byte b : mac) node = (node << 8) | (b & 0xffL);
+                    return node;
+                }
+            }
+        }catch(Exception ignored){
+        }
+
+        long node = rand.nextLong() & 0xffffffffffffL;
+        return node | 0x010000000000L;
+    }
+}

--- a/desktop/src/mindustry/desktop/DesktopLauncher.java
+++ b/desktop/src/mindustry/desktop/DesktopLauncher.java
@@ -505,21 +505,6 @@ public class DesktopLauncher extends ClientLauncher{
         }
     }
 
-    @Override
-    public String getUUID(){
-        if(steam){
-            try{
-                byte[] result = new byte[8];
-                new Rand(SVars.user.user.getSteamID().getAccountID()).nextBytes(result);
-                return new String(Base64Coder.encode(result));
-            }catch(Exception e){
-                e.printStackTrace();
-            }
-        }
-
-        return super.getUUID();
-    }
-
     private static void message(String message){
         SDL.SDL_ShowSimpleMessageBox(SDL.SDL_MESSAGEBOX_ERROR, "oh no", message);
     }


### PR DESCRIPTION
## Summary
Player identifiers were previously 8 random bytes padded with a CRC32 checksum of those same bytes (unchecked, unused) to reach the 16-byte wire size - giving only 64 bits of real entropy. This replaces that scheme with a proper RFC 4122 version 1 (time-based) UUID, using the machine's MAC address as the node ID.

## Security
- **MAC-based node ID** makes the identifier tied to actual hardware, making it harder to spin up new identities to dodge bans compared to a purely random value.
- **Removed the Steam-account-derived UUID** (`Rand(steamAccountId).nextBytes(...)`). Steam account IDs are often publicly visible, so this was a deterministic, guessable mapping from a public SteamID to a player's in-game uuid - anyone could compute another player's identifier from their SteamID. Steam clients now use the same random UUIDv1 generation as everyone else.
- Dropped the unchecked CRC32 padding, which added wire bytes without any real verification.

## Compatibility
Wire format size is unchanged (still 16 bytes in `ConnectPacket`), so client and server from this fork remain fully compatible with each other.

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
