### PR TITLE
Make the Back button first in the keybind dialog

### DIFF
--- a/core/src/mindustry/ui/dialogs/KeybindDialog.java
+++ b/core/src/mindustry/ui/dialogs/KeybindDialog.java
@@ -163,12 +163,11 @@ public class KeybindDialog extends Dialog{
             title.setAlignment(Align.center);
             cont.add(rebindAxis ? bundle.get("keybind.press.axis") : bundle.get("keybind.press")).pad(40f);
 
+            buttons.button("@back", Icon.left, this::hide).size(bw, bh).get().addListener(blocker);
             buttons.button("@settings.unbindKey", Icon.cancel, () -> {
                 keyBind.unset();
                 hide();
             }).size(bw, bh).get().addListener(blocker);
-
-            buttons.button("@back", Icon.left, this::hide).size(bw, bh).get().addListener(blocker);
         }};
 
         rebindKey = keyBind;


### PR DESCRIPTION
I've realized the Back button is typically the leftmost button in Mindustry. This PR swaps the buttons in the keybind dialog to match.

<img width="512" height="298" alt="image" src="https://github.com/user-attachments/assets/3dfc6336-9d04-4a7d-b6dd-142ac340e289" />

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
