### PR TITLE
Unset key bindings

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -1110,6 +1110,7 @@ settings.data = Game Data
 settings.reset = Reset to Defaults
 settings.rebind = Rebind
 settings.resetKey = Reset
+settings.unbindKey = Unbind
 settings.controls = Controls
 settings.game = Game
 settings.sound = Sound

--- a/core/src/mindustry/ui/dialogs/KeybindDialog.java
+++ b/core/src/mindustry/ui/dialogs/KeybindDialog.java
@@ -149,24 +149,43 @@ public class KeybindDialog extends Dialog{
         }
     }
 
-    private void openDialog( KeyBind name){
-        rebindDialog = new Dialog(rebindAxis ? bundle.get("keybind.press.axis") : bundle.get("keybind.press"));
+    private void openDialog(KeyBind keyBind){
+        InputListener blocker = new InputListener(){
+            @Override
+            public boolean touchDown(InputEvent event, float x, float y, int pointer, KeyCode button){
+                event.cancel();
+                return true;
+            }
+        };
 
-        rebindKey = name;
+        float bw = 210f, bh = 64f;
+        rebindDialog = new Dialog(bundle.get("keybind." + keyBind.name + ".name", Strings.capitalize(keyBind.name))){{
+            title.setAlignment(Align.center);
+            cont.add(rebindAxis ? bundle.get("keybind.press.axis") : bundle.get("keybind.press")).pad(40f);
+
+            buttons.button("@settings.unbindKey", Icon.cancel, () -> {
+                keyBind.unset();
+                hide();
+            }).size(bw, bh).get().addListener(blocker);;
+
+            buttons.button("@back", Icon.left, this::hide).size(bw, bh).get().addListener(blocker);
+        }};
+
+        rebindKey = keyBind;
 
         rebindDialog.titleTable.getCells().first().pad(4);
         rebindDialog.addListener(new InputListener(){
             @Override
             public boolean touchDown(InputEvent event, float x, float y, int pointer, KeyCode button){
                 if(Core.app.isAndroid()) return false;
-                rebind(name, button);
+                rebind(keyBind, button);
                 return false;
             }
 
             @Override
             public boolean keyDown(InputEvent event, KeyCode keycode){
                 rebindDialog.hide();
-                rebind(name, keycode);
+                rebind(keyBind, keycode);
                 return false;
             }
 
@@ -174,7 +193,7 @@ public class KeybindDialog extends Dialog{
             public boolean scrolled(InputEvent event, float x, float y, float amountX, float amountY){
                 if(!rebindAxis) return false;
                 rebindDialog.hide();
-                rebind(name, KeyCode.scroll);
+                rebind(keyBind, KeyCode.scroll);
                 return false;
             }
         });


### PR DESCRIPTION
The second attempt at https://github.com/Anuken/Mindustry-Suggestions/issues/6428: Allow players to set their Keybinds to "unset". The first one was https://github.com/Anuken/Mindustry/pull/12378.

I've moved the unbind button to the dialog that sets the bind:

<img width="534" height="276" alt="image" src="https://github.com/user-attachments/assets/d9b98edf-ca47-4d1f-819f-a0e86f63885e" />

To prevent a click on one of these buttons to be captured as the key, I've added a listener to them that cancels the `touchDown` event. I believe it is the right approach and it works okay on my system (Windows 11), but I'm not knowledgeable about the events in arc enough to be absolutely sure it will work as well every time. The worst that can happen, though, is that the click on the button will be interpreted as the key.

I've left the reset button in the main screen. It looks better that way imo, it visually indicates the key binding is non-standard, and it allows quickly resetting a bunch of keys. I can move it to the binding dialog if preferred.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
