### PR TITLE
Fix mod browser null listing crash

### DIFF
--- a/core/src/mindustry/ui/dialogs/ModBrowserDialog.java
+++ b/core/src/mindustry/ui/dialogs/ModBrowserDialog.java
@@ -93,8 +93,8 @@ public class ModBrowserDialog extends BaseDialog{
             String strResult = response.getResultAsString();
 
             try{
-                Seq<ModListing> mods = json.fromJson(Seq.class, ModListing.class, strResult);
-                if(mods == null) mods = new Seq<>();
+                Seq<ModListing> parsed = json.fromJson(Seq.class, ModListing.class, strResult);
+                Seq<ModListing> mods = parsed == null ? new Seq<>() : parsed;
 
                 var d = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
                 Func<String, Date> parser = text -> {

--- a/core/src/mindustry/ui/dialogs/ModBrowserDialog.java
+++ b/core/src/mindustry/ui/dialogs/ModBrowserDialog.java
@@ -94,6 +94,7 @@ public class ModBrowserDialog extends BaseDialog{
 
             try{
                 Seq<ModListing> mods = json.fromJson(Seq.class, ModListing.class, strResult);
+                if(mods == null) mods = new Seq<>();
 
                 var d = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
                 Func<String, Date> parser = text -> {


### PR DESCRIPTION
If the mod list endpoint returns JSON null, ModBrowserDialog now uses an empty Seq before sorting instead of throwing a NullPointerException.

Verification: git diff --check passed. :core:compileJava was attempted but the checkout has pre-existing generated-entity compilation failures (missing Posc/Unitc/etc. symbols during kaptKotlin).