### PR TITLE
Bugfix/bug generator: GenericCrafter hasitems by default

### DIFF
--- a/core/src/mindustry/world/blocks/production/GenericCrafter.java
+++ b/core/src/mindustry/world/blocks/production/GenericCrafter.java
@@ -54,7 +54,6 @@ public class GenericCrafter extends Block{
         super(name);
         update = true;
         solid = true;
-        hasItems = true;
         ambientSound = Sounds.loopMachine;
         sync = true;
         ambientSoundVolume = 0.03f;


### PR DESCRIPTION
Maybe postinit hasitems = false would be better
Obviously spamming hasitems in blocks.java would be safer

### Before
<img width="537" height="512" alt="Captura de pantalla 2026-09-12 024331" src="https://github.com/user-attachments/assets/87feb3f0-e56b-46ea-b21e-468c8c2c7da3" />
<img width="512" height="401" alt="image" src="https://github.com/user-attachments/assets/1c81db0b-3512-47f4-a0dd-7dc26ec22e4e" />


### After
<img width="530" height="475" alt="image" src="https://github.com/user-attachments/assets/51538585-02f0-4e1c-9426-24c369706022" />
<img width="483" height="368" alt="image" src="https://github.com/user-attachments/assets/49bff661-0030-4bdb-90ce-6d81ace20569" />
<img width="524" height="533" alt="image" src="https://github.com/user-attachments/assets/d7b450e9-8311-40dc-8fcc-92666aeac9ea" />


Datapatches seem fine?

.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
