### PR TITLE
Restore failed mod indicator

### DIFF
--- a/core/src/mindustry/ui/dialogs/ModsDialog.java
+++ b/core/src/mindustry/ui/dialogs/ModsDialog.java
@@ -238,7 +238,7 @@ public class ModsDialog extends BaseDialog{
                                         (shortDesc.length() > 0 ? "[lightgray]" + shortDesc + "\n" : "")
                                         //so does anybody care about version?
                                         //+ "[gray]v" + Strings.stripColors(trimText(item.meta.version)) + "\n"
-                                        + (mod.enabled() || hideDisabled ? "" : Core.bundle.get("mod.disabled") + ""))
+                                        + (mod.enabled() || hideDisabled ? "" : Core.bundle.get(mod.failed() ? "mod.failed" : "mod.disabled")))
                                     .wrap().top().width(300f).growX().left();
 
                                     text.row();


### PR DESCRIPTION
When merging #12263, the indication of failed mods has been (I believe mistakenly) removed. This PR restores the indication.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
