### PR TITLE
Leave sinking wreckage when units die over liquids

### DIFF
--- a/core/src/mindustry/content/Fx.java
+++ b/core/src/mindustry/content/Fx.java
@@ -118,6 +118,22 @@ public class Fx{
         Draw.scl = p;
     }),
 
+    //water equivalent of wreck decals - Effect.decal() doesn't render on liquids
+    unitDrown = new Effect(3600f, e -> {
+        if(!(e.data instanceof TextureRegion reg)) return;
+
+        Draw.z(Layer.scorch);
+        mixcol(e.color, 1f);
+        alpha(0.85f * (1f - Mathf.curve(e.fin(), 0.98f)));
+        rect(reg, e.x, e.y, e.rotation);
+        reset();
+
+        //small ripples drifting over the debris, so the water still reads as moving on top of it
+        if(Mathf.chanceDelta(0.02f)){
+            Fx.ripple.at(e.x + Mathf.range(reg.width / 3f), e.y + Mathf.range(reg.height / 3f), 0.6f, e.color);
+        }
+    }),
+
     unitSpirit = new Effect(17f, e -> {
         if(!(e.data instanceof Position to)) return;
 

--- a/core/src/mindustry/entities/comp/UnitComp.java
+++ b/core/src/mindustry/entities/comp/UnitComp.java
@@ -929,11 +929,20 @@ abstract class UnitComp implements Healthc, Physicsc, Hitboxc, Statusc, Teamc, I
         }
 
         if(!headless && type.createScorch){
+            Tile deathTile = world.tileWorld(x, y);
+            //decals don't render on liquids, so wreckage sinks instead of leaving a mark on top
+            boolean sinks = deathTile != null && !deathTile.floor().hasSurface();
+            Color sinkColor = sinks ? deathTile.floor().mapColor : null;
+
             for(int i = 0; i < type.wreckRegions.length; i++){
                 if(type.wreckRegions[i].found()){
                     float range = type.hitSize /4f;
                     Tmp.v1.rnd(range);
-                    Effect.decal(type.wreckRegions[i], x + Tmp.v1.x, y + Tmp.v1.y, rotation - 90);
+                    if(sinks){
+                        Fx.unitDrown.at(x + Tmp.v1.x, y + Tmp.v1.y, rotation - 90, sinkColor, type.wreckRegions[i]);
+                    }else{
+                        Effect.decal(type.wreckRegions[i], x + Tmp.v1.x, y + Tmp.v1.y, rotation - 90);
+                    }
                 }
             }
         }


### PR DESCRIPTION
- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

Resolves Anuken/Mindustry-Suggestions#5848

Effect.decal() - used for both the land scorch mark and the scattered wreck decals - silently no-ops on liquid tiles, so units dying over water/lava/etc. disappeared without a trace.

Add a water equivalent: the same wreck regions, at the same 3600-tick lifetime as the land decals, tinted with the liquid's color and kept translucent so the water's own motion still reads on top, with occasional ripples for a submerged feel.

https://github.com/user-attachments/assets/8df0b1b6-1255-421f-8001-49306a9efb81