### PR TITLE
Allow ucontrol deconstruct in campaign

### DIFF
--- a/core/src/mindustry/core/Logic.java
+++ b/core/src/mindustry/core/Logic.java
@@ -108,6 +108,7 @@ public class Logic implements ApplicationListener{
                 state.rules.allowEditRules = false;
                 state.rules.allowEditWorldProcessors = false;
                 state.rules.worldProcessorPlayerLink = false;
+                state.rules.logicUnitDeconstruct = true;
 
                 if(state.getPlanet().enemyInfiniteItems){
                     state.rules.waveTeam.rules().infiniteResources = true;


### PR DESCRIPTION
Using logic to deconstruct blocks is currently disabled in campaign. I guess it's an oversight, this is a functionality which could be quite useful in campaign and it won't harm anyone, as campaign is single-player.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
