### PR TITLE
Add sort-by-recently-played option to the map list

### DIFF
--- a/core/assets/bundles/bundle.properties
+++ b/core/assets/bundles/bundle.properties
@@ -534,6 +534,7 @@ editor.filters.prioritize.name = Prioritize: Name
 editor.filters.prioritize.custom = Prioritize: Custom
 editor.filters.prioritize.builtin = Prioritize: Built-In
 editor.filters.prioritize.recent = Prioritize: Recently Modified
+editor.filters.prioritize.played = Prioritize: Recently Played
 editor.filters.planetselect = Planet Selection
 editor.shiftx = Shift X
 editor.shifty = Shift Y

--- a/core/src/mindustry/core/Control.java
+++ b/core/src/mindustry/core/Control.java
@@ -412,6 +412,9 @@ public class Control implements ApplicationListener, Loadable{
             if(settings.getBool("savecreate") && !world.isInvalidMap() && !playtest){
                 control.saves.addSave(map.name() + " " + new SimpleDateFormat("MMM dd h:mm", Locale.getDefault()).format(new Date()));
             }
+            if(!world.isInvalidMap() && !playtest){
+                map.setLastPlayed();
+            }
             Events.fire(Trigger.newGame);
 
             //booted out of map, resume editing

--- a/core/src/mindustry/maps/Map.java
+++ b/core/src/mindustry/maps/Map.java
@@ -83,6 +83,14 @@ public class Map implements Comparable<Map>, Publishable{
         Core.settings.put("hiscore" + file.nameWithoutExtension() + tags.get("steamid", ""), score);
     }
 
+    public long getLastPlayed(){
+        return Core.settings.getLong("lastplayed" + file.nameWithoutExtension() + tags.get("steamid", ""), 0);
+    }
+
+    public void setLastPlayed(){
+        Core.settings.put("lastplayed" + file.nameWithoutExtension() + tags.get("steamid", ""), Time.millis());
+    }
+
     /** Returns the result of applying this map's rules to the specified gamemode.*/
     public Rules applyRules(Gamemode mode){
         //mode specific defaults have been applied

--- a/core/src/mindustry/ui/dialogs/MapListDialog.java
+++ b/core/src/mindustry/ui/dialogs/MapListDialog.java
@@ -255,7 +255,7 @@ public abstract class MapListDialog extends BaseDialog{
                 tab.table(t -> {
                     t.add("@editor.filters.priorities").padBottom(6f).row();
                     t.table(Tex.button, right -> {
-                        TextureRegionDrawable[] icons = {Icon.fileText, Icon.players, Icon.hammer, Icon.play, Icon.eye};
+                        TextureRegionDrawable[] icons = {Icon.fileText, Icon.players, Icon.hammer, Icon.play, Icon.eyeSmall};
 
                         for(int i = 0; i < MapPriority.all.length; i++){
                             var prio = MapPriority.all[i];

--- a/core/src/mindustry/ui/dialogs/MapListDialog.java
+++ b/core/src/mindustry/ui/dialogs/MapListDialog.java
@@ -44,7 +44,8 @@ public abstract class MapListDialog extends BaseDialog{
         name(Structs.comparing(Map::name)),
         custom(Structs.comps(Structs.comparingBool(m -> !m.custom), Structs.comparingLong(m -> -m.file.lastModified()))),
         builtin(Structs.comps(Structs.comparingBool(m -> m.custom), Structs.comparingLong(m -> -m.file.lastModified()))),
-        recent(Structs.comps(Structs.comparingLong(m -> -m.file.lastModified()), Structs.comparing(Map::name)));
+        recent(Structs.comps(Structs.comparingLong(m -> -m.file.lastModified()), Structs.comparing(Map::name))),
+        played(Structs.comps(Structs.comparingLong(m -> -m.getLastPlayed()), Structs.comparing(Map::name)));
 
         final Comparator<Map> comparator;
 
@@ -254,7 +255,7 @@ public abstract class MapListDialog extends BaseDialog{
                 tab.table(t -> {
                     t.add("@editor.filters.priorities").padBottom(6f).row();
                     t.table(Tex.button, right -> {
-                        TextureRegionDrawable[] icons = {Icon.fileText, Icon.players, Icon.hammer, Icon.play};
+                        TextureRegionDrawable[] icons = {Icon.fileText, Icon.players, Icon.hammer, Icon.play, Icon.eye};
 
                         for(int i = 0; i < MapPriority.all.length; i++){
                             var prio = MapPriority.all[i];


### PR DESCRIPTION
- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

Resolves Anuken/Mindustry-Suggestions#5115

The existing "recent" sort orders by the map file's last-modified time, which only reflects edits - built-in maps never touch their file, so it's meaningless for them, and for custom maps it tracks last edited, not last played.

Track an actual last-played timestamp per map, the same way high scores are already tracked (Core.settings, keyed by filename), updated whenever a map finishes loading successfully outside of playtesting. Add it as a fifth MapPriority option alongside the existing four.

<img width="1920" height="1032" alt="{0ABD029E-F84E-4F5C-B6E1-E3791CA3963D}" src="https://github.com/user-attachments/assets/ebe8e0d7-6dea-42dc-b9f2-2fc39b553605" />
