### PR TITLE
Fixed campaign.rework.serpulo invisible characters

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -230,7 +230,7 @@ campaign.erekir = Newer, more polished content. Mostly linear campaign progressi
 campaign.serpulo = Older content; the classic experience. More open-ended, more content.\n\nPotentially unbalanced maps and campaign mechanics. Less polished.
 campaign.difficulty = Difficulty
 campaign.rework.title = Campaign Changes Notice
-campaign.rework.serpulo ️️️️️️️= [accent]⚠ The Serpulo campaign has been reworked.[]\n\n\
+campaign.rework.serpulo = [accent]⚠ The Serpulo campaign has been reworked.[]\n\n\
 Sector positions and difficulty have changed. You may encounter issues relating to leftover campaign saves from the old layout.\n\n\
 For a cleaner experience, consider resetting your campaign saves in the settings.
 completed = [accent]Researched


### PR DESCRIPTION
On text editor only show displayable characters that show as same as old one but some non-displayable was added.

<img width="1053" height="526" alt="Screenshot_20260902_120927_Chrome" src="https://github.com/user-attachments/assets/b21e8e2b-831e-46fc-9c49-366b13e24d62" />
Fig 1: My translator tool included equals sign (`=`) while parsing __bundle.properties__???

<img width="1080" height="349" alt="Screenshot_20260902_122507_Chrome" src="https://github.com/user-attachments/assets/7743669d-f6cf-4564-abee-348b367e5784" />
Fig 2: GitHub parser/highlighter gone wrong?
 
<img width="1080" height="1941" alt="Screenshot_20260902_120825_HEX Editor" src="https://github.com/user-attachments/assets/6a7be113-5c6d-44a7-8d21-da7cf282ac64" />
Fig 3: Ah! Found it!
  
<img width="1080" height="698" alt="Screenshot_20260902_122830_Chrome" src="https://github.com/user-attachments/assets/d8ea0fc6-c4c2-4250-a34b-17c91a5fa4ea" />
Fig 4: Source of this issue!!