### PR TITLE
Duct caps

### DIFF
--- a/core/src/mindustry/world/blocks/distribution/Duct.java
+++ b/core/src/mindustry/world/blocks/distribution/Duct.java
@@ -29,6 +29,7 @@ public class Duct extends Block implements Autotiler{
 
     public @Load(value = "@-top-#", length = 5) TextureRegion[] topRegions;
     public @Load(value = "@-bottom-#", length = 5, fallback = "duct-bottom-#") TextureRegion[] botRegions;
+    public @Load("@-cap") TextureRegion capRegion;
 
     public @Nullable Block bridgeReplacement, junctionReplacement;
 
@@ -132,8 +133,9 @@ public class Duct extends Block implements Autotiler{
         public @Nullable Item current;
         public int recDir = 0;
         public int blendbits, xscl, yscl, blending;
-        public @Nullable Building next;
+        public @Nullable Building next, prev;
         public @Nullable DuctBuild nextc;
+        public boolean capped, backCapped = false;
 
         @Override
         public void draw(){
@@ -174,6 +176,11 @@ public class Duct extends Block implements Autotiler{
             Draw.z(Layer.blockUnder + 0.2f);
             drawAt(x, y, blendbits, rotation, SliceMode.none, under);
             Draw.reset();
+
+            if(!under) return;
+
+            if(capped && capRegion.found()) Draw.rect(capRegion, x, y, rotdeg());
+            if(backCapped && capRegion.found()) Draw.rect(capRegion, x, y, rotdeg() + 180);
         }
 
         @Override
@@ -254,6 +261,10 @@ public class Duct extends Block implements Autotiler{
             blending = bits[4];
             next = front();
             nextc = next instanceof DuctBuild d ? d : null;
+
+            prev = back();
+            capped = next == null || next.team != team || !next.block.hasItems;
+            backCapped = blendbits == 0 && (prev == null || prev.team != team || !prev.block.hasItems);
         }
 
         @Override


### PR DESCRIPTION
Allows modded/datapatched item ducts to have caps similar to plated/reinforced conduits by copy-pasting their code in ducts.
Example of modded duct:
<img width="477" height="267" alt="image" src="https://github.com/user-attachments/assets/bb4f4a3c-d1f1-449a-aae5-5e86ee863ae8" />

I only tested it in my mod, and it does compile and work, so it _should_ work in vanilla.
And in case it's to be actually merged, I can try doing the same with conveyors.


If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
