### PR TITLE
Improved banned and patched content indicators in the database

### DIFF
--- a/core/src/mindustry/ui/dialogs/DatabaseDialog.java
+++ b/core/src/mindustry/ui/dialogs/DatabaseDialog.java
@@ -7,6 +7,7 @@ import arc.scene.event.*;
 import arc.scene.style.*;
 import arc.scene.ui.*;
 import arc.scene.ui.layout.*;
+import arc.scene.ui.layout.Stack;
 import arc.struct.*;
 import arc.util.*;
 import mindustry.*;
@@ -178,21 +179,22 @@ public class DatabaseDialog extends BaseDialog{
                         for(var unlock : array){
                             Image image = unlocked(unlock) ? new Image(new TextureRegionDrawable(unlock.uiIcon), mobile ? Color.white : Color.lightGray).setScaling(Scaling.fit) : new Image(Icon.lock, Pal.gray);
 
-                            //banned cross
-                            if(state.isGame() && unlock.isBanned()){
-                                list.stack(image, new Image(Icon.cancel){{
-                                    setColor(Color.scarlet);
-                                    touchable = Touchable.disabled;
-                                }}).size(8 * 4).pad(3);
-                            }else if(state.isGame() && state.data.isPatched(unlock)){
-                                list.stack(image, new Table(){{
-                                    right().bottom().touchable = Touchable.disabled;
-                                    // Interpolated color (lerp lightishGray and white) for better contrast
-                                    image(Icon.fileSmall).size(12f).color(Tmp.c1.set(Color.white).a(0.5f));
-                                }}).size(8 * 4).pad(3);
-                            }else{
-                                list.add(image).size(8 * 4).pad(3);
-                            }
+                            //banned cross and patched icon
+                            list.stack(image, new Stack(){{
+                                if(state.isGame()){
+                                    if(state.data.isPatched(unlock)){
+                                        add(new Table(){{
+                                            right().bottom().touchable = Touchable.disabled;
+                                            image(Icon.fileSmall).size(12f).color(Tmp.c1.set(Color.white).a(0.5f));
+                                        }});
+                                    }
+                                    if(unlock.isBanned()){
+                                        add(new Image(Icon.cancel, Tmp.c1.set(Color.scarlet).a(0.6f)){{
+                                            touchable = Touchable.disabled;
+                                        }});
+                                    }
+                                }
+                            }}).size(iconMed).pad(3);
 
                             ClickListener listener = new ClickListener();
                             image.addListener(listener);
@@ -221,7 +223,7 @@ public class DatabaseDialog extends BaseDialog{
                         for(int k = 0; k < cols - count; k++){
                             Image image = new Image();
                             image.setColor(Color.clear);
-                            list.add(image).size(8 * 4).pad(3);
+                            list.add(image).size(iconMed).pad(3);
                         }
                     });
                     sub.row();


### PR DESCRIPTION
Improved the content status indicators in the database dialog. 
Banned and patched markers can now be shown at the same time.
<img width="337" height="79" alt="image" src="https://github.com/user-attachments/assets/d86563fb-99c7-4ca7-a1aa-a5f71b7a2c14" />



If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
