### PR TITLE
Fixes #12640: Unset keybinding not saved

### DIFF
--- a/core/src/mindustry/ui/dialogs/KeybindDialog.java
+++ b/core/src/mindustry/ui/dialogs/KeybindDialog.java
@@ -167,6 +167,7 @@ public class KeybindDialog extends Dialog{
             buttons.button("@back", Icon.left, this::hide).size(bw, bh).get().addListener(blocker);
             buttons.button("@settings.unbindKey", Icon.cancel, () -> {
                 keyBind.unset();
+                keyBind.save();
                 hide();
             }).size(bw, bh).get().addListener(blocker);
         }};


### PR DESCRIPTION
The keybind wasn't saved after unsetting, plus the arc needs a change to support loading unset keycode from the settings.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
