### PR TITLE
Add configPos unit control

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -3066,6 +3066,7 @@ lenum.payenter = Enter/land on the payload block the unit is on.
 lenum.flag = Numeric unit flag.
 lenum.mine = Mine at a position.
 lenum.build = Build a structure.
+lenum.configpos = Configure a building with a target position.
 lenum.getblock = Fetch building, floor and block type at coordinates.\nUnit must be in range of the position, otherwise null is returned.
 lenum.within = Check if unit is near a position.
 lenum.boost = Start/stop boosting.

--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -467,6 +467,22 @@ public class LExecutor{
                             }
                         }
                     }
+                    case configPos -> {
+                        float range = Math.max(unit.range(), unit.type.buildRange);
+
+                        if(!p3.isobj && !p4.isobj && unit.within(x1, y1, range)){
+                            float x2 = World.unconv(p3.numf()), y2 = World.unconv(p4.numf());
+                            Building source = world.buildWorld(x1, y1);
+                            Tile target = world.tileWorld(x2, y2);
+
+                            if(source != null && target != null && source.team == unit.team && source.block.configurations.containsKey(Point2.class)){
+                                source.configured(unit, Tmp.p1.set(
+                                        target.x - source.tileX(),
+                                        target.y - source.tileY()
+                                ));
+                            }
+                        }
+                    }
                     case deconstruct -> {
                         if((state.rules.logicUnitDeconstruct || exec.privileged) && unit.canBuild()){
                             //reset state of last request when necessary

--- a/core/src/mindustry/logic/LUnitControl.java
+++ b/core/src/mindustry/logic/LUnitControl.java
@@ -18,6 +18,7 @@ public enum LUnitControl{
     mine("x", "y"),
     flag("value"),
     build("x", "y", "block", "rotation", "config"),
+    configPos("x", "y", "tx", "ty"),
     deconstruct("x", "y"),
     getBlock("x", "y", "type", "building", "floor"),
     within("x", "y", "radius", "result"),


### PR DESCRIPTION
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

Adds ucontrol configPos x y tx ty, allowing units to configure nearby buildings with a target position using normal logic coordinates.

This is a different approach to #12538. No internal information exposed to user. The target coordinates are converted internally to the existing Point2 configuration used by compatible blocks. Blocks without a Point2 configuration handler are left unaffected.

Tested in-game with phase conveyors/conduits, bridge conveyors/conduits, and mass drivers. Also tested with a power node to verify that unsupported configuration types are not affected.