### PR TITLE
Silicon crucible duplicated enhancements issue

### DIFF
--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -1092,7 +1092,6 @@ public class Blocks{
             hasPower = true;
             hasLiquids = false;
             itemCapacity = 30;
-            boostScale = 0.15f;
             outputScale = 0.15f;
             drawer = new DrawMulti(new DrawDefault(), new DrawFlame(Color.valueOf("ffef99")));
             ambientSound = Sounds.loopSmelter;

--- a/core/src/mindustry/content/Blocks.java
+++ b/core/src/mindustry/content/Blocks.java
@@ -1092,6 +1092,7 @@ public class Blocks{
             hasPower = true;
             hasLiquids = false;
             itemCapacity = 30;
+            boostScale = 0f;
             outputScale = 0.15f;
             drawer = new DrawMulti(new DrawDefault(), new DrawFlame(Color.valueOf("ffef99")));
             ambientSound = Sounds.loopSmelter;


### PR DESCRIPTION
likely caused by #11552 
silicon crucible's efficiency was affected by both output rate and production time, making it (167.5%)^2 more effective instead of 167.5% in 159.7 does.(take hot rock tiles for example)
it might be an unexpected buff for silicon crucibles, making it extremely op in hot places.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
