### PR TITLE
Allow one research tree to be associated with multiple planets

### DIFF
--- a/core/src/mindustry/content/TechTree.java
+++ b/core/src/mindustry/content/TechTree.java
@@ -98,14 +98,17 @@ public class TechTree{
         public Seq<Objective> objectives = new Seq<>();
         /** Nodes that depend on this node. */
         public final Seq<TechNode> children = new Seq<>();
-        /** Planet associated with this tech node. Null to auto-detect, or use Serpulo if no associated planet is found. */
+        /** The main planet associated with this tech node. Null to auto-detect, or use Serpulo if no associated planet is found. */
         public @Nullable Planet planet;
+        /** Secondary planets associated with this tech node. */
+        public @Nullable Seq<Planet> planets = new Seq<>();
 
         public TechNode(@Nullable TechNode parent, UnlockableContent content, ItemStack[] requirements){
             if(parent != null){
                 parent.children.add(this);
                 rootNode = parent.rootNode == null ? parent : parent.rootNode;
                 planet = parent.planet;
+                planets = parent.planets;
                 researchCostMultipliers = parent.researchCostMultipliers;
             }else if(researchCostMultipliers == null){
                 researchCostMultipliers = new ObjectFloatMap<>();

--- a/core/src/mindustry/mod/ContentParser.java
+++ b/core/src/mindustry/mod/ContentParser.java
@@ -1389,6 +1389,14 @@ public class ContentParser{
 
                 if(research.has("planet")){
                     node.planet = find(ContentType.planet, research.getString("planet"));
+                    node.planets.addUnique(node.planet);
+                }
+
+                if(research.has("planets")){
+                    for(var name: research.get("planets").asStringArray()){
+                        node.planets.addUnique(find(ContentType.planet, name));
+                    }
+
                 }
 
                 if(research.getBoolean("root", false)){
@@ -1410,6 +1418,7 @@ public class ContentParser{
                             //reparent the node
                             node.parent = parent;
                             node.planet = parent.planet;
+                            node.planets = parent.planets;
                         }
                     }else{
                         warn(unlock.name + " is not a root node, and does not have a `parent: ` property. Ignoring.");

--- a/core/src/mindustry/type/Planet.java
+++ b/core/src/mindustry/type/Planet.java
@@ -450,12 +450,14 @@ public class Planet extends UnlockableContent{
         loadStats();
 
         if(techTree == null){
-            techTree = TechTree.roots.find(n -> n.planet == this);
+            techTree = TechTree.roots.find(n -> n.planets.contains(this));
         }
 
-        if(techTree != null && autoAssignPlanet){
-            techTree.addDatabaseTab(this);
-            techTree.addPlanet(this);
+        if(autoAssignPlanet){
+            for(var tech : TechTree.roots.select(n -> n.planets.contains(this))){
+                tech.addDatabaseTab(this);
+                tech.addPlanet(this);
+            }
         }
 
         for(Sector sector : sectors){

--- a/core/src/mindustry/ui/dialogs/ResearchDialog.java
+++ b/core/src/mindustry/ui/dialogs/ResearchDialog.java
@@ -218,7 +218,7 @@ public class ResearchDialog extends BaseDialog{
                 //first, find a planets associated with the current tech tree
                 rootPlanets.clear();
                 for(var planet : content.planets()){
-                    if(planet.techTree == lastNode || lastNode.planet == planet){
+                    if(planet.techTree == lastNode || lastNode.planet == planet || lastNode.planets.contains(planet)){
                         rootPlanets.add(planet);
                     }
                 }


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

This commit ensures compability with previous version. Just add a `planets` field to ensure a new tech tree can use the resources from multiple planets.