### PR TITLE
Properly compute UTF16 sizes for escapes

### DIFF
--- a/core/src/mindustry/logic/LParser.java
+++ b/core/src/mindustry/logic/LParser.java
@@ -51,7 +51,7 @@ public class LParser{
             //skip over \n, \" and \\ escape sequences
             //this doesn't actually transform the sequences, as that would output invalid characters into Statement fields and break round-trip parsing
             if(c == '\\' && pos + 1 < chars.length && (chars[pos + 1] == 'n' || chars[pos + 1] == '"' || chars[pos + 1] == '\\')){
-                utflen += 2;
+                utflen += utf16size(chars[pos + 1]);
                 pos ++; //consume the escaped character too
                 continue;
             }
@@ -59,10 +59,13 @@ public class LParser{
             //uXXXX: validate 4 hex digits
             if(c == '\\' && pos + 1 < chars.length && chars[pos + 1] == 'u'){
                 if(pos + 5 >= chars.length) error("Invalid \\u escape; expected 4 hex digits.");
+                int value = 0;
                 for(int j = pos + 2; j <= pos + 5; j++){
-                    if(Character.digit(chars[j], 16) == -1) error("Invalid \\u escape; expected 4 hex digits.");
+                    //if any of the digits is invalid, digit() returns -1 and value becomes and stays negative
+                    value = value << 4 | Character.digit(chars[j], 16);
                 }
-                utflen += 3; //decoded char may take up to 3 bytes in modified UTF-8
+                if(value < 0) error("Invalid \\u escape; expected 4 hex digits.");
+                utflen += utf16size(value);
                 pos += 5; //consume u and the 4 hex digits
                 continue;
             }
@@ -73,8 +76,7 @@ public class LParser{
                 break;
             }
 
-            // See ByteBufferOutput.writeUTF()
-            utflen += c != 0 && c <= 0x7F ? 1 : c <= 0x7FF ? 2 : 3;
+            utflen += utf16size(c);
         }
 
         if(pos >= chars.length || chars[pos] != '"') error("Missing closing quote \" before end of file.");
@@ -83,6 +85,11 @@ public class LParser{
         pos ++; //move past the closing quote
 
         return new String(chars, from, pos - from);
+    }
+
+    static int utf16size(int c){
+        //see ByteBufferOutput.writeUTF()
+        return c != 0 && c < 0x80 ? 1 : c < 0x800 ? 2 : 3;
     }
 
     String token(){


### PR DESCRIPTION
Replaces the conservative estimates of utf16 sizes of character escapes with actual size based on the decoded char. Allows parsing strings that are under the 65535 UTF-16 size limit, but exceed the conservative estimate by using Unicode escapes for chars in the `\u0000` .. `0x001F` range.

Also, I don't think the string size limit is checked on strings entered in UI (LStatement), but that probably isn't needed. No one's going to edit that directly.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
