### PR TITLE
remove pulsar and quasar's ability to mine (pr this time)

### DIFF
--- a/core/src/mindustry/content/UnitTypes.java
+++ b/core/src/mindustry/content/UnitTypes.java
@@ -394,8 +394,6 @@ public class UnitTypes{
             armor = 4f;
             riseSpeed = descentSpeed = 0.07f;
 
-            mineTier = 2;
-            mineSpeed = 3f;
 
             abilities.add(new ShieldRegenFieldAbility(20f, 40f, 60f * 5, 60f));
 
@@ -440,7 +438,6 @@ public class UnitTypes{
         }};
 
         quasar = new UnitType("quasar"){{
-            mineTier = 3;
             boostMultiplier = 2f;
             health = 640f;
             buildSpeed = 1.1f;
@@ -457,7 +454,6 @@ public class UnitTypes{
             speed = 0.5f;
             hitSize = 13f;
 
-            mineSpeed = 4f;
             drawShields = false;
 
             abilities.add(new ForceFieldAbility(60f, 0.4f, 500f, 60f * 6));


### PR DESCRIPTION
original suggestion, also made by me: https://github.com/Anuken/Mindustry-Suggestions/issues/6496

the nova line's ability to mine is such a random ability for them to have; their main role (or at least, their _intended_ main role) is supporting units at the front line, and being able to mine has absolutely nothing to do with that
doesnt help that umining happens to be one of the most broken mechanics in the game, so these units almost always end up as mining slaves instead of offensive support units

this change will _not_ drastically affect game balancing up until you hit the unit cap since i didnt change the mono tree at all, so you can just fall back on poly and mega if youre going for umining

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [ ] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
