### PR TITLE
update Allure to an archive public repo

### DIFF
--- a/tests/src/test/java/ModTestAllure.java
+++ b/tests/src/test/java/ModTestAllure.java
@@ -19,7 +19,7 @@ public class ModTestAllure extends GenericModTest{
     public void begin(){
         //As of September 5, the Allure repository has been deleted or made private. I do not know why.
         // Archive version of Allure (archive last pull date: 10 April 2026)
-        grabMod("https://github.com/JasonP01/AllureMod/archive/6781eec0838e114f1de1ce572ebbe5790943cfaa.zip");
+        grabMod("https://github.com/JasonP01/AllureMod/archive/3d580bda58e98f6339e1b746980b66b791f108ee.zip");
         checkExistence("allure");
 
         UnitType type = Vars.content.unit("allure-0b11-exodus");

--- a/tests/src/test/java/ModTestAllure.java
+++ b/tests/src/test/java/ModTestAllure.java
@@ -18,8 +18,8 @@ public class ModTestAllure extends GenericModTest{
     @Test
     public void begin(){
         //As of September 5, the Allure repository has been deleted or made private. I do not know why.
-        if(true) return;
-        grabMod("https://github.com/LixieWulf/Allure/archive/c94e83e07ab918c0402b8f3897bba832e42432f0.zip");
+        // Archive version of Allure (archive last pull date: 10 April 2026)
+        grabMod("https://github.com/JasonP01/AllureMod/archive/6781eec0838e114f1de1ce572ebbe5790943cfaa.zip");
         checkExistence("allure");
 
         UnitType type = Vars.content.unit("allure-0b11-exodus");


### PR DESCRIPTION
Since the Allure mod has been archived, there is no good json test. This replaces the fetch with an "archived" version of allure before it went private. Permission to do this has been gotten from LixieWulf, and an invite as collaborator to the repository has been given to Anuken for him to do as he wishes
<img width="1082" height="100" alt="image" src="https://github.com/user-attachments/assets/0ac00066-9879-4e9e-9871-dea3c826a67c" />

This archive is solely so the test can run, i will not be maintaining it, and nobody should attempt to play this mod as it has been removed of all assets as per request. Check the repo https://github.com/JasonP01/AllureMod README.md for slightly more information regarding that