### PR TITLE
workaround for the requiredPlanets patch filter

### DIFF
--- a/core/src/mindustry/io/SaveVersion.java
+++ b/core/src/mindustry/io/SaveVersion.java
@@ -6,6 +6,7 @@ import arc.math.geom.*;
 import arc.struct.*;
 import arc.util.*;
 import arc.util.io.*;
+import arc.util.serialization.*;
 import mindustry.content.*;
 import mindustry.content.TechTree.*;
 import mindustry.core.*;
@@ -553,6 +554,14 @@ public abstract class SaveVersion extends SaveFileReader{
 
     public void readDataPatches(DataInput stream, SaveReadState saveState) throws IOException{
         stream.readInt(); //version - ignored for now
+
+        //the requiredPlanets filter needs this, since the rules aren't read yet
+        if(headless){
+            try{
+                Planet planet = content.planet(new JsonReader().parse(saveState.ruleString).getString("planet", Planets.serpulo.name));
+                state.rules.planet = planet == null ? Planets.serpulo : planet;
+            }catch(Exception ignored){}
+        }
 
         int total = stream.readInt();
         Seq<DataAsset> assets = new Seq<>(total);


### PR DESCRIPTION
makes the requiredPlanets patch filter work again

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
