### PR TITLE
Erekir unit producers disable commands

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -6483,6 +6483,7 @@ public class Blocks{
             regionSuffix = "-dark";
 
             size = 3;
+            configurable = false;
             consumePower(3f);
             consumeLiquid(Liquids.hydrogen, 3f / 60f);
             consumeItems(with(Items.silicon, 40, Items.tungsten, 30));
@@ -6500,6 +6501,7 @@ public class Blocks{
             regionSuffix = "-dark";
 
             size = 3;
+            configurable = false;
             consumePower(2.5f);
             consumeLiquid(Liquids.hydrogen, 3f / 60f);
             consumeItems(with(Items.silicon, 60, Items.tungsten, 40));
@@ -6518,6 +6520,7 @@ public class Blocks{
             regionSuffix = "-dark";
 
             size = 3;
+            configurable = false;
             consumePower(2.5f);
             consumeLiquid(Liquids.hydrogen, 3f / 60f);
             consumeItems(with(Items.silicon, 50, Items.tungsten, 40));
@@ -6538,6 +6541,7 @@ public class Blocks{
             researchCostMultipliers.put(Items.thorium, 0.2f);
 
             size = 5;
+            configurable = false;
             consumePower(4.5f);
             consumeLiquid(Liquids.nitrogen, 10f / 60f);
             consumeItems(with(Items.thorium, 80, Items.silicon, 100));


### PR DESCRIPTION
The recently merged payenter command #11613 makes unit production schematics and mechanics involving units + payload drivers basically obsolete (since it has become automatic). 
"Move to position" rts command for reconstructors/unit factories is still available. Manual payenter for ground units is still available

### Before
<img width="300" height="384" alt="image" src="https://github.com/user-attachments/assets/d003c69e-3b5d-42a3-a2c5-f35091fb8e29" />


### After
<img width="1054" height="604" alt="image" src="https://github.com/user-attachments/assets/fcd96724-6827-4632-a9ac-003990b1d10a" />


If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
