### PR TITLE
Bugfix: status display in HeatCrafter and Constructor

### DIFF
--- a/core/src/mindustry/world/blocks/payloads/BlockProducer.java
+++ b/core/src/mindustry/world/blocks/payloads/BlockProducer.java
@@ -109,7 +109,7 @@ public abstract class BlockProducer extends PayloadBlock{
 
         @Override
         public boolean shouldConsume(){
-            return super.shouldConsume() && recipe() != null;
+            return super.shouldConsume() && recipe() != null && payload == null;
         }
 
         @Override

--- a/core/src/mindustry/world/blocks/production/GenericCrafter.java
+++ b/core/src/mindustry/world/blocks/production/GenericCrafter.java
@@ -201,6 +201,7 @@ public class GenericCrafter extends Block{
             drawer.drawLight(this);
         }
 
+        /** Checks whether this block can output. */
         @Override
         public boolean shouldConsume(){
             if(outputItems != null){

--- a/core/src/mindustry/world/blocks/production/HeatCrafter.java
+++ b/core/src/mindustry/world/blocks/production/HeatCrafter.java
@@ -6,6 +6,7 @@ import mindustry.graphics.*;
 import mindustry.logic.*;
 import mindustry.ui.*;
 import mindustry.world.blocks.heat.*;
+import mindustry.world.consumers.*;
 import mindustry.world.meta.*;
 
 /** A crafter that requires contact from heater blocks to craft. */
@@ -33,6 +34,28 @@ public class HeatCrafter extends GenericCrafter{
     }
 
     @Override
+    public void init(){
+        initializePower();
+        super.init();
+    }
+
+    @Override
+    public void afterPatch(){
+        super.afterPatch();
+        initializePower();
+        reinitializeConsumers();
+    }
+
+    //power usage should account for heat
+    public void initializePower(){
+        if(consPower != null && !consPower.buffered && !(consPower instanceof ConsumePowerCondition)){
+            float usage = consPower.usage;
+            removeConsumers(c -> c instanceof ConsumePower);
+            consumePowerCond(usage, (HeatCrafterBuild b) -> heatRequirement <= 0f || b.heat > 0f);
+        }
+    }
+
+    @Override
     public void setStats(){
         super.setStats();
 
@@ -50,11 +73,6 @@ public class HeatCrafter extends GenericCrafter{
             heat = calculateHeat(sideHeat);
 
             super.updateTile();
-        }
-
-        @Override
-        public boolean shouldConsume(){
-            return (heatRequirement <= 0f || heat > 0) && super.shouldConsume();
         }
 
         @Override


### PR DESCRIPTION
Implements: 
- https://github.com/Anuken/Mindustry-Suggestions/issues/6499


https://github.com/Anuken/Mindustry/commit/9cc687efcac628aea7d45a2e7e1ab973eae0b418 while it worked for patching the issue

> build consumes power when normal consumers (item, liquid) are satisfied but not heat

; it also broke status display (`buildingcomp` `status()` `!shouldconsume = noOutput`).
My fix to this is rather ugly, but aside from overriding status() (_bad scalability_) or touching/refactoring buildingcomp itself (_oh god please no_), I m too stupid to see a better option

### Current (`shouldConsume` override)
<img width="1213" height="548" alt="image" src="https://github.com/user-attachments/assets/e0f2f33c-aec3-4f2f-bc67-5e20060c23d9" />

### No `shouldConsume`
<img width="1168" height="559" alt="image" src="https://github.com/user-attachments/assets/162cb41a-967a-4d5f-9bca-89e27f6798a7" />

### My "fix"

<img width="1002" height="450" alt="image" src="https://github.com/user-attachments/assets/2d12e5d6-c291-4899-be2a-b674deff5910" />
<img width="843" height="612" alt="Captura de pantalla 2026-09-10 215913" src="https://github.com/user-attachments/assets/31ea8fee-5f79-40ff-b1e7-557bbe1a9620" />


If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
