### PR TITLE
Add integer configs to unit build control

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -456,8 +456,11 @@ public class LExecutor{
                             }
 
                             var conf = p5.obj();
+                            if(!p5.isobj){
+                                conf = p5.numi();
+                            }
                             ai.plan.set(x, y, rot, block);
-                            ai.plan.config = conf instanceof Content c ? c : conf instanceof Building b ? b : null;
+                            ai.plan.config = conf instanceof Content c ? c : conf instanceof Building b ? b : conf instanceof Integer i ? i : null;
 
                             unit.clearBuilding();
                             Tile tile = ai.plan.tile();

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -1114,7 +1114,7 @@ public class LStatements{
     @RegisterStatement("ucontrol")
     public static class UnitControlStatement extends LStatement{
         public LUnitControl type = LUnitControl.move;
-        public String p1 = "0", p2 = "0", p3 = "0", p4 = "0", p5 = "0";
+        public String p1 = "0", p2 = "0", p3 = "0", p4 = "0", p5 = "null";
 
         @Override
         public void build(Table table){


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

Problem: Currently ucontrol build instruction does not support Integer config even if some of the blocks already have Integer configuration handlers.  
Changes: Default ucontrol build config value set to "null" instead of "0". Numeric p5 values are read using p5.numi() and forwarded as Integer configs.  
Compatibility: Old 4-operand ucontrol build instruction is compatible, Old 5-operand with numeric config may observe different behavior on blocks with Integer configuration handlers.  
Testing: Tested with Phase Conveyor, Power Node, Mass Driver, Unit Factory and Illuminator. Also verified existing Content and Building configs still work.
