### PR TITLE
Bugfix: Fix target dummy velocity upon knockback under lower fps

### DIFF
--- a/core/src/mindustry/world/blocks/defense/TargetDummy.java
+++ b/core/src/mindustry/world/blocks/defense/TargetDummy.java
@@ -131,7 +131,7 @@ public class TargetDummy extends Block{
                 unit.hitSize = dummySize;
 
                 //similar to impulseNet but does not factor in mass
-                Tmp.v1.set(this).sub(unit).limit(dst(unit) * pullScale * Time.delta);
+                Tmp.v1.set(this).sub(unit).limit(dst(unit) * pullScale);
                 unit.vel.add(Tmp.v1);
 
                 //manually move units to simulate velocity for remote players


### PR DESCRIPTION
Delta was being applied twice (TargetDummy class + Velcomp)

### Before

<img width="1410" height="717" alt="image" src="https://github.com/user-attachments/assets/4d9d92ef-5600-400c-9360-d956cdf57a9d" />

### After

https://github.com/user-attachments/assets/6d290e2d-2164-4c6c-ad7a-7d6a6ab87b42



If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
