### PR TITLE
Write to multiple adjacent elements at once

### DIFF
--- a/core/src/mindustry/logic/LExecutor.java
+++ b/core/src/mindustry/logic/LExecutor.java
@@ -645,12 +645,13 @@ public class LExecutor{
     }
 
     public static class WriteI implements LInstruction{
-        public LVar target, position, value;
+        public LVar target, position, value, length;
 
-        public WriteI(LVar target, LVar position, LVar value){
+        public WriteI(LVar target, LVar position, LVar value, LVar length){
             this.target = target;
             this.position = position;
             this.value = value;
+            this.length = length;
         }
 
         public WriteI(){
@@ -661,7 +662,7 @@ public class LExecutor{
             Object targetObj = target.obj();
             if(targetObj instanceof LWritable write){
                 if(!write.writable(exec)) return;
-                write.write(position, value);
+                write.write(position, value, length);
             }
         }
     }

--- a/core/src/mindustry/logic/LStatements.java
+++ b/core/src/mindustry/logic/LStatements.java
@@ -93,7 +93,7 @@ public class LStatements{
 
     @RegisterStatement("write")
     public static class WriteStatement extends LStatement{
-        public String input = "result", target = "cell1", address = "0";
+        public String input = "result", target = "cell1", address = "0", length = "1";
 
         @Override
         public void build(Table table){
@@ -110,11 +110,15 @@ public class LStatements{
             table.add(bundle("at"));
 
             field(table, address, str -> address = str);
+
+            table.add(bundle("length"));
+
+            field(table, length, str -> length = str);
         }
 
         @Override
         public LInstruction build(LAssembler builder){
-            return new WriteI(builder.var(target), builder.var(address), builder.var(input));
+            return new WriteI(builder.var(target), builder.var(address), builder.var(input), builder.var(length));
         }
 
         @Override

--- a/core/src/mindustry/logic/LWritable.java
+++ b/core/src/mindustry/logic/LWritable.java
@@ -2,5 +2,5 @@ package mindustry.logic;
 
 public interface LWritable{
     boolean writable(LExecutor exec);
-    void write(LVar position, LVar value);
+    void write(LVar position, LVar value, LVar length);
 }

--- a/core/src/mindustry/world/blocks/logic/CanvasBlock.java
+++ b/core/src/mindustry/world/blocks/logic/CanvasBlock.java
@@ -154,9 +154,12 @@ public class CanvasBlock extends Block{
         public int blending;
         protected boolean invalidated = false;
 
-        public void setPixel(int pos, int index){
+        public void setPixel(int pos, int length, int index){
             if(pos < canvasSize * canvasSize && pos >= 0 && index >= 0 && index < palette.length){
-                setByte(data, pos * bitsPerPixel, index);
+                int repeat = Math.min(length, canvasSize * canvasSize - pos);
+                while (repeat-- > 0) {
+                    setByte(data, pos++ * bitsPerPixel, index);
+                }
                 invalidated = true;
             }
         }
@@ -244,8 +247,8 @@ public class CanvasBlock extends Block{
         }
 
         @Override
-        public void write(LVar position, LVar value){
-            setPixel(position.numi(), value.numi());
+        public void write(LVar position, LVar value, LVar length){
+            setPixel(position.numi(), length.numi(), value.numi());
         }
 
         boolean blends(Tile other){

--- a/core/src/mindustry/world/blocks/logic/LogicBlock.java
+++ b/core/src/mindustry/world/blocks/logic/LogicBlock.java
@@ -633,7 +633,7 @@ public class LogicBlock extends Block{
         }
 
         @Override
-        public void write(LVar position, LVar value){
+        public void write(LVar position, LVar value, LVar length){
             if(position.isobj && position.objval instanceof String varName){
                 LVar at = executor.optionalVar(varName);
                 if(at == null || at.constant) return;

--- a/core/src/mindustry/world/blocks/logic/MemoryBlock.java
+++ b/core/src/mindustry/world/blocks/logic/MemoryBlock.java
@@ -109,15 +109,17 @@ public class MemoryBlock extends Block{
         }
 
         @Override
-        public void write(LVar position, LVar value){
+        public void write(LVar position, LVar value, LVar length){
             int address = position.numi();
-            if(address < 0 || address >= objectMemory.length) return;
+            int len = length.numi();
+            if(address < 0 || address >= objectMemory.length || len <= 0) return;
+            int end = Math.min(objectMemory.length, address + len);
 
             if(value.isobj){
-                objectMemory[address] = value.objval;
+                Arrays.fill(objectMemory, address, end, value.objval);
             }else{
-                objectMemory[address] = sentinel;
-                numberMemory[address] = value.numval;
+                Arrays.fill(objectMemory, address, end, sentinel);
+                Arrays.fill(numberMemory, address, end, value.numval);
             }
         }
 


### PR DESCRIPTION
This PR adds a `length` parameter to the `write` instruction. It specifies the number of elements to write to. The primary goal is to allow clearing memory cells faster, e.g. `write 0 cell1 0 64` clears the entire memory cell in a single instruction. The default value of `length` is `1`, meaning that old code works the same as before.

The `LWritable.write()` method has been updated to accept the `length` parameter. The `CanvasBlock` and `MemoryBlock` implementations limit the length to the maximum supported value, so that providing an absurd number, such as `1e20`, doesn't hang the processor in a loop. The `LogicBlock` implementation ignores the parameter entirely, as the `address` is a string and `length` doesn't make sense in that context.

`MemoryBlock` uses `Arrays.fill()` to set the arrays. The `CanvasBlock` uses loops; it could be optimized and I'll do it if required, but I didn't want to risk introducing bugs if not necessary.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
